### PR TITLE
Limit the number of spawned go-rountines in RetrieveBlockData

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
 	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 // indirect
 	google.golang.org/grpc v1.35.0
 )

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
-	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
 	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 // indirect
 	google.golang.org/grpc v1.35.0
 )

--- a/p2p/ipld/read.go
+++ b/p2p/ipld/read.go
@@ -17,7 +17,7 @@ import (
 
 const baseErrorMsg = "failure to retrieve block data:"
 
-const maxGoRoutines = 512
+var maxGoRoutines = 512
 
 var ErrEncounteredTooManyErrors = fmt.Errorf("%s %s", baseErrorMsg, "encountered too many errors")
 var ErrTimeout = fmt.Errorf("%s %s", baseErrorMsg, "timeout")

--- a/p2p/ipld/read.go
+++ b/p2p/ipld/read.go
@@ -18,7 +18,7 @@ import (
 
 const baseErrorMsg = "failure to retrieve block data:"
 
-const maxGoRoutines = 512
+const maxGoRoutines = 4096
 
 var ErrEncounteredTooManyErrors = fmt.Errorf("%s %s", baseErrorMsg, "encountered too many errors")
 var ErrTimeout = fmt.Errorf("%s %s", baseErrorMsg, "timeout")
@@ -140,8 +140,8 @@ func newshareCounter(parentCtx context.Context, edsWidth uint32) *shareCounter {
 		shares:          make(map[index][]byte),
 		edsWidth:        edsWidth,
 		minSharesNeeded: minSharesNeeded,
-		shareChan:       make(chan indexedShare, 1),
-		errc:            make(chan error, 1),
+		shareChan:       make(chan indexedShare),
+		errc:            make(chan error),
 		ctx:             ctx,
 		cancel:          cancel,
 	}

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -163,7 +163,7 @@ func TestRetrieveBlockData(t *testing.T) {
 			colRoots := rootsToDigests(rawColRoots)
 
 			// limit with deadline retrieval specifically
-			ctx, cancel := context.WithTimeout(ctx, time.Second*2)
+			ctx, cancel := context.WithTimeout(ctx, time.Second*6)
 			defer cancel()
 
 			rblockData, err := RetrieveBlockData(

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -163,7 +163,7 @@ func TestRetrieveBlockData(t *testing.T) {
 			colRoots := rootsToDigests(rawColRoots)
 
 			// limit with deadline retrieval specifically
-			ctx, cancel := context.WithTimeout(ctx, time.Second*2)
+			ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
 			defer cancel()
 
 			rblockData, err := RetrieveBlockData(

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -132,11 +132,6 @@ func TestRetrieveBlockData(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		// TODO(Wondertan): remove this
-		if tc.squareSize > 8 {
-			continue
-		}
-
 		tc := tc
 		t.Run(fmt.Sprintf("%s size %d", tc.name, tc.squareSize), func(t *testing.T) {
 			ctx := context.Background()

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -163,7 +163,7 @@ func TestRetrieveBlockData(t *testing.T) {
 			colRoots := rootsToDigests(rawColRoots)
 
 			// limit with deadline retrieval specifically
-			ctx, cancel := context.WithTimeout(ctx, time.Minute*1)
+			ctx, cancel := context.WithTimeout(ctx, time.Second*2)
 			defer cancel()
 
 			rblockData, err := RetrieveBlockData(


### PR DESCRIPTION
#357 

## Description
Set a limit of 100 go routines
used solution from this article: https://medium.com/happytech/limiting-goroutines-with-semaphore-b8ccc248e5f0

Closes: #357 

