### PR TITLE
abci/example/dummyapp: initialise the IPFS directory before starting dummy node

### DIFF
--- a/abci/example/dummyapp/main.go
+++ b/abci/example/dummyapp/main.go
@@ -79,6 +79,10 @@ func main() {
 
 // DummyNode implements NodeProvider.
 func DummyNode(config *cfg.Config, provider ipfs.NodeProvider, logger log.Logger) (*node.Node, error) {
+	if err := ipfs.InitRepo(config.IPFS.Path(), logger); err != nil {
+		return nil, fmt.Errorf("failed to initialize IPFS repo at path %s: %v", config.IPFS.Path(), err)
+	}
+
 	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load or gen node key %s: %w", config.NodeKeyFile(), err)


### PR DESCRIPTION
This PR fixes a problem with the dummy app where the app crashes due to missing `ipfs` directory. 

Error message: 
```
ERROR: failed to create node: no IPFS repo found in /root/.tendermint/ipfs.
please use flag: --ipfs-init
```

This flag does not exist in our version anymore, so it's best to explicitly create the directory. If the directory is already created, it will not error out.