### PR TITLE
types: export dummy random block generation functions

### DIFF
--- a/ipfs/plugin/nmt_test.go
+++ b/ipfs/plugin/nmt_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"math/rand"
-	"sort"
 	"strings"
 	"testing"
 
@@ -13,6 +11,7 @@ import (
 	"github.com/ipfs/go-verifcid"
 	mh "github.com/multiformats/go-multihash"
 
+	"github.com/celestiaorg/celestia-core/testutils"
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/rsmt2d"
 )
@@ -34,8 +33,8 @@ func TestDataSquareRowOrColumnRawInputParserCidEqNmtRoot(t *testing.T) {
 		name     string
 		leafData [][]byte
 	}{
-		{"16 leaves", generateRandNamespacedRawData(16, namespaceSize, shareSize)},
-		{"32 leaves", generateRandNamespacedRawData(32, namespaceSize, shareSize)},
+		{"16 leaves", testutils.GenerateRandNamespacedRawData(16, namespaceSize, shareSize)},
+		{"32 leaves", testutils.GenerateRandNamespacedRawData(32, namespaceSize, shareSize)},
 		{"extended row", generateExtendedRow(t)},
 	}
 	for _, tt := range tests {
@@ -68,8 +67,8 @@ func TestNodeCollector(t *testing.T) {
 		name     string
 		leafData [][]byte
 	}{
-		{"16 leaves", generateRandNamespacedRawData(16, namespaceSize, shareSize)},
-		{"32 leaves", generateRandNamespacedRawData(32, namespaceSize, shareSize)},
+		{"16 leaves", testutils.GenerateRandNamespacedRawData(16, namespaceSize, shareSize)},
+		{"32 leaves", testutils.GenerateRandNamespacedRawData(32, namespaceSize, shareSize)},
 		{"extended row", generateExtendedRow(t)},
 	}
 	for _, tt := range tests {
@@ -134,7 +133,7 @@ func TestDagPutWithPlugin(t *testing.T) {
 	t.Log("Warning: running this test writes to your local IPFS block store!")
 
 	const numLeaves = 32
-	data := generateRandNamespacedRawData(numLeaves, namespaceSize, shareSize)
+	data := testutils.GenerateRandNamespacedRawData(numLeaves, namespaceSize, shareSize)
 	buf := createByteBufFromRawData(t, data)
 	printFirst := 10
 	t.Logf("first leaf, nid: %x, data: %x...", data[0][:namespaceSize], data[0][namespaceSize:namespaceSize+printFirst])
@@ -178,7 +177,7 @@ func TestDagPutWithPlugin(t *testing.T) {
 }
 
 func generateExtendedRow(t *testing.T) [][]byte {
-	origData := generateRandNamespacedRawData(16, namespaceSize, shareSize)
+	origData := testutils.GenerateRandNamespacedRawData(16, namespaceSize, shareSize)
 	origDataWithoutNamespaces := make([][]byte, 16)
 	for i, share := range origData {
 		origDataWithoutNamespaces[i] = share[namespaceSize:]
@@ -225,25 +224,4 @@ func createByteBufFromRawData(t *testing.T, leafData [][]byte) *bytes.Buffer {
 		}
 	}
 	return buf
-}
-
-func generateRandNamespacedRawData(total int, nidSize int, leafSize int) [][]byte {
-	data := make([][]byte, total)
-	for i := 0; i < total; i++ {
-		nid := make([]byte, nidSize)
-		rand.Read(nid)
-		data[i] = nid
-	}
-	sortByteArrays(data)
-	for i := 0; i < total; i++ {
-		d := make([]byte, leafSize)
-		rand.Read(d)
-		data[i] = append(data[i], d...)
-	}
-
-	return data
-}
-
-func sortByteArrays(src [][]byte) {
-	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i], src[j]) < 0 })
 }

--- a/testutils/blockdata.go
+++ b/testutils/blockdata.go
@@ -12,16 +12,19 @@ import (
 	"github.com/celestiaorg/celestia-core/types/consts"
 )
 
-// GenerateRandomBlockData returns randomly generated block data for testing purposes
+// GenerateRandomBlockData returns randomly generated block data for testing purposes.
 func GenerateRandomBlockData(txCount, isrCount, evdCount, msgCount, maxSize int) types.Data {
 	var out types.Data
 	out.Txs = GenerateRandomlySizedContiguousShares(txCount, maxSize)
-	out.IntermediateStateRoots = generateRandomISR(isrCount)
-	out.Evidence = generateIdenticalEvidence(evdCount)
+	out.IntermediateStateRoots = GenerateRandomISR(isrCount)
+	out.Evidence = GenerateIdenticalEvidence(evdCount)
 	out.Messages = GenerateRandomlySizedMessages(msgCount, maxSize)
 	return out
 }
 
+// GenerateRandomlySizedContiguousShares returns a given amount of randomly
+// sized (up to the given maximum size) transactions that can be included in
+// dummy block data.
 func GenerateRandomlySizedContiguousShares(count, max int) types.Txs {
 	txs := make(types.Txs, count)
 	for i := 0; i < count; i++ {
@@ -31,12 +34,12 @@ func GenerateRandomlySizedContiguousShares(count, max int) types.Txs {
 		if size == 0 {
 			size = 1
 		}
-		txs[i] = GenerateRandomContiguousShares(1, size)[0]
+		txs[i] = generateRandomContiguousShares(1, size)[0]
 	}
 	return txs
 }
 
-func GenerateRandomContiguousShares(count, size int) types.Txs {
+func generateRandomContiguousShares(count, size int) types.Txs {
 	txs := make(types.Txs, count)
 	for i := 0; i < count; i++ {
 		tx := make([]byte, size)
@@ -50,15 +53,19 @@ func GenerateRandomContiguousShares(count, size int) types.Txs {
 	return txs
 }
 
-func generateRandomISR(count int) types.IntermediateStateRoots {
+// GenerateRandomISR returns a given amount of randomly generated intermediate
+// state roots that can be included in dummy block data.
+func GenerateRandomISR(count int) types.IntermediateStateRoots {
 	roots := make([]tmbytes.HexBytes, count)
 	for i := 0; i < count; i++ {
-		roots[i] = tmbytes.HexBytes(GenerateRandomContiguousShares(1, 32)[0])
+		roots[i] = tmbytes.HexBytes(generateRandomContiguousShares(1, 32)[0])
 	}
 	return types.IntermediateStateRoots{RawRootsList: roots}
 }
 
-func generateIdenticalEvidence(count int) types.EvidenceData {
+// GenerateIdenticalEvidence returns a given amount of vote evidence data that
+// can be included in dummy block data.
+func GenerateIdenticalEvidence(count int) types.EvidenceData {
 	evidence := make([]types.Evidence, count)
 	for i := 0; i < count; i++ {
 		ev := types.NewMockDuplicateVoteEvidence(math.MaxInt64, time.Now(), "chainID")
@@ -67,11 +74,13 @@ func generateIdenticalEvidence(count int) types.EvidenceData {
 	return types.EvidenceData{Evidence: evidence}
 }
 
+// GenerateRandomlySizedMessages returns a given amount of Messages up to the given maximum
+// message size that can be included in dummy block data.
 func GenerateRandomlySizedMessages(count, maxMsgSize int) types.Messages {
 	msgs := make([]types.Message, count)
 	for i := 0; i < count; i++ {
 		//nolint
-		msgs[i] = GenerateRandomMessage(rand.Intn(maxMsgSize))
+		msgs[i] = generateRandomMessage(rand.Intn(maxMsgSize))
 	}
 
 	// this is just to let us use assert.Equal
@@ -82,8 +91,8 @@ func GenerateRandomlySizedMessages(count, maxMsgSize int) types.Messages {
 	return types.Messages{MessagesList: msgs}
 }
 
-func GenerateRandomMessage(size int) types.Message {
-	share := GenerateRandomNamespacedShares(1, size)[0]
+func generateRandomMessage(size int) types.Message {
+	share := generateRandomNamespacedShares(1, size)[0]
 	msg := types.Message{
 		NamespaceID: share.NamespaceID(),
 		Data:        share.Data(),
@@ -91,7 +100,7 @@ func GenerateRandomMessage(size int) types.Message {
 	return msg
 }
 
-func GenerateRandomNamespacedShares(count, msgSize int) types.NamespacedShares {
+func generateRandomNamespacedShares(count, msgSize int) types.NamespacedShares {
 	shares := generateRandNamespacedRawData(uint32(count), consts.NamespaceSize, uint32(msgSize))
 	msgs := make([]types.Message, count)
 	for i, s := range shares {

--- a/testutils/blockdata.go
+++ b/testutils/blockdata.go
@@ -1,0 +1,127 @@
+package testutils
+
+import (
+	"bytes"
+	"math"
+	"math/rand"
+	"sort"
+	"time"
+
+	tmbytes "github.com/celestiaorg/celestia-core/libs/bytes"
+	"github.com/celestiaorg/celestia-core/types"
+	"github.com/celestiaorg/celestia-core/types/consts"
+)
+
+// GenerateRandomBlockData returns randomly generated block data for testing purposes
+func GenerateRandomBlockData(txCount, isrCount, evdCount, msgCount, maxSize int) types.Data {
+	var out types.Data
+	out.Txs = GenerateRandomlySizedContiguousShares(txCount, maxSize)
+	out.IntermediateStateRoots = generateRandomISR(isrCount)
+	out.Evidence = generateIdenticalEvidence(evdCount)
+	out.Messages = GenerateRandomlySizedMessages(msgCount, maxSize)
+	return out
+}
+
+func GenerateRandomlySizedContiguousShares(count, max int) types.Txs {
+	txs := make(types.Txs, count)
+	for i := 0; i < count; i++ {
+		//nolint
+		size := rand.Intn(max)
+		// ensure that no transactions are 0 bytes, as no valid transaction has only 0 bytes
+		if size == 0 {
+			size = 1
+		}
+		txs[i] = GenerateRandomContiguousShares(1, size)[0]
+	}
+	return txs
+}
+
+func GenerateRandomContiguousShares(count, size int) types.Txs {
+	txs := make(types.Txs, count)
+	for i := 0; i < count; i++ {
+		tx := make([]byte, size)
+		//nolint
+		_, err := rand.Read(tx)
+		if err != nil {
+			panic(err)
+		}
+		txs[i] = tx
+	}
+	return txs
+}
+
+func generateRandomISR(count int) types.IntermediateStateRoots {
+	roots := make([]tmbytes.HexBytes, count)
+	for i := 0; i < count; i++ {
+		roots[i] = tmbytes.HexBytes(GenerateRandomContiguousShares(1, 32)[0])
+	}
+	return types.IntermediateStateRoots{RawRootsList: roots}
+}
+
+func generateIdenticalEvidence(count int) types.EvidenceData {
+	evidence := make([]types.Evidence, count)
+	for i := 0; i < count; i++ {
+		ev := types.NewMockDuplicateVoteEvidence(math.MaxInt64, time.Now(), "chainID")
+		evidence[i] = ev
+	}
+	return types.EvidenceData{Evidence: evidence}
+}
+
+func GenerateRandomlySizedMessages(count, maxMsgSize int) types.Messages {
+	msgs := make([]types.Message, count)
+	for i := 0; i < count; i++ {
+		//nolint
+		msgs[i] = GenerateRandomMessage(rand.Intn(maxMsgSize))
+	}
+
+	// this is just to let us use assert.Equal
+	if count == 0 {
+		msgs = nil
+	}
+
+	return types.Messages{MessagesList: msgs}
+}
+
+func GenerateRandomMessage(size int) types.Message {
+	share := GenerateRandomNamespacedShares(1, size)[0]
+	msg := types.Message{
+		NamespaceID: share.NamespaceID(),
+		Data:        share.Data(),
+	}
+	return msg
+}
+
+func GenerateRandomNamespacedShares(count, msgSize int) types.NamespacedShares {
+	shares := generateRandNamespacedRawData(uint32(count), consts.NamespaceSize, uint32(msgSize))
+	msgs := make([]types.Message, count)
+	for i, s := range shares {
+		msgs[i] = types.Message{
+			Data:        s[consts.NamespaceSize:],
+			NamespaceID: s[:consts.NamespaceSize],
+		}
+	}
+	return types.Messages{MessagesList: msgs}.SplitIntoShares()
+}
+
+func generateRandNamespacedRawData(total, nidSize, leafSize uint32) [][]byte {
+	data := make([][]byte, total)
+	for i := uint32(0); i < total; i++ {
+		nid := make([]byte, nidSize)
+		//nolint
+		rand.Read(nid)
+		data[i] = nid
+	}
+	sortByteArrays(data)
+	for i := uint32(0); i < total; i++ {
+		d := make([]byte, leafSize)
+		//nolint
+		rand.Read(d)
+		data[i] = append(data[i], d...)
+	}
+
+	return data
+}
+
+func sortByteArrays(src [][]byte) {
+	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i], src[j]) < 0 })
+}

--- a/types/block.go
+++ b/types/block.go
@@ -1251,7 +1251,7 @@ type IntermediateStateRoots struct {
 	RawRootsList []tmbytes.HexBytes `json:"intermediate_roots"`
 }
 
-func (roots IntermediateStateRoots) splitIntoShares() NamespacedShares {
+func (roots IntermediateStateRoots) SplitIntoShares() NamespacedShares {
 	rawDatas := make([][]byte, 0, len(roots.RawRootsList))
 	for _, root := range roots.RawRootsList {
 		rawData, err := root.MarshalDelimited()
@@ -1264,7 +1264,7 @@ func (roots IntermediateStateRoots) splitIntoShares() NamespacedShares {
 	return shares
 }
 
-func (msgs Messages) splitIntoShares() NamespacedShares {
+func (msgs Messages) SplitIntoShares() NamespacedShares {
 	shares := make([]NamespacedShare, 0)
 	for _, m := range msgs.MessagesList {
 		rawData, err := m.MarshalDelimited()
@@ -1283,12 +1283,12 @@ func (data *Data) ComputeShares() (NamespacedShares, int) {
 	// see: https://github.com/celestiaorg/celestia-specs/blob/master/specs/block_proposer.md#laying-out-transactions-and-messages
 
 	// reserved shares:
-	txShares := data.Txs.splitIntoShares()
-	intermRootsShares := data.IntermediateStateRoots.splitIntoShares()
-	evidenceShares := data.Evidence.splitIntoShares()
+	txShares := data.Txs.SplitIntoShares()
+	intermRootsShares := data.IntermediateStateRoots.SplitIntoShares()
+	evidenceShares := data.Evidence.SplitIntoShares()
 
 	// application data shares from messages:
-	msgShares := data.Messages.splitIntoShares()
+	msgShares := data.Messages.SplitIntoShares()
 	curLen := len(txShares) + len(intermRootsShares) + len(evidenceShares) + len(msgShares)
 
 	// find the number of shares needed to create a square that has a power of
@@ -1557,7 +1557,7 @@ func (data *EvidenceData) FromProto(eviData *tmproto.EvidenceList) error {
 	return nil
 }
 
-func (data *EvidenceData) splitIntoShares() NamespacedShares {
+func (data *EvidenceData) SplitIntoShares() NamespacedShares {
 	rawDatas := make([][]byte, 0, len(data.Evidence))
 	for _, ev := range data.Evidence {
 		pev, err := EvidenceToProto(ev)

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1,15 +1,11 @@
 package types
 
 import (
-	// it is ok to use math/rand here: we do not need a cryptographically secure random
-	// number generator here and we can run the tests a bit faster
-	stdbytes "bytes"
 	"encoding/hex"
 	"math"
 	mrand "math/rand"
 	"os"
 	"reflect"
-	"sort"
 	"testing"
 	"time"
 
@@ -1364,33 +1360,4 @@ func TestNextHighestPowerOf2(t *testing.T) {
 		res := nextHighestPowerOf2(tt.input)
 		assert.Equal(t, tt.expected, res)
 	}
-}
-
-// this code is copy pasted from the plugin, and should likely be exported in the plugin instead
-func generateRandNamespacedRawData(total int, nidSize int, leafSize int) [][]byte {
-	data := make([][]byte, total)
-	for i := 0; i < total; i++ {
-		nid := make([]byte, nidSize)
-		_, err := mrand.Read(nid)
-		if err != nil {
-			panic(err)
-		}
-		data[i] = nid
-	}
-
-	sortByteArrays(data)
-	for i := 0; i < total; i++ {
-		d := make([]byte, leafSize)
-		_, err := mrand.Read(d)
-		if err != nil {
-			panic(err)
-		}
-		data[i] = append(data[i], d...)
-	}
-
-	return data
-}
-
-func sortByteArrays(src [][]byte) {
-	sort.Slice(src, func(i, j int) bool { return stdbytes.Compare(src[i], src[j]) < 0 })
 }

--- a/types/shares_test.go
+++ b/types/shares_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -18,8 +19,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type splitter interface {
-	splitIntoShares() NamespacedShares
+type Splitter interface {
+	SplitIntoShares() NamespacedShares
 }
 
 func TestMakeShares(t *testing.T) {
@@ -54,31 +55,36 @@ func TestMakeShares(t *testing.T) {
 	}
 
 	type args struct {
-		data splitter
+		data Splitter
 	}
 	tests := []struct {
 		name string
 		args args
 		want NamespacedShares
 	}{
-		{"evidence",
-			args{
+		{
+			name: "evidence",
+			args: args{
 				data: &EvidenceData{
 					Evidence: []Evidence{testEvidence},
 				},
-			}, NamespacedShares{NamespacedShare{
-				Share: append(
-					append(reservedEvidenceNamespaceID, byte(0)),
-					testEvidenceBytes[:consts.TxShareSize]...,
-				),
-				ID: reservedEvidenceNamespaceID,
-			}, NamespacedShare{
-				Share: append(
-					append(reservedEvidenceNamespaceID, byte(0)),
-					zeroPadIfNecessary(testEvidenceBytes[consts.TxShareSize:], consts.TxShareSize)...,
-				),
-				ID: reservedEvidenceNamespaceID,
-			}},
+			},
+			want: NamespacedShares{
+				NamespacedShare{
+					Share: append(
+						append(reservedEvidenceNamespaceID, byte(0)),
+						testEvidenceBytes[:consts.TxShareSize]...,
+					),
+					ID: reservedEvidenceNamespaceID,
+				},
+				NamespacedShare{
+					Share: append(
+						append(reservedEvidenceNamespaceID, byte(0)),
+						zeroPadIfNecessary(testEvidenceBytes[consts.TxShareSize:], consts.TxShareSize)...,
+					),
+					ID: reservedEvidenceNamespaceID,
+				},
+			},
 		},
 		{"small LL Tx",
 			args{
@@ -161,7 +167,7 @@ func TestMakeShares(t *testing.T) {
 		tt := tt // stupid scopelint :-/
 		i := i
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.args.data.splitIntoShares()
+			got := tt.args.data.SplitIntoShares()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%v: makeShares() = \n%+v\nwant\n%+v\n", i, got, tt.want)
 			}
@@ -237,7 +243,6 @@ func TestDataFromSquare(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// generate random data
 			data := generateRandomBlockData(
-				t,
 				tc.txCount,
 				tc.isrCount,
 				tc.evdCount,
@@ -321,7 +326,7 @@ func Test_processContiguousShares(t *testing.T) {
 		t.Run(fmt.Sprintf("%s idendically sized ", tc.name), func(t *testing.T) {
 			txs := generateRandomContiguousShares(tc.txCount, tc.txSize)
 
-			shares := txs.splitIntoShares()
+			shares := txs.SplitIntoShares()
 
 			parsedTxs, err := processContiguousShares(shares.RawShares())
 			if err != nil {
@@ -338,7 +343,7 @@ func Test_processContiguousShares(t *testing.T) {
 		t.Run(fmt.Sprintf("%s randomly sized", tc.name), func(t *testing.T) {
 			txs := generateRandomlySizedContiguousShares(tc.txCount, tc.txSize)
 
-			shares := txs.splitIntoShares()
+			shares := txs.SplitIntoShares()
 
 			parsedTxs, err := processContiguousShares(shares.RawShares())
 			if err != nil {
@@ -402,7 +407,7 @@ func Test_parseMsgShares(t *testing.T) {
 			}
 			msgs := Messages{MessagesList: rawmsgs}
 
-			shares := msgs.splitIntoShares()
+			shares := msgs.SplitIntoShares()
 
 			parsedMsgs, err := parseMsgShares(shares.RawShares())
 			if err != nil {
@@ -419,7 +424,7 @@ func Test_parseMsgShares(t *testing.T) {
 		// run the same tests using randomly sized messages with caps of tc.msgSize
 		t.Run(fmt.Sprintf("%s randomly sized", tc.name), func(t *testing.T) {
 			msgs := generateRandomlySizedMessages(tc.msgCount, tc.msgSize)
-			shares := msgs.splitIntoShares()
+			shares := msgs.SplitIntoShares()
 
 			parsedMsgs, err := parseMsgShares(shares.RawShares())
 			if err != nil {
@@ -452,11 +457,11 @@ func Test_parseDelimiter(t *testing.T) {
 }
 
 // generateRandomBlockData returns randomly generated block data for testing purposes
-func generateRandomBlockData(t *testing.T, txCount, isrCount, evdCount, msgCount, maxSize int) Data {
+func generateRandomBlockData(txCount, isrCount, evdCount, msgCount, maxSize int) Data {
 	var out Data
 	out.Txs = generateRandomlySizedContiguousShares(txCount, maxSize)
 	out.IntermediateStateRoots = generateRandomISR(isrCount)
-	out.Evidence = generateIdenticalEvidence(t, evdCount)
+	out.Evidence = generateIdenticalEvidence(evdCount)
 	out.Messages = generateRandomlySizedMessages(msgCount, maxSize)
 	return out
 }
@@ -481,7 +486,7 @@ func generateRandomContiguousShares(count, size int) Txs {
 		if err != nil {
 			panic(err)
 		}
-		txs[i] = Tx(tx)
+		txs[i] = tx
 	}
 	return txs
 }
@@ -494,13 +499,13 @@ func generateRandomISR(count int) IntermediateStateRoots {
 	return IntermediateStateRoots{RawRootsList: roots}
 }
 
-func generateIdenticalEvidence(t *testing.T, count int) EvidenceData {
+func generateIdenticalEvidence(count int) EvidenceData {
 	evidence := make([]Evidence, count)
 	for i := 0; i < count; i++ {
 		ev := NewMockDuplicateVoteEvidence(math.MaxInt64, time.Now(), "chainID")
 		evidence[i] = ev
 	}
-	return EvidenceData{Evidence: EvidenceList(evidence)}
+	return EvidenceData{Evidence: evidence}
 }
 
 func generateRandomlySizedMessages(count, maxMsgSize int) Messages {
@@ -527,7 +532,7 @@ func generateRandomMessage(size int) Message {
 }
 
 func generateRandomNamespacedShares(count, msgSize int) NamespacedShares {
-	shares := generateRandNamespacedRawData(count, consts.NamespaceSize, msgSize)
+	shares := generateRandNamespacedRawData(uint32(count), consts.NamespaceSize, uint32(msgSize))
 	msgs := make([]Message, count)
 	for i, s := range shares {
 		msgs[i] = Message{
@@ -535,5 +540,26 @@ func generateRandomNamespacedShares(count, msgSize int) NamespacedShares {
 			NamespaceID: s[:consts.NamespaceSize],
 		}
 	}
-	return Messages{MessagesList: msgs}.splitIntoShares()
+	return Messages{MessagesList: msgs}.SplitIntoShares()
+}
+
+func generateRandNamespacedRawData(total, nidSize, leafSize uint32) [][]byte {
+	data := make([][]byte, total)
+	for i := uint32(0); i < total; i++ {
+		nid := make([]byte, nidSize)
+		rand.Read(nid)
+		data[i] = nid
+	}
+	sortByteArrays(data)
+	for i := uint32(0); i < total; i++ {
+		d := make([]byte, leafSize)
+		rand.Read(d)
+		data[i] = append(data[i], d...)
+	}
+
+	return data
+}
+
+func sortByteArrays(src [][]byte) {
+	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i], src[j]) < 0 })
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -80,7 +80,7 @@ func (txs Txs) Proof(i int) TxProof {
 	}
 }
 
-func (txs Txs) splitIntoShares() NamespacedShares {
+func (txs Txs) SplitIntoShares() NamespacedShares {
 	rawDatas := make([][]byte, len(txs))
 	for i, tx := range txs {
 		rawData, err := tx.MarshalDelimited()


### PR DESCRIPTION
This PR exports the functions necessary to generate random block / share / message data. I'd like to reuse these functions for testing purposes outside the scope of the `types` package as it's a useful tool for mocking away celestia-core functionality. Eventually, we can expand this `testutils` package to also mock state and other data produced by a celestia core node.

**TODO**: 
Add generator in `testutils` for DAH, and Header based on block data

