### PR TITLE
sort namespaced shares before splitting

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -1101,6 +1101,7 @@ func (roots IntermediateStateRoots) SplitIntoShares() NamespacedShares {
 
 func (msgs Messages) SplitIntoShares() NamespacedShares {
 	shares := make([]NamespacedShare, 0)
+	msgs.sortMessages()
 	for _, m := range msgs.MessagesList {
 		rawData, err := m.MarshalDelimited()
 		if err != nil {
@@ -1108,12 +1109,13 @@ func (msgs Messages) SplitIntoShares() NamespacedShares {
 		}
 		shares = appendToShares(shares, m.NamespaceID, rawData)
 	}
-	sortNamespacedShares(shares)
 	return shares
 }
 
-func sortNamespacedShares(src []NamespacedShare) {
-	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i].Data(), src[j].Data()) < 0 })
+func (msgs *Messages) sortMessages() {
+	sort.Slice(msgs.MessagesList, func(i, j int) bool {
+		return bytes.Compare(msgs.MessagesList[i].NamespaceID, msgs.MessagesList[j].NamespaceID) < 0
+	})
 }
 
 // ComputeShares splits block data into shares of an original data square and

--- a/types/block.go
+++ b/types/block.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -1107,7 +1108,12 @@ func (msgs Messages) SplitIntoShares() NamespacedShares {
 		}
 		shares = appendToShares(shares, m.NamespaceID, rawData)
 	}
+	sortNamespacedShares(shares)
 	return shares
+}
+
+func sortNamespacedShares(src []NamespacedShare) {
+	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i].Data(), src[j].Data()) < 0 })
 }
 
 // ComputeShares splits block data into shares of an original data square and

--- a/types/shares_test.go
+++ b/types/shares_test.go
@@ -14,9 +14,11 @@ import (
 	tmbytes "github.com/celestiaorg/celestia-core/libs/bytes"
 	"github.com/celestiaorg/celestia-core/libs/protoio"
 	"github.com/celestiaorg/celestia-core/pkg/consts"
+	"github.com/celestiaorg/celestia-core/pkg/wrapper"
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/celestiaorg/rsmt2d"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Splitter interface {
@@ -248,14 +250,14 @@ func TestDataFromSquare(t *testing.T) {
 				tc.msgCount,
 				tc.maxSize,
 			)
-
 			shares, _ := data.ComputeShares()
 			rawShares := shares.RawShares()
+			squareSize := uint64(math.Sqrt(float64(len(shares))))
 
-			eds, err := rsmt2d.ComputeExtendedDataSquare(rawShares, rsmt2d.NewRSGF8Codec(), rsmt2d.NewDefaultTree)
-			if err != nil {
-				t.Error(err)
-			}
+			tree := wrapper.NewErasuredNamespacedMerkleTree(squareSize)
+
+			eds, err := rsmt2d.ComputeExtendedDataSquare(rawShares, rsmt2d.NewRSGF8Codec(), tree.Constructor)
+			require.NoError(t, err)
 
 			res, err := DataFromSquare(eds)
 			if err != nil {


### PR DESCRIPTION
## Description

This quick patch fixes the bug @renaynay found by sorting messages before they are split. This will allow for messages to not be sorted before calling the `SplitIntoShares` method on `Messages`, and protects against accidental panics.

Closes: #545

