### PR TITLE
Change go version from 1.16 to 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ a more detailed overview what to expect from this repository.
 
 | Requirement | Notes            |
 |-------------|------------------|
-| Go version  | Go1.16 or higher |
+| Go version  | Go1.17 or higher |
 
 ## Contributing
 


### PR DESCRIPTION
## Description

All CI at this point basically uses Go version 1.17. Since we're not testing against older versions, we should bump our minimum supported version.

Relevant: https://github.com/celestiaorg/celestia-node/pull/135#issuecomment-944797354
