### PR TITLE
protobuf decode tx patch

### DIFF
--- a/types/tx.go
+++ b/types/tx.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 
@@ -177,8 +176,11 @@ func DecodeChildTx(tx Tx) (hash []byte, unwrapped Tx, has bool) {
 	if err != nil {
 		return nil, nil, false
 	}
-	// this check isn't fool proof but it should work most of the time
-	if len(childTx.ParentTxHash) != sha256.Size {
+	// this check will fail to catch unwanted types should those unmarshalled
+	// types happen to have a hash sized slice of bytes in the same field number
+	// as ParentTxHash. TODO(evan): either fix this, or better yet use a different
+	// mechanism
+	if len(childTx.ParentTxHash) != tmhash.Size {
 		return nil, nil, false
 	}
 	return childTx.ParentTxHash, childTx.Tx, true

--- a/types/tx.go
+++ b/types/tx.go
@@ -177,7 +177,7 @@ func DecodeChildTx(tx Tx) (hash []byte, unwrapped Tx, has bool) {
 	if err != nil {
 		return nil, nil, false
 	}
-	// this check isn't fool proof
+	// this check isn't fool proof but it should work most of the time
 	if len(childTx.ParentTxHash) != sha256.Size {
 		return nil, nil, false
 	}

--- a/types/tx.go
+++ b/types/tx.go
@@ -167,7 +167,7 @@ func ComputeProtoSizeForTxs(txs []Tx) int64 {
 // transaction is a normal transaction that has been derived from a different
 // parent transaction. The returned hash is that of the parent transaction,
 // which allows us to remove the parent transaction from the mempool. NOTE:
-// protobuf sometimes does not through an error if the transaction passed is not
+// protobuf sometimes does not throw an error if the transaction passed is not
 // a tmproto.ChildTx, since the schema for PayForMessage is kept in the app, we
 // cannot perform further checks without creating an import cycle.
 func DecodeChildTx(tx Tx) (hash []byte, unwrapped Tx, has bool) {

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -176,7 +176,7 @@ func TestDecodeChildTx(t *testing.T) {
 	rawBlock, err := protoB.Marshal()
 	require.NoError(t, err)
 
-	// due to protobuf not actually requiring type compatability
+	// due to protobuf not actually requiring type compatibility
 	// we need to make sure that there is some check
 	_, _, ok = DecodeChildTx(rawBlock)
 	require.False(t, ok)

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -185,6 +185,8 @@ func TestDecodeChildTx(t *testing.T) {
 	childTx, err := WrapChildTx(pHash[:], rawBlock)
 	require.NoError(t, err)
 
-	_, _, ok = DecodeChildTx(childTx)
+	unwrappedHash, unwrapped, ok := DecodeChildTx(childTx)
 	require.True(t, ok)
+	assert.Equal(t, 32, len(unwrappedHash))
+	require.Equal(t, rawBlock, []byte(unwrapped))
 }

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -152,10 +152,13 @@ func assertBadProof(t *testing.T, root []byte, bad []byte, good TxProof) {
 }
 
 func TestDecodeChildTx(t *testing.T) {
+	// perform a simple test for being unable to decode a non
+	// child transaction
 	tx := Tx{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
 	_, _, ok := DecodeChildTx(tx)
 	require.False(t, ok)
 
+	// create a proto message that used to be decoded when it shouldn't have
 	randomBlock := MakeBlock(
 		1,
 		[]Tx{tx},
@@ -185,6 +188,7 @@ func TestDecodeChildTx(t *testing.T) {
 	childTx, err := WrapChildTx(pHash[:], rawBlock)
 	require.NoError(t, err)
 
+	// finally, ensure that the unwrapped bytes are identical to the input
 	unwrappedHash, unwrapped, ok := DecodeChildTx(childTx)
 	require.True(t, ok)
 	assert.Equal(t, 32, len(unwrappedHash))


### PR DESCRIPTION
## Description

I didn't know protobuf doesn't check types when unmarshalling, so there needs to be some check to prevent random stuff from being returned successfully from `DecodeChildTx`


