### PR TITLE
force linter to use go 1.17

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
-      - uses: actions/checkout@v2
-      - uses: technote-space/get-diff-action@v4
+      - uses: actions/setup-go@v2
+        with: 
+          go-version: 1.17.1
+      - uses: actions/checkout@v2.4.0
+      - uses: technote-space/get-diff-action@v5
         with:
           PATTERNS: |
             **/**.go
@@ -26,4 +29,5 @@ jobs:
           version: v1.38
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
+          skip-go-installation: true
         if: env.GIT_DIFF


### PR DESCRIPTION
## Description

the linter auto updates to the latest version of go, which breaks our linter.

Closes: #XXX


