### PR TITLE
Remove push from Build & Push ci

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,5 @@
-name: Build & Push
-#  Build & Push rebuilds the tendermint docker image on every push to master and creation of tags
-# and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
+name: Build Docker
+# Rebuilds the tendermint docker image on every push to default branch and creation of tags.
 on:
   pull_request:
   push:
@@ -42,18 +41,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Publish to Docker Hub
+      - name: Build but do not Publish to Docker Hub
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./DOCKER/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}


### PR DESCRIPTION
The `Build & Push` workflow was failing on the default branch (https://github.com/celestiaorg/celestia-core/actions/runs/2149689908) since obviously we can't push to Tendermint's repo. Removes the login and push steps, but keeps build.