### PR TITLE
Refactor and test split message

### DIFF
--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -82,7 +82,7 @@ func splitMessage(rawData []byte, nid namespace.ID) NamespacedShares {
 		end := cursor + consts.MsgShareSize
 		// ensure that we do not index out of bounds. this condition can only be
 		// hit once, because count is determined by dividing the total size by
-		// the MsgShare size, and the cursor is being incremented by
+		// the MsgShareSize, and the cursor is being incremented by
 		// MsgShareSize
 		if end > dataSize {
 			end = dataSize

--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -80,7 +80,10 @@ func splitMessage(rawData []byte, nid namespace.ID) NamespacedShares {
 	// iterate over the data and break it up into consts.ShareSize chunks
 	for i := 0; i < count; i++ {
 		end := cursor + consts.MsgShareSize
-		// ensure that we do not index out of bounds
+		// ensure that we do not index out of bounds. this condition can only be
+		// hit once, because count is determined by dividing the total size by
+		// the MsgShare size, and the cursor is being incremented by
+		// MsgShareSize
 		if end > dataSize {
 			end = dataSize
 		}

--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -65,16 +65,22 @@ func AppendToShares(shares []NamespacedShare, nid namespace.ID, rawData []byte) 
 	return shares
 }
 
+// splitMessage breaks the data in a message into the minimum number of
+// namespaced shares
 func splitMessage(rawData []byte, nid namespace.ID) NamespacedShares {
 	dataSize := len(rawData)
 	count := (dataSize / consts.MsgShareSize)
+	// incrememt if the message exceeds the number of shares required to contain
+	// the entire message
 	if dataSize%consts.MsgShareSize != 0 {
 		count++
 	}
 	shares := make([]NamespacedShare, count)
 	cursor := 0
+	// iterate over the data and break it up into consts.ShareSize chunks
 	for i := 0; i < count; i++ {
 		end := cursor + consts.MsgShareSize
+		// ensure that we do not index out of bounds
 		if end > dataSize {
 			end = dataSize
 		}

--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -226,13 +226,6 @@ func TailPaddingShares(n int) NamespacedShares {
 	return shares
 }
 
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
-}
-
 func zeroPadIfNecessary(share []byte, width int) []byte {
 	oldLen := len(share)
 	if oldLen < width {

--- a/types/shares_test.go
+++ b/types/shares_test.go
@@ -483,6 +483,10 @@ func TestSplitMessage(t *testing.T) {
 			bytes.Repeat([]byte{1, 2}, 1000),
 			9,
 		},
+		{
+			[]byte{},
+			0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/types/shares_test.go
+++ b/types/shares_test.go
@@ -456,6 +456,41 @@ func TestContigShareWriter(t *testing.T) {
 	assert.Equal(t, txs, resTxs)
 }
 
+func TestSplitMessage(t *testing.T) {
+	type test struct {
+		data               []byte
+		expectedShareCount int
+	}
+
+	tests := []test{
+		{
+			bytes.Repeat([]byte{1}, consts.MsgShareSize),
+			1,
+		},
+		{
+			bytes.Repeat([]byte{1}, consts.MsgShareSize+1),
+			2,
+		},
+		{
+			bytes.Repeat([]byte{1, 2, 3}, 100),
+			2,
+		},
+		{
+			bytes.Repeat([]byte{1, 2}, 100),
+			1,
+		},
+		{
+			bytes.Repeat([]byte{1, 2}, 1000),
+			9,
+		},
+	}
+
+	for _, tt := range tests {
+		shares := splitMessage(tt.data, namespace.ID{1, 2, 3, 4, 5, 6, 7, 8})
+		assert.Equal(t, tt.expectedShareCount, len(shares))
+	}
+}
+
 func Test_parseDelimiter(t *testing.T) {
 	for i := uint64(0); i < 100; i++ {
 		tx := generateRandomContiguousShares(1, int(i))[0]


### PR DESCRIPTION
## Description

While debugging some stuff, I came across this potential refactor. It's completely optional and functions identically to the previous implementation. Even if we don't want to keep the refactor, we can keep the new test.

Closes: #XXX

