### PR TITLE
pass the entire block data when making a block

### DIFF
--- a/internal/evidence/pool_test.go
+++ b/internal/evidence/pool_test.go
@@ -202,7 +202,7 @@ func TestEvidencePoolUpdate(t *testing.T) {
 		evidenceChainID,
 	)
 	lastCommit := makeCommit(height, val.PrivKey.PubKey().Address())
-	block := types.MakeBlock(height+1, []types.Tx{}, []types.Evidence{ev}, nil, lastCommit)
+	block := types.MakeBlock(height+1, sf.MakeData([]types.Tx{}, []types.Evidence{ev}, nil), lastCommit)
 
 	// update state (partially)
 	state.LastBlockHeight = height + 1

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -171,10 +171,8 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 
 	return state.MakeBlock(
 		height,
-		newData.Txs,
+		newData,
 		commit,
-		newData.Evidence.Evidence,
-		newData.Messages.MessagesList,
 		proposerAddr,
 	)
 }

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -58,7 +58,7 @@ func makeAndCommitGoodBlock(
 
 func makeAndApplyGoodBlock(state sm.State, height int64, lastCommit *types.Commit, proposerAddr []byte,
 	blockExec *sm.BlockExecutor, evidence []types.Evidence) (sm.State, types.BlockID, error) {
-	block, _ := state.MakeBlock(height, factory.MakeTenTxs(height), lastCommit, evidence, nil, proposerAddr)
+	block, _ := state.MakeBlock(height, sf.MakeData(factory.MakeTenTxs(height), evidence, nil), lastCommit, proposerAddr)
 	if err := blockExec.ValidateBlock(state, block); err != nil {
 		return state, types.BlockID{}, err
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -254,15 +254,13 @@ func FromProto(pb *tmstate.State) (*State, error) { //nolint:golint
 // track rounds, and hence does not know the correct proposer. TODO: fix this!
 func (state State) MakeBlock(
 	height int64,
-	txs []types.Tx,
+	data types.Data,
 	commit *types.Commit,
-	evidence []types.Evidence,
-	messages []types.Message,
 	proposerAddress []byte,
 ) (*types.Block, *types.PartSet) {
 
 	// Build base block with block data.
-	block := types.MakeBlock(height, txs, evidence, messages, commit)
+	block := types.MakeBlock(height, data, commit)
 
 	// Set time.
 	var timestamp time.Time

--- a/internal/state/test/factory/block.go
+++ b/internal/state/test/factory/block.go
@@ -38,13 +38,29 @@ func MakeBlocks(n int, state *sm.State, privVal types.PrivValidator) []*types.Bl
 func MakeBlock(state sm.State, height int64, c *types.Commit) *types.Block {
 	block, _ := state.MakeBlock(
 		height,
-		factory.MakeTenTxs(state.LastBlockHeight),
+		MakeData(factory.MakeTenTxs(state.LastBlockHeight), nil, nil),
 		c,
-		nil,
-		nil,
 		state.Validators.GetProposer().Address,
 	)
 	return block
+}
+
+func MakeData(txs []types.Tx, evd []types.Evidence, msgs []types.Message) types.Data {
+	return types.Data{
+		Txs: txs,
+		Evidence: types.EvidenceData{
+			Evidence: evd,
+		},
+		Messages: types.Messages{
+			MessagesList: msgs,
+		},
+	}
+}
+
+func MakeDataFromTxs(txs []types.Tx) types.Data {
+	return types.Data{
+		Txs: txs,
+	}
 }
 
 func makeBlockAndPartSet(state sm.State, lastBlock *types.Block, lastBlockMeta *types.BlockMeta,
@@ -62,5 +78,5 @@ func makeBlockAndPartSet(state sm.State, lastBlock *types.Block, lastBlockMeta *
 			lastBlockMeta.BlockID, []types.CommitSig{vote.CommitSig()})
 	}
 
-	return state.MakeBlock(height, []types.Tx{}, lastCommit, nil, nil, state.Validators.GetProposer().Address)
+	return state.MakeBlock(height, MakeDataFromTxs([]types.Tx{}), lastCommit, state.Validators.GetProposer().Address)
 }

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -16,6 +16,7 @@ import (
 	memmock "github.com/tendermint/tendermint/internal/mempool/mock"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/internal/state/mocks"
+	sf "github.com/tendermint/tendermint/internal/state/test/factory"
 	statefactory "github.com/tendermint/tendermint/internal/state/test/factory"
 	"github.com/tendermint/tendermint/internal/store"
 	testfactory "github.com/tendermint/tendermint/internal/test/factory"
@@ -278,7 +279,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 				evidence = append(evidence, newEv)
 				currentBytes += int64(len(newEv.Bytes()))
 			}
-			block, _ := state.MakeBlock(height, testfactory.MakeTenTxs(height), lastCommit, evidence, nil, proposerAddr)
+			block, _ := state.MakeBlock(height, sf.MakeData(testfactory.MakeTenTxs(height), evidence, nil), lastCommit, proposerAddr)
 			err := blockExec.ValidateBlock(state, block)
 			if assert.Error(t, err) {
 				_, ok := err.(*types.ErrEvidenceOverflow)

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -16,7 +16,6 @@ import (
 	memmock "github.com/tendermint/tendermint/internal/mempool/mock"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/internal/state/mocks"
-	sf "github.com/tendermint/tendermint/internal/state/test/factory"
 	statefactory "github.com/tendermint/tendermint/internal/state/test/factory"
 	"github.com/tendermint/tendermint/internal/store"
 	testfactory "github.com/tendermint/tendermint/internal/test/factory"
@@ -279,7 +278,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 				evidence = append(evidence, newEv)
 				currentBytes += int64(len(newEv.Bytes()))
 			}
-			block, _ := state.MakeBlock(height, sf.MakeData(testfactory.MakeTenTxs(height), evidence, nil), lastCommit, proposerAddr)
+			block, _ := state.MakeBlock(height, statefactory.MakeData(testfactory.MakeTenTxs(height), evidence, nil), lastCommit, proposerAddr)
 			err := blockExec.ValidateBlock(state, block)
 			if assert.Error(t, err) {
 				_, ok := err.(*types.ErrEvidenceOverflow)

--- a/proto/tendermint/blocksync/message_test.go
+++ b/proto/tendermint/blocksync/message_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 
+	sf "github.com/tendermint/tendermint/internal/state/test/factory"
 	bcproto "github.com/tendermint/tendermint/proto/tendermint/blocksync"
 	"github.com/tendermint/tendermint/types"
 )
@@ -85,7 +86,7 @@ func TestStatusResponse_Validate(t *testing.T) {
 }
 
 func TestBlockchainMessageVectors(t *testing.T) {
-	block := types.MakeBlock(int64(3), []types.Tx{types.Tx("Hello World")}, nil, nil, nil)
+	block := types.MakeBlock(int64(3), sf.MakeDataFromTxs([]types.Tx{types.Tx("Hello World")}), nil)
 	block.Version.Block = 11 // overwrite updated protocol version
 
 	bpb, err := block.ToProto()

--- a/types/block.go
+++ b/types/block.go
@@ -313,18 +313,14 @@ func MaxDataBytesNoEvidence(maxBytes int64, valsCount int) int64 {
 // It populates the same set of fields validated by ValidateBasic.
 func MakeBlock(
 	height int64,
-	txs []Tx, evidence []Evidence, messages []Message,
+	data Data,
 	lastCommit *Commit) *Block {
 	block := &Block{
 		Header: Header{
 			Version: version.Consensus{Block: version.BlockProtocol, App: 0},
 			Height:  height,
 		},
-		Data: Data{
-			Txs:      txs,
-			Evidence: EvidenceData{Evidence: evidence},
-			Messages: Messages{MessagesList: messages},
-		},
+		Data:       data,
 		LastCommit: lastCommit,
 	}
 	block.fillHeader()

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -46,7 +46,7 @@ func TestBlockAddEvidence(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	block := MakeBlock(h, txs, evList, nil, commit)
+	block := MakeBlock(h, makeData(txs, evList, nil), commit)
 	require.NotNil(t, block)
 	require.Equal(t, 1, len(block.Evidence.Evidence))
 	require.NotNil(t, block.EvidenceHash)
@@ -107,7 +107,7 @@ func TestBlockValidateBasic(t *testing.T) {
 		tc := tc
 		i := i
 		t.Run(tc.testName, func(t *testing.T) {
-			block := MakeBlock(h, txs, evList, nil, commit)
+			block := MakeBlock(h, makeData(txs, evList, nil), commit)
 			block.ProposerAddress = valSet.GetProposer().Address
 			tc.malleateBlock(block)
 			err = block.ValidateBasic()
@@ -119,13 +119,13 @@ func TestBlockValidateBasic(t *testing.T) {
 
 func TestBlockHash(t *testing.T) {
 	assert.Nil(t, (*Block)(nil).Hash())
-	assert.Nil(t, MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, nil).Hash())
+	assert.Nil(t, MakeBlock(int64(3), makeData([]Tx{Tx("Hello World")}, nil, nil), nil).Hash())
 }
 
 func TestBlockMakePartSet(t *testing.T) {
 	assert.Nil(t, (*Block)(nil).MakePartSet(2))
 
-	partSet := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, nil).MakePartSet(1024)
+	partSet := MakeBlock(int64(3), makeData([]Tx{Tx("Hello World")}, nil, nil), nil).MakePartSet(1024)
 	assert.NotNil(t, partSet)
 	assert.EqualValues(t, 1, partSet.Total())
 }
@@ -143,7 +143,7 @@ func TestBlockMakePartSetWithEvidence(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	partSet := MakeBlock(h, []Tx{Tx("Hello World")}, evList, nil, commit).MakePartSet(512)
+	partSet := MakeBlock(h, makeData([]Tx{Tx("Hello World")}, evList, nil), commit).MakePartSet(512)
 	assert.NotNil(t, partSet)
 	assert.EqualValues(t, 4, partSet.Total())
 }
@@ -160,7 +160,7 @@ func TestBlockHashesTo(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	block := MakeBlock(h, []Tx{Tx("Hello World")}, evList, nil, commit)
+	block := MakeBlock(h, makeData([]Tx{Tx("Hello World")}, evList, nil), commit)
 	block.ValidatorsHash = valSet.Hash()
 	assert.False(t, block.HashesTo([]byte{}))
 	assert.False(t, block.HashesTo([]byte("something else")))
@@ -168,7 +168,7 @@ func TestBlockHashesTo(t *testing.T) {
 }
 
 func TestBlockSize(t *testing.T) {
-	size := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, nil).Size()
+	size := MakeBlock(int64(3), makeData([]Tx{Tx("Hello World")}, nil, nil), nil).Size()
 	if size <= 0 {
 		t.Fatal("Size of the block is zero or negative")
 	}
@@ -179,7 +179,7 @@ func TestBlockString(t *testing.T) {
 	assert.Equal(t, "nil-Block", (*Block)(nil).StringIndented(""))
 	assert.Equal(t, "nil-Block", (*Block)(nil).StringShort())
 
-	block := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, nil)
+	block := MakeBlock(int64(3), makeData([]Tx{Tx("Hello World")}, nil, nil), nil)
 	assert.NotEqual(t, "nil-Block", block.String())
 	assert.NotEqual(t, "nil-Block", block.StringIndented(""))
 	assert.NotEqual(t, "nil-Block", block.StringShort())
@@ -636,16 +636,16 @@ func TestBlockIDValidateBasic(t *testing.T) {
 func TestBlockProtoBuf(t *testing.T) {
 	h := mrand.Int63()
 	c1 := randCommit(time.Now())
-	b1 := MakeBlock(h, []Tx{Tx([]byte{1})}, []Evidence{}, nil, &Commit{Signatures: []CommitSig{}})
+	b1 := MakeBlock(h, makeData([]Tx{Tx([]byte{1})}, []Evidence{}, nil), &Commit{Signatures: []CommitSig{}})
 	b1.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
 
 	evidenceTime := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
 	evi := NewMockDuplicateVoteEvidence(h, evidenceTime, "block-test-chain")
-	b2 := MakeBlock(h, []Tx{Tx([]byte{1})}, []Evidence{evi}, nil, c1)
+	b2 := MakeBlock(h, makeData([]Tx{Tx([]byte{1})}, []Evidence{evi}, nil), c1)
 	b2.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
 	b2.Data.Evidence.ByteSize()
 
-	b3 := MakeBlock(h, []Tx{}, []Evidence{}, nil, c1)
+	b3 := MakeBlock(h, makeData([]Tx{}, []Evidence{}, nil), c1)
 	b3.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
 	testCases := []struct {
 		msg      string

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -126,7 +126,7 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 		}
 	})
 
-	block := MakeBlock(0, []Tx{}, []Evidence{}, nil, nil)
+	block := MakeBlock(0, makeData([]Tx{}, []Evidence{}, nil), nil)
 	blockID := BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(BlockPartSizeBytes).Header()}
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
@@ -288,7 +288,7 @@ func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
 		}
 	})
 
-	block := MakeBlock(0, []Tx{}, []Evidence{}, nil, nil)
+	block := MakeBlock(0, makeData([]Tx{}, []Evidence{}, nil), nil)
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
 			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "baz", Value: "1"}}},

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -45,3 +45,15 @@ func signAddVote(privVal PrivValidator, vote *Vote, voteSet *VoteSet) (signed bo
 	vote.Signature = v.Signature
 	return voteSet.AddVote(vote)
 }
+
+func makeData(txs []Tx, evd []Evidence, msgs []Message) Data {
+	return Data{
+		Txs: txs,
+		Evidence: EvidenceData{
+			Evidence: evd,
+		},
+		Messages: Messages{
+			MessagesList: msgs,
+		},
+	}
+}


### PR DESCRIPTION
## Description

this PR passes the entire block data instead of the txs, evidence, and messages as distinct objects. This then passes along crucial information such as the square size and the data hash.

blocking https://github.com/celestiaorg/celestia-app/pull/419

Closes #753

