### PR TITLE
Increase amount of addresses accepted in PEX response

### DIFF
--- a/internal/p2p/pex/reactor.go
+++ b/internal/p2p/pex/reactor.go
@@ -221,7 +221,7 @@ func (r *ReactorV2) handlePexMessage(envelope p2p.Envelope) error {
 		}
 
 		// check the size of the response
-		if len(msg.Addresses) > int(maxAddresses) {
+		if len(msg.Addresses) > int(maxGetSelection) {
 			return fmt.Errorf("peer sent too many addresses (max: %d, got: %d)",
 				maxAddresses,
 				len(msg.Addresses),


### PR DESCRIPTION
increasing this number makes the new and legacy pex more compatible for large networks retroactively.

closes #777 

