### PR TITLE
decrease default peer gossip sleep duration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1152,7 +1152,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		SkipTimeoutCommit:           false,
 		CreateEmptyBlocks:           true,
 		CreateEmptyBlocksInterval:   0 * time.Second,
-		PeerGossipSleepDuration:     100 * time.Millisecond,
+		PeerGossipSleepDuration:     2 * time.Millisecond,
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
 		DoubleSignCheckHeight:       int64(0),
 	}


### PR DESCRIPTION
decrease the default peer gossip sleep duration from 100ms to 2ms. 

Closes #784


