### PR TITLE
Configure dependabot to only check for Celestia deps.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+    allow:
+      - dependency-name: "*/celestiaorg/*"


### PR DESCRIPTION
Fixes #697

Not actually 100% sure the `dependency-name` field is set correctly, but I guess we'll find out.