### PR TITLE
Fix links to celestia-architecture ADRs

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -86,7 +86,6 @@ Note the context/background should be written in the present tense.
 - [ADR-029: Check-Tx-Consensus](./adr-029-check-tx-consensus.md)
 - [ADR-058: Event-Hashing](./adr-058-event-hashing.md)
 
-
 ### Proposed
 
 - [ADR-007: Trust-Metric-Usage](./adr-007-trust-metric-usage.md)
@@ -106,5 +105,6 @@ Note the context/background should be written in the present tense.
 - [ADR-072: Restore Requests for Comments](./adr-072-request-for-comments.md)
 
 ### Draft
+
 - [ADR-036: Empty-Blocks-ABCI](./adr-036-empty-blocks-abci.md)
 - [ADR-040: Blockchain-Reactor-Refactor](./adr-040-blockchain-reactor-refactor.md)

--- a/docs/celestia-architecture/README.md
+++ b/docs/celestia-architecture/README.md
@@ -1,4 +1,6 @@
-# Tendermint and Celestia
+# Celestia Architecture
+
+## Tendermint
 
 celestia-core is not meant to be used as a general purpose framework.
 Instead, its main purpose is to provide certain components (mainly consensus but also a p2p layer for Tx gossiping) for the Celestia main chain.
@@ -6,17 +8,17 @@ Hence, we do not provide any extensive documentation here.
 
 Instead of keeping a copy of the Tendermint documentation, we refer to the existing extensive and maintained documentation and specification:
 
- - https://docs.tendermint.com/
- - https://github.com/tendermint/tendermint/tree/master/docs/
- - https://github.com/tendermint/spec
+- <https://docs.tendermint.com/>
+- <https://github.com/tendermint/tendermint/tree/master/docs/>
+- <https://github.com/tendermint/spec>
 
 Reading these will give you a lot of background and context on Tendermint which will also help you understand how celestia-core and [celestia-app](https://github.com/celestiaorg/celestia-app) interact with each other.
 
-# Celestia
+## Celestia
 
 As mentioned above, celestia-core aims to be more focused on the Celestia use-case than vanilla Tendermint.
 Moving forward we might provide a clear overview on the changes we incorporated.
-For now, we refer to the Celestia specific [ADRs](./adr) in this repository as well as to the Celestia specification:
+For now, we refer to the Celestia architecture ADRs in this repository as well as to the Celestia specification:
 
- - [celestia-adr](./adr)
- - [celestia-specs](https://github.com/celestiaorg/celestia-specs)
+- [celestia-adr](./celestia-adr.md)
+- [celestia-specs](https://github.com/celestiaorg/celestia-specs)

--- a/docs/celestia-architecture/celestia-adr.md
+++ b/docs/celestia-architecture/celestia-adr.md
@@ -29,9 +29,12 @@ Note the context/background should be written in the present tense.
 
 To start a new ADR, you can use this template: [adr-template.md](./adr-template.md)
 
-### Table of Contents:
+## Table of Contents
 
 - [ADR 001: Erasure Coding Block Propagation](./adr-001-block-propagation.md)
 - [ADR 002: Sampling erasure coded Block chunks](./adr-002-ipld-da-sampling.md)
 - [ADR 003: Retrieving Application messages](./adr-003-application-data-retrieval.md)
 - [ADR 004: Data Availability Sampling Light Client](./adr-004-mvp-light-client.md)
+- [ADR 005: Decouple the PartSetHeader from the BlockID](./adr-005-decouple-blockid-and-partsetheader.md)
+- [ADR 006: Consensus Block Gossiping with Rows](./adr-006-row-propoagation.md)
+- [ADR 007: From Ukraine, with Love](./adr-007-minimal-changes-to-tendermint.md)


### PR DESCRIPTION
Description
1. Fix link by renaming `README copy.md` to `celestia-adr.md`
1. Add three missing ADRs to `celestia-adr.md`
1. Formatting fixes auto applied by
   [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)

Questions
1. When are ADRs placed in in `celestia-architecture/` vs `architecture/`?
