### PR TITLE
fix: patch mempool logging error

### DIFF
--- a/internal/mempool/v0/clist_mempool.go
+++ b/internal/mempool/v0/clist_mempool.go
@@ -244,17 +244,13 @@ func (mem *CListMempool) CheckTx(
 		// so we only record the sender for txs still in the mempool.
 		if e, ok := mem.txsMap.Load(tx.Key()); ok {
 			memTx := e.(*clist.CElement).Value.(*mempoolTx)
-			_, loaded := memTx.senders.LoadOrStore(txInfo.SenderID, true)
+			memTx.senders.LoadOrStore(txInfo.SenderID, true)
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
 			// but they can spam the same tx with little cost to them atm.
-			if loaded {
-				return types.ErrTxInCache
-			}
 		}
 
-		mem.logger.Debug("tx exists already in cache", "tx_hash", tx.Hash())
-		return nil
+		return types.ErrTxInCache
 	}
 
 	if ctx == nil {

--- a/internal/mempool/v0/clist_mempool_test.go
+++ b/internal/mempool/v0/clist_mempool_test.go
@@ -201,7 +201,7 @@ func TestMempoolUpdate(t *testing.T) {
 		err := mp.Update(1, []types.Tx{[]byte{0x01}}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 		require.NoError(t, err)
 		err = mp.CheckTx(context.Background(), []byte{0x01}, nil, mempool.TxInfo{})
-		require.NoError(t, err)
+		assert.Error(t, err)
 	}
 
 	// 2. Removes valid txs from the mempool
@@ -329,11 +329,15 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 
 		// a must be added to the cache
 		err = mp.CheckTx(context.Background(), a, nil, mempool.TxInfo{})
-		require.NoError(t, err)
+		if assert.Error(t, err) {
+			assert.Equal(t, types.ErrTxInCache, err)
+		}
 
 		// b must remain in the cache
 		err = mp.CheckTx(context.Background(), b, nil, mempool.TxInfo{})
-		require.NoError(t, err)
+		if assert.Error(t, err) {
+			assert.Equal(t, types.ErrTxInCache, err)
+		}
 	}
 
 	// 2. An invalid transaction must remain in the cache

--- a/internal/mempool/v1/mempool.go
+++ b/internal/mempool/v1/mempool.go
@@ -265,8 +265,10 @@ func (txmp *TxMempool) CheckTx(
 	// transaction is already present in the cache, i.e. false is returned, then we
 	// check if we've seen this transaction and error if we have.
 	if !txmp.cache.Push(tx) {
-		txmp.txStore.GetOrSetPeerByTxHash(txHash, txInfo.SenderID)
-		return types.ErrTxInCache
+		if _, loaded := txmp.txStore.GetOrSetPeerByTxHash(txHash, txInfo.SenderID); loaded {
+			return types.ErrTxInCache
+		}
+		return nil
 	}
 
 	if ctx == nil {

--- a/types/mempool.go
+++ b/types/mempool.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 )
 
-// ErrTxInCache is returned to the client if we saw tx earlier
-var ErrTxInCache = errors.New("tx already exists in cache")
+// ErrTxInCache is returned to the client if we saw tx earlier from the same peer
+var ErrTxInCache = errors.New("tx seen from the same peer")
 
 // TxKey is the fixed length array key used as an index.
 type TxKey [sha256.Size]byte


### PR DESCRIPTION
This PR pulls a fix from v0.35.7 and patches the mempool logging issue that causes too many logs.

