### PR TITLE
feat: adds reserved namespace check when adding messages to blocks

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -1326,11 +1326,26 @@ func DataFromProto(dp *tmproto.Data) (Data, error) {
 
 // ValidateBasic performs basic validation.
 func (msg Message) ValidateBasic() error {
-	if msg.NamespaceID == nil {
+	if err := ValidateMessageNamespaceID(msg.NamespaceID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateMessageNamespaceID created in a separate function so that it can be used
+// also on messages in proto format.
+func ValidateMessageNamespaceID(n namespace.ID) error {
+	if n == nil {
 		return fmt.Errorf("nil namespace id")
 	}
-	if bytes.Compare(msg.NamespaceID, consts.MaxReservedNamespace) < 1 {
-		return fmt.Errorf("message using reserved namespace id %d", binary.BigEndian.Uint64(msg.NamespaceID))
+	if bytes.Compare(n, consts.MaxReservedNamespace) < 1 {
+		return fmt.Errorf("message using reserved namespace id %d", binary.BigEndian.Uint64(n))
+	}
+	if bytes.Compare(n, consts.TailPaddingNamespaceID) < 1 {
+		return fmt.Errorf("message using tail padding namespace id %d", binary.BigEndian.Uint64(n))
+	}
+	if bytes.Compare(n, consts.ParitySharesNamespaceID) < 1 {
+		return fmt.Errorf("message using parity shares namespace id %d", binary.BigEndian.Uint64(n))
 	}
 	return nil
 }

--- a/types/block.go
+++ b/types/block.go
@@ -1341,10 +1341,10 @@ func ValidateMessageNamespaceID(n namespace.ID) error {
 	if bytes.Compare(n, consts.MaxReservedNamespace) < 1 {
 		return fmt.Errorf("message using reserved namespace id %d", binary.BigEndian.Uint64(n))
 	}
-	if bytes.Compare(n, consts.TailPaddingNamespaceID) < 1 {
+	if bytes.Compare(n, consts.TailPaddingNamespaceID) == 0 {
 		return fmt.Errorf("message using tail padding namespace id %d", binary.BigEndian.Uint64(n))
 	}
-	if bytes.Compare(n, consts.ParitySharesNamespaceID) < 1 {
+	if bytes.Compare(n, consts.ParitySharesNamespaceID) == 0 {
 		return fmt.Errorf("message using parity shares namespace id %d", binary.BigEndian.Uint64(n))
 	}
 	return nil

--- a/types/share_merging.go
+++ b/types/share_merging.go
@@ -235,6 +235,9 @@ func parseMsgShares(shares [][]byte) ([]Message, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := msg.ValidateBasic(); err != nil {
+			return nil, err
+		}
 		if msg.Data != nil {
 			msgs = append(msgs, msg)
 		}

--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -23,6 +23,9 @@ func NewMessageShareWriter() *MessageShareWriter {
 
 // Write adds the delimited data to the underlying contiguous shares.
 func (msw *MessageShareWriter) Write(msg Message) {
+	if err := msg.ValidateBasic(); err != nil {
+		panic(err)
+	}
 	rawMsg, err := msg.MarshalDelimited()
 	if err != nil {
 		panic(fmt.Sprintf("app accepted a Message that can not be encoded %#v", msg))


### PR DESCRIPTION
## Description

Adds `ValidateBasic()` to `Message` and calls it when:
- converting block data to proto format
- converting block data from proto format
- share splitting and merging

Closes: https://github.com/celestiaorg/celestia-app/issues/571

