### PR TITLE
Chore/bubble data hash error

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -250,9 +250,11 @@ func TestStateOversizedBlock(t *testing.T) {
 	timeoutProposeCh := subscribe(cs1.eventBus, types.EventQueryTimeoutPropose)
 	voteCh := subscribe(cs1.eventBus, types.EventQueryVote)
 
+	var err error
 	propBlock, _ := cs1.createProposalBlock()
 	propBlock.Data.Txs = []types.Tx{tmrand.Bytes(2001)}
-	propBlock.Header.DataHash = propBlock.Data.Hash()
+	propBlock.Header.DataHash, err = propBlock.Data.Hash()
+	assert.Nil(t, err)
 
 	// make the second validator the proposer by incrementing round
 	round++

--- a/types/block.go
+++ b/types/block.go
@@ -86,7 +86,7 @@ func (b *Block) ValidateBasic() error {
 
 	// NOTE: b.Data.Txs may be nil, but b.Data.Hash() still works fine.
 	if w, err := b.Data.Hash(); err != nil {
-		return fmt.Errorf("square size for the block data to be hashed over: %v", err)
+		return fmt.Errorf("square size for the block data to be hashed over is not a power of 2: %v", err)
 	} else {
 		if g := b.DataHash; !bytes.Equal(w, g) {
 			return fmt.Errorf("wrong Header.DataHash. Expected %X, got %X", w, g)

--- a/types/block.go
+++ b/types/block.go
@@ -85,12 +85,12 @@ func (b *Block) ValidateBasic() error {
 	}
 
 	// NOTE: b.Data.Txs may be nil, but b.Data.Hash() still works fine.
-	if w, err := b.Data.Hash(); err != nil {
+	w, err := b.Data.Hash()
+	if err != nil {
 		return fmt.Errorf("square size for the block data to be hashed over is not a power of 2: %v", err)
-	} else {
-		if g := b.DataHash; !bytes.Equal(w, g) {
-			return fmt.Errorf("wrong Header.DataHash. Expected %X, got %X", w, g)
-		}
+	}
+	if g := b.DataHash; !bytes.Equal(w, g) {
+		return fmt.Errorf("wrong Header.DataHash. Expected %X, got %X", w, g)
 	}
 
 	// NOTE: b.Evidence.Evidence may be nil, but we're just looping.

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -693,11 +693,13 @@ func TestBlockDataProtobuf(t *testing.T) {
 
 	for _, tt := range tests {
 		d := Data{Txs: tt.txs, Evidence: tt.evd, Messages: Messages{MessagesList: tt.msgs}}
-		firstHash := d.Hash()
+		firstHash, err1 := d.Hash()
+		assert.Nil(t, err1)
 		pd := d.ToProto()
 		d2, err := DataFromProto(&pd)
 		require.NoError(t, err)
-		secondHash := d2.Hash()
+		secondHash, err2 := d2.Hash()
+		assert.Nil(t, err2)
 		assert.Equal(t, firstHash, secondHash, tt.name)
 	}
 }


### PR DESCRIPTION
## Description

Propagate error to user if data being hashed has invalid square size (not a power of 2) while doing basic validation of block. 
Returns `nil` block while making a new block with invalid data. 
Returns `nil` hash for an incorrectly constructed block

Relevant files:
-  types/block.go
-  types/block_test.go

Checks:
- [ ] Test case for returning `nil` block for invalid data
- [ ] Test case for get `nil` hash for incorrectly constructed block

Ps: I'm not quite sure about this one, seems like returning a `nil` `Block` could be unexpected behaviour in a lot of places

Closes: #728

