### PR TITLE
add metrics for monitoring tx availability in the mempool

### DIFF
--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -38,6 +38,7 @@ func (emptyMempool) Update(
 ) error {
 	return nil
 }
+func (emptyMempool) ObserveTxAvailability(txs types.Txs) {}
 func (emptyMempool) Flush()                        {}
 func (emptyMempool) FlushAppConn() error           { return nil }
 func (emptyMempool) TxsAvailable() <-chan struct{} { return make(chan struct{}) }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -63,6 +63,7 @@ func (ti *timeoutInfo) String() string {
 // interface to the mempool
 type txNotifier interface {
 	TxsAvailable() <-chan struct{}
+	ObserveTxAvailability(txs types.Txs)
 }
 
 // interface to the evidence pool
@@ -1918,6 +1919,10 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID p2p.ID) (add
 		if err := cs.eventBus.PublishEventCompleteProposal(cs.CompleteProposalEvent()); err != nil {
 			cs.Logger.Error("failed publishing event complete proposal", "err", err)
 		}
+
+		// NOTE: for testing purposes only
+		// monitor how many txs in the block were already available in the nodes mempool
+		go cs.txNotifier.ObserveTxAvailability(block.Data.Txs)
 	}
 	return added, nil
 }

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1528,6 +1528,8 @@ func (n *fakeTxNotifier) Notify() {
 	n.ch <- struct{}{}
 }
 
+func (n *fakeTxNotifier) ObserveTxAvailability(txs types.Txs) {}
+
 // 2 vals precommit votes for a block but node times out waiting for the third. Move to next round
 // and third precommit arrives which leads to the commit of that header and the correct
 // start of the next round

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -96,6 +96,13 @@ type Mempool interface {
 
 	// SizeBytes returns the total size of all txs in the mempool.
 	SizeBytes() int64
+
+	// NOTE: For test purposes only.
+	//
+	// ObserveTxAvailability is triggered whenever a node receives a complete new block
+	// It is used to measure how many of the transactions as a percentage the mempool
+	// already has.
+	ObserveTxAvailability(txs types.Txs)
 }
 
 // PreCheckFunc is an optional filter executed before CheckTx and rejects

--- a/mempool/mock/mempool.go
+++ b/mempool/mock/mempool.go
@@ -30,11 +30,12 @@ func (Mempool) Update(
 ) error {
 	return nil
 }
-func (Mempool) Flush()                        {}
-func (Mempool) FlushAppConn() error           { return nil }
-func (Mempool) TxsAvailable() <-chan struct{} { return make(chan struct{}) }
-func (Mempool) EnableTxsAvailable()           {}
-func (Mempool) SizeBytes() int64              { return 0 }
+func (Mempool) ObserveTxAvailability(types.Txs) {}
+func (Mempool) Flush()                          {}
+func (Mempool) FlushAppConn() error             { return nil }
+func (Mempool) TxsAvailable() <-chan struct{}   { return make(chan struct{}) }
+func (Mempool) EnableTxsAvailable()             {}
+func (Mempool) SizeBytes() int64                { return 0 }
 
 func (Mempool) TxsFront() *clist.CElement    { return nil }
 func (Mempool) TxsWaitChan() <-chan struct{} { return nil }

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -194,7 +194,9 @@ func (mem *CListMempool) TxsWaitChan() <-chan struct{} {
 
 // It blocks if we're waiting on Update() or Reap().
 // cb: A callback from the CheckTx command.
-//     It gets called from another goroutine.
+//
+//	It gets called from another goroutine.
+//
 // CONTRACT: Either cb will get called, or err returned.
 //
 // Safe for concurrent use by multiple goroutines.
@@ -310,7 +312,7 @@ func (mem *CListMempool) reqResCb(
 }
 
 // Called from:
-//  - resCbFirstTime (lock not held) if tx is valid
+//   - resCbFirstTime (lock not held) if tx is valid
 func (mem *CListMempool) addTx(memTx *mempoolTx) {
 	e := mem.txs.PushBack(memTx)
 	mem.txsMap.Store(memTx.tx.Key(), e)
@@ -319,8 +321,8 @@ func (mem *CListMempool) addTx(memTx *mempoolTx) {
 }
 
 // Called from:
-//  - Update (lock held) if tx was committed
-// 	- resCbRecheck (lock not held) if tx was invalidated
+//   - Update (lock held) if tx was committed
+//   - resCbRecheck (lock not held) if tx was invalidated
 func (mem *CListMempool) removeTx(tx types.Tx, elem *clist.CElement, removeFromCache bool) {
 	mem.txs.Remove(elem)
 	elem.DetachPrev()
@@ -644,6 +646,19 @@ func (mem *CListMempool) Update(
 	mem.metrics.Size.Set(float64(mem.Size()))
 
 	return nil
+}
+
+// ObserveTxAvailability simply records, as a percentage, the amount of txs passed as the argument
+// which are already present in the mempool
+func (mem *CListMempool) ObserveTxAvailability(txs types.Txs) {
+	var count float64 = 0
+	for _, tx := range txs {
+		_, ok := mem.txsMap.Load(tx.Key())
+		if ok {
+			count++
+		}
+	}
+	mem.metrics.TxAvailability.Observe(count / float64(len(txs)))
 }
 
 func (mem *CListMempool) recheckTxs() {

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/creachadair/taskgroup"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/clist"
@@ -437,6 +438,21 @@ func (txmp *TxMempool) Update(
 		}
 	}
 	return nil
+}
+
+// ObserveTxAvailability simply records, as a percentage, the amount of txs passed as the argument
+// which are already present in the mempool
+func (txmp *TxMempool) ObserveTxAvailability(txs types.Txs) {
+	txmp.mtx.RLock()
+	defer txmp.mtx.RUnlock()
+	var count float64 = 0
+	for _, tx := range txs {
+		_, ok := txmp.txByKey[tx.Key()]
+		if ok {
+			count++
+		}
+	}
+	txmp.metrics.TxAvailability.Observe(count / float64(len(txs)))
 }
 
 // addNewTransaction handles the ABCI CheckTx response for the first time a

--- a/test/maverick/consensus/replay_stubs.go
+++ b/test/maverick/consensus/replay_stubs.go
@@ -34,6 +34,7 @@ func (emptyMempool) Update(
 ) error {
 	return nil
 }
+func (emptyMempool) ObserveTxAvailability(txs types.Txs) {}
 func (emptyMempool) Flush()                        {}
 func (emptyMempool) FlushAppConn() error           { return nil }
 func (emptyMempool) TxsAvailable() <-chan struct{} { return make(chan struct{}) }


### PR DESCRIPTION
## Description

This PR is a little more of an intrusive change. The goal is to validate the effectiveness of compact blocks (blocks containing only tx hashes). To do this, we need to observe the behaviour and performance of the current mempool in a "real world" environment. This PR tracks for every new complete block received, what percentage of the transactions it already had in the mempool. If this values is close to 1 then this would indicate a lot to gain from compact blocks. 

