### PR TITLE
chore: clarify sort for blobs

### DIFF
--- a/proto/tendermint/types/types.pb.go
+++ b/proto/tendermint/types/types.pb.go
@@ -780,7 +780,8 @@ func (m *EvidenceList) GetEvidence() []Evidence {
 	return nil
 }
 
-// Blob defines an indivisible chunk of data that is posted on chain.
+// Blob defines a chunk of data that is attributed to a namespace and under
+// usual circumstances, ends up published on-chain.
 type Blob struct {
 	NamespaceId []byte `protobuf:"bytes,1,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
 	Data        []byte `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`

--- a/types/block.go
+++ b/types/block.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -1047,34 +1046,24 @@ func (data *Data) Hash() tmbytes.HexBytes {
 	return data.hash
 }
 
-// ByNamespace implements sort.Interface for Blob
-type Blobs []Blob
+// BlobsByNamespace implements sort.Interface for Blob
+type BlobsByNamespace []Blob
 
-func (b Blobs) Len() int {
+func (b BlobsByNamespace) Len() int {
 	return len(b)
 }
 
-func (b Blobs) Swap(i, j int) {
+func (b BlobsByNamespace) Swap(i, j int) {
 	b[i], b[j] = b[j], b[i]
 }
 
-func (b Blobs) Less(i, j int) bool {
+func (b BlobsByNamespace) Less(i, j int) bool {
 	// The following comparison is `<` and not `<=` because bytes.Compare returns 0 for if a == b.
 	// We want this comparison to return `false` if a == b because:
 	// If both Less(i, j) and Less(j, i) are false,
 	// then the elements at index i and j are considered equal.
 	// See https://pkg.go.dev/sort#Interface
 	return bytes.Compare(b[i].NamespaceID, b[j].NamespaceID) < 0
-}
-
-// SortMessages sorts messages by ascending namespace id
-func (b *Blobs) SortMessages() {
-	sort.Sort(b)
-}
-
-// IsSorted returns whether the messages are sorted by namespace id
-func (b *Blobs) IsSorted() bool {
-	return sort.IsSorted(b)
 }
 
 type Blob struct {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -900,8 +901,8 @@ func TestMessagesIsSorted(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.descripton, func(t *testing.T) {
-			bs := Blobs(tc.blobs)
-			assert.Equal(t, tc.want, bs.IsSorted())
+			bs := tc.blobs
+			assert.Equal(t, tc.want, sort.IsSorted(BlobsByNamespace(bs)))
 		})
 	}
 }


### PR DESCRIPTION
Partially addresses https://github.com/celestiaorg/celestia-core/issues/887 by removing two exported methods which are no longer needed after this refactor: https://github.com/celestiaorg/celestia-core/pull/879#discussion_r1019587387 and addressing this feedback: https://github.com/celestiaorg/celestia-core/pull/879#discussion_r1019596230

## Testing

After this change, celestia-app can sort a slice of blobs via:

```golang
sort.Sort(coretypes.BlobsByNamespace(data.Blobs))
```

and verify a slice of blobs is sorted via:

```golang
if sort.IsSorted(coretypes.BlobsByNamespace(data.Blobs)) {
    // ...
}
```