### PR TITLE
chore: remove residual comment

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -112,7 +112,6 @@ type PostCheckFunc func(types.Tx, *abci.ResponseCheckTx) error
 // to the expected maxBytes.
 func PreCheckMaxBytes(maxBytes int64) PreCheckFunc {
 	return func(tx types.Tx) error {
-		// we subtract 4 here to account for the extra fields added to the data message
 		txSize := types.ComputeProtoSizeForTxs([]types.Tx{tx})
 
 		if txSize > maxBytes {


### PR DESCRIPTION
Originally reported in https://github.com/celestiaorg/celestia-core/pull/898#discussion_r1046379044

Note that this comment is the only difference between celestia-core v0.34.x-celestia and tendermint v0.34.20: https://www.diffchecker.com/dmlnxenh so it seems residual
