### PR TITLE
disable generated mocks check

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -13,29 +13,32 @@ permissions:
   contents: read
 
 jobs:
-  check-mocks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
+  # Disabled mock checks because they were manually modified in v0.34.23 to adhere to the new Peer interface.
+  # This should be resolved in v0.37.x and we can reactivate this then. 
+  #
+  # check-mocks:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: '1.18'
 
-      - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v3
 
-      - name: "Check generated mocks"
-        run: |
-          set -euo pipefail
-          readonly MOCKERY=2.14.0  # N.B. no leading "v"
-          curl -sL "https://github.com/vektra/mockery/releases/download/v${MOCKERY}/mockery_${MOCKERY}_Linux_x86_64.tar.gz" | tar -C /usr/local/bin -xzf -
-          make mockery 2>/dev/null
-          if ! git diff --stat --exit-code ; then
-            echo ">> ERROR:"
-            echo ">>"
-            echo ">> Generated mocks require update (either Mockery or source files may have changed)."
-            echo ">> Ensure your tools are up-to-date, re-run 'make mockery' and update this PR."
-            echo ">>"
-            exit 1
-          fi
+  #     - name: "Check generated mocks"
+  #       run: |
+  #         set -euo pipefail
+  #         readonly MOCKERY=2.14.0  # N.B. no leading "v"
+  #         curl -sL "https://github.com/vektra/mockery/releases/download/v${MOCKERY}/mockery_${MOCKERY}_Linux_x86_64.tar.gz" | tar -C /usr/local/bin -xzf -
+  #         make mockery 2>/dev/null
+  #         if ! git diff --stat --exit-code ; then
+  #           echo ">> ERROR:"
+  #           echo ">>"
+  #           echo ">> Generated mocks require update (either Mockery or source files may have changed)."
+  #           echo ">> Ensure your tools are up-to-date, re-run 'make mockery' and update this PR."
+  #           echo ">>"
+  #           exit 1
+  #         fi
 
   check-proto:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disabled mock checks because they were manually modified in v0.34.23 to adhere to the new Peer interface.
This should be resolved in v0.37.x and we can reactivate this then. 

Ref: https://github.com/celestiaorg/celestia-core/pull/906#issuecomment-1348036502
