### PR TITLE
chore: Fix link to the rsmt2d library repo

### DIFF
--- a/docs/celestia-architecture/adr-002-ipld-da-sampling.md
+++ b/docs/celestia-architecture/adr-002-ipld-da-sampling.md
@@ -272,7 +272,7 @@ Proposed
 [IPLD selectors]: https://github.com/ipld/specs/blob/master/selectors/selectors.md
 [ipld-prime]: https://github.com/ipld/go-ipld-prime
 
-[rsmt2d]: https://github.com/celestia/rsmt2d
+[rsmt2d]: https://github.com/celestiaorg/rsmt2d
 
 
 [p2p]: https://github.com/celestiaorg/celestia-core/tree/0eccfb24e2aa1bb9c4428e20dd7828c93f300e60/p2p


### PR DESCRIPTION
## Description

Fixes the rsmt2d link in ADR-002 to point correctly to the rsmt2d GitHub repository



