### PR TITLE
blocksync: run process proposal when verifying new blocks

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -366,12 +366,15 @@ FOR_LOOP:
 			err := state.Validators.VerifyCommitLight(
 				chainID, firstID, first.Height, second.LastCommit)
 
-			var stateMachineValid bool
 			if err == nil {
-				// We need to check that the `Data` in the block is valid. As we don't check it elsewhere and only
-				// the application can tell us if it is valid or not, we need to ask the application to check it via
-				// ProcessProposal. If we don't do this step a malicious node could fabricate an alternative set of 
-				// transactions that would cause a different app hash and thus cause this node to panic.
+				var stateMachineValid bool
+				// Block sync doesn't check that the `Data` in a block is valid.
+				// Since celestia-core can't determine if the `Data` in a block
+				// is valid, the next line asks celestia-app to check if the
+				// block is valid via ProcessProposal. If this step wasn't
+				// performed, a malicious node could fabricate an alternative
+				// set of transactions that would cause a different app hash and
+				// thus cause this node to panic.
 				stateMachineValid, err = bcR.blockExec.ProcessProposal(first)
 				if !stateMachineValid {
 					err = fmt.Errorf("application has rejected syncing block (%X) at height %d", first.Hash(), first.Height)

--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -366,6 +366,18 @@ FOR_LOOP:
 			err := state.Validators.VerifyCommitLight(
 				chainID, firstID, first.Height, second.LastCommit)
 
+			var stateMachineValid bool
+			if err == nil {
+				// We need to check that the `Data` in the block is valid. As we don't check it elsewhere and only
+				// the application can tell us if it is valid or not, we need to ask the application to check it via
+				// ProcessProposal. If we don't do this step a malicious node could fabricate an alternative set of 
+				// transactions that would cause a different app hash and thus cause this node to panic.
+				stateMachineValid, err = bcR.blockExec.ProcessProposal(first)
+				if !stateMachineValid {
+					err = fmt.Errorf("application has rejected syncing block (%X) at height %d", first.Hash(), first.Height)
+				}
+			}
+
 			if err == nil {
 				// validate the block before we persist it
 				err = bcR.blockExec.ValidateBlock(state, first)


### PR DESCRIPTION
## Description

Closes: #926

This is a possible solution to the problem outlined in the issue where the integrity of the `Data` struct which is relied upon by the application isn't checked at all in blocksync. 

I have looked into ways of testing this but this is ridiculously hard (even going across multiple repos). The best solution I can think of is to refactor the blocksync v0 to use interfaces for the `BlockExecutor` so I am able to hook up a mock to check that the methods are called.

