### PR TITLE
blocksync: disable v1 and v2 reactors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -900,10 +900,7 @@ func (cfg *FastSyncConfig) ValidateBasic() error {
 	switch cfg.Version {
 	case "v0":
 		return nil
-	case "v1":
-		return nil
-	case "v2":
-		return nil
+	// v1 and v2 are disabled. They have been deprecated.
 	default:
 		return fmt.Errorf("unknown fastsync version %s", cfg.Version)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -133,7 +133,7 @@ func TestFastSyncConfigValidateBasic(t *testing.T) {
 
 	// tamper with version
 	cfg.Version = "v1"
-	assert.NoError(t, cfg.ValidateBasic())
+	assert.Error(t, cfg.ValidateBasic())
 
 	cfg.Version = "invalid"
 	assert.Error(t, cfg.ValidateBasic())

--- a/config/toml.go
+++ b/config/toml.go
@@ -435,8 +435,8 @@ chunk_fetchers = "{{ .StateSync.ChunkFetchers }}"
 
 # Fast Sync version to use:
 #   1) "v0" (default) - the legacy fast sync implementation
-#   2) "v1" - refactor of v0 version for better testability
-#   2) "v2" - complete redesign of v0, optimized for testability & readability
+#   "v1" and "v2" are disabled. They have been deprecated and will
+#   be completely removed in one of the upcoming releases
 version = "{{ .FastSync.Version }}"
 
 #######################################################


### PR DESCRIPTION
## Description

These have been deprecated and are removed in v0.37. This PR disables them for now so I don't have to update them as well with #929

