### PR TITLE
QGB remove dependency on geth dependency for encoding the data root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,16 +48,10 @@ require (
 require github.com/vektra/mockery/v2 v2.14.0
 
 require (
-	github.com/ethereum/go-ethereum v1.10.26
 	github.com/gogo/protobuf v1.3.2
 	github.com/informalsystems/tm-load-test v1.0.0
 	gonum.org/v1/gonum v0.12.0
 	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8
-)
-
-require (
-	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,6 @@ github.com/btcsuite/btcd v0.21.0-beta/go.mod h1:ZSWyehm27aAuS9bvkATT+Xte3hjHZ+MR
 github.com/btcsuite/btcd v0.22.0-beta/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
 github.com/btcsuite/btcd v0.22.1 h1:CnwP9LM/M9xuRrGSCGeMVs9iv09uMqwsVX7EeIpgV2c=
 github.com/btcsuite/btcd v0.22.1/go.mod h1:wqgTSL29+50LRkmOVknEdmt8ZojIzhuWvgu/iptuN7Y=
-github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
-github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
@@ -261,10 +259,6 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/denis-tingaikin/go-header v0.4.3 h1:tEaZKAlqql6SKCY++utLmkPLd6K8IBM20Ha7UVm+mtU=
 github.com/denis-tingaikin/go-header v0.4.3/go.mod h1:0wOCWuN71D5qIgE2nz9KrKmuYBAC2Mra5RassOIQ2/c=
@@ -306,8 +300,6 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/esimonov/ifshort v1.0.4 h1:6SID4yGWfRae/M7hkVDVVyppy8q/v9OuxNdmjLQStBA=
 github.com/esimonov/ifshort v1.0.4/go.mod h1:Pe8zjlRrJ80+q2CxHLfEOfTwxCZ4O+MuhcHcfgNWTk0=
-github.com/ethereum/go-ethereum v1.10.26 h1:i/7d9RBBwiXCEuyduBQzJw/mKmnvzsN14jqBmytw72s=
-github.com/ethereum/go-ethereum v1.10.26/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
 github.com/ettle/strcase v0.1.1 h1:htFueZyVeE1XNnMEfbqp5r67qAN/4r6ya1ysq8Q+Zcw=
 github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 h1:0JZ+dUmQeA8IIVUMzysrX4/AKuQwWhV2dYQuPZdvdSQ=

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -1,15 +1,15 @@
 package core
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
+	"strconv"
 
 	"github.com/tendermint/tendermint/crypto/merkle"
 	blockidxnull "github.com/tendermint/tendermint/state/indexer/block/null"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/pkg/consts"
@@ -177,59 +177,31 @@ func DataRootInclusionProof(
 	return &ctypes.ResultDataRootInclusionProof{Proof: *proof}, nil
 }
 
+// Pad bytes to given length
+func padBytes(byt []byte, length int) []byte {
+	l := len(byt)
+	if l == length {
+		return byt
+	}
+	tmp := make([]byte, length)
+	copy(tmp[length-l:], byt)
+	return tmp
+}
+
 // EncodeDataRootTuple takes a height and a data root and returns the equivalent of
-// `abi.encode(...)` in Ethereum.
-// The encoded type is a DataRootTuple, which has the following ABI:
-// ```
-//
-//	{
-//	  "components": [
-//	    {
-//	      "internalType": "uint256",
-//	      "name": "height",
-//	      "type": "uint256"
-//	    },
-//	    {
-//	      "internalType": "bytes32",
-//	      "name": "dataRoot",
-//	      "type": "bytes32"
-//	    }
-//	  ],
-//	  "internalType": "structDataRootTuple",
-//	  "name": "_tuple",
-//	  "type": "tuple"
-//	},
-//
-// ```
+// padding the hex representation of the height to 32 bytes and concatenating the data root to it
 // For more information, refer to:
 // https://github.com/celestiaorg/quantum-gravity-bridge/blob/master/src/DataRootTuple.sol
 func EncodeDataRootTuple(height uint64, dataRoot [32]byte) ([]byte, error) {
-	dataRootTupleStruct, err := abi.NewType(
-		"tuple",
-		"structDataRootTuple",
-		[]abi.ArgumentMarshaling{
-			{Name: "height", Type: "uint256"},
-			{Name: "dataRoot", Type: "bytes32"},
-		},
-	)
-	if err != nil {
-		return nil, err
+	hexRepresentation := strconv.FormatUint(height, 16)
+	// Make sure hex representation has even length
+	if len(hexRepresentation)%2 == 1 {
+		hexRepresentation = "0" + hexRepresentation
 	}
+	hexBytes, _ := hex.DecodeString(hexRepresentation)
 
-	args := abi.Arguments{{Type: dataRootTupleStruct, Name: "tuple"}}
-	tuple := struct {
-		Height   *big.Int
-		DataRoot [32]byte
-	}{
-		Height:   big.NewInt(int64(height)),
-		DataRoot: dataRoot,
-	}
-	packed, err := args.Pack(&tuple)
-	if err != nil {
-		return nil, err
-	}
-
-	return packed, nil
+	dataSlice := dataRoot[:]
+	return append(padBytes(hexBytes, 32), dataSlice...), nil
 }
 
 // generateHeightsList takes a begin and end block, then generates a list of heights

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -177,7 +177,7 @@ func DataRootInclusionProof(
 	return &ctypes.ResultDataRootInclusionProof{Proof: *proof}, nil
 }
 
-// Pad bytes to given length
+// padBytes Pad bytes to given length
 func padBytes(byt []byte, length int) ([]byte, error) {
 	l := len(byt)
 	if l > length {


### PR DESCRIPTION
## Description

- Remove dependency on geth dependency for encoding the data root
- Manually pad the hex representation of the height to 32 bytes and concatenate the data root to it.

Closes: #934 

