### PR TITLE
Upgrade to Go 1.19 on `0.34.x` (#360)

### DIFF
--- a/.changelog/unreleased/breaking-changes/360-update-to-go-119.md
+++ b/.changelog/unreleased/breaking-changes/360-update-to-go-119.md
@@ -1,0 +1,2 @@
+- Use Go 1.19 to build CometBFT, since Go 1.18 has reached end-of-life.
+   ([\#360](https://github.com/cometbft/cometbft/issues/360))

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -21,7 +21,7 @@ jobs:
   #   steps:
   #     - uses: actions/setup-go@v3
   #       with:
-  #         go-version: '1.18'
+  #         go-version: '1.19'
 
   #     - uses: actions/checkout@v3
 
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - run: echo https://github.com/tendermint/tendermint/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md#${GITHUB_REF#refs/tags/} > ../release_notes.md
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,5 +1,9 @@
-# stage 1 Generate Tendermint Binary
-FROM golang:1.18-alpine as builder
+# Use a build arg to ensure that both stages use the same,
+# hopefully current, go version.
+ARG GOLANG_BASE_IMAGE=golang:1.19-alpine
+
+# stage 1 Generate CometBFT Binary
+FROM --platform=$BUILDPLATFORM $GOLANG_BASE_IMAGE as builder
 RUN apk update && \
     apk upgrade && \
     apk --no-cache add make

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.18
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/scripts/proto-gen.sh
+++ b/scripts/proto-gen.sh
@@ -10,7 +10,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Run inside Docker to install the correct versions of the required tools
 # without polluting the local system.
-docker run --rm -i -v "$PWD":/w --workdir=/w golang:1.18-alpine sh <<"EOF"
+docker run --rm -i -v "$PWD":/w --workdir=/w golang:1.19-alpine sh <<"EOF"
 apk add git make
 
 go install github.com/bufbuild/buf/cmd/buf

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.18
+FROM golang:1.19
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null


### PR DESCRIPTION
## Description

cherry picks https://github.com/cometbft/cometbft/pull/360 to partially fix the CI issue with buf and to move away from go 1.18

Closes: #XXX

