### PR TITLE
dynamic block time modifications

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1029,7 +1029,11 @@ func (cfg *ConsensusConfig) Precommit(round int32) time.Duration {
 
 // NextStartTime adds the TargetHeightDuration to the provided starting time.
 func (cfg *ConsensusConfig) NextStartTime(t time.Time) time.Time {
-	return t.Add(cfg.TargetHeightDuration)
+	newStartTime := t.Add(cfg.TargetHeightDuration)
+	if newStartTime.Before(time.Now()) {
+		return time.Now()
+	}
+	return newStartTime
 }
 
 // WalFile returns the full path to the write-ahead log file

--- a/config/toml.go
+++ b/config/toml.go
@@ -467,7 +467,7 @@ timeout_precommit_delta = "{{ .Consensus.TimeoutPrecommitDelta }}"
 # TargetHeigtDuration is used to determine how long we wait after a
 # block is committed. If this time is shorter than the actual time to reach
 # consensus for that height, then we do not wait at all.
-target_round_duration = "{{ .Consensus.TargetHeightDuration }}"
+target_height_duration = "{{ .Consensus.TargetHeightDuration }}"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart

--- a/state/execution.go
+++ b/state/execution.go
@@ -400,7 +400,7 @@ func execBlockOnProxyApp(
 		return nil, err
 	}
 
-	logger.Info("executed block", "height", block.Height, "num_valid_txs", validTxs, "num_invalid_txs", invalidTxs)
+	logger.Info("executed block", "height", block.Height, "num_valid_txs", validTxs, "num_invalid_txs", invalidTxs, "time", block.Time)
 	return abciResponses, nil
 }
 


### PR DESCRIPTION
## Description

Some data from a 4 validator network under transaction load with a 5 second target height:

```
Chain: simple-xUmLu2
Block Time:
        Average: 5.00s
        Min: 4.67s
        Max: 5.31s
        Standard Deviation: 0.112s

Transactions:
        Bytes per Block: 10219.52
        Transactions per Block: 9.98
```

Would be good to test this under "realistic" network environments i.e. most likely with testground.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

