### PR TITLE
fix: add an extra check when the data commitment first block is 0

### DIFF
--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -660,7 +660,7 @@ func TestDataCommitment(t *testing.T) {
 
 	// check if data commitment is not nil.
 	// Checking if the commitment is correct is done in `core/blocks_test.go`.
-	dataCommitment, err := c.DataCommitment(ctx, 0, uint64(expectedHeight))
+	dataCommitment, err := c.DataCommitment(ctx, 1, uint64(expectedHeight))
 	require.NotNil(t, dataCommitment, "data commitment shouldn't be nul.")
 	require.Nil(t, err, "%+v when creating data commitment.", err)
 }

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -290,6 +290,9 @@ func generateHeightsList(beginBlock uint64, endBlock uint64) []int64 {
 // validateDataCommitmentRange runs basic checks on the asc sorted list of heights
 // that will be used subsequently in generating data commitments over the defined set of heights.
 func validateDataCommitmentRange(firstBlock uint64, lastBlock uint64) error {
+	if firstBlock == 0 {
+		return fmt.Errorf("the first block is 0")
+	}
 	env := GetEnvironment()
 	heightsRange := lastBlock - firstBlock + 1
 	if heightsRange > uint64(consts.DataCommitmentBlocksLimit) {

--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -166,6 +166,7 @@ func TestDataCommitmentResults(t *testing.T) {
 		{2727, 2828, false},
 		{10, 9, false},
 		{0, 1000, false},
+		{0, 10, false},
 		{10, 8, false},
 	}
 
@@ -225,6 +226,7 @@ func TestDataRootInclusionProofResults(t *testing.T) {
 		expectPass bool
 	}{
 		{8, 10, 15, false},
+		{10, 0, 15, false},
 		{10, 10, 15, true},
 		{13, 10, 15, true},
 		{15, 10, 15, true},


### PR DESCRIPTION
## Description

Related to https://github.com/celestiaorg/celestia-app/issues/1513

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

