### PR TITLE
fix: send LastValidators instead of Validators in SignedBlock event

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -267,7 +267,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 
 	// Events are fired after everything else.
 	// NOTE: if we crash between Commit and Save, events wont be fired during replay
-	fireEvents(blockExec.logger, blockExec.eventBus, block, abciResponses, validatorUpdates, state.Validators, commit)
+	fireEvents(blockExec.logger, blockExec.eventBus, block, abciResponses, validatorUpdates, state.LastValidators, commit)
 
 	return state, retainHeight, nil
 }

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -606,7 +606,7 @@ func TestFireEventSignedBlockEvent(t *testing.T) {
 	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
 
 	state, stateDB, _ := makeState(2, 1)
-	// modify the last validators so it's different to the current validators
+	// modify the current validators so it's different to the last validators
 	state.Validators.Validators[0].VotingPower = 10
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 		DiscardABCIResponses: false,
@@ -631,13 +631,6 @@ func TestFireEventSignedBlockEvent(t *testing.T) {
 
 	block := makeBlock(state, 1)
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
-
-	vp, err := cryptoenc.PubKeyToProto(state.Validators.Validators[0].PubKey)
-	require.NoError(t, err)
-	// Update the validator so that the validator hash is now different
-	app.ValidatorUpdates = []abci.ValidatorUpdate{
-		{PubKey: vp, Power: 100},
-	}
 
 	commit := &types.Commit{
 		Height:  block.Height,

--- a/types/events.go
+++ b/types/events.go
@@ -165,6 +165,7 @@ var (
 	EventQueryNewEvidence         = QueryForEvent(EventNewEvidence)
 	EventQueryNewRound            = QueryForEvent(EventNewRound)
 	EventQueryNewRoundStep        = QueryForEvent(EventNewRoundStep)
+	EventQueryNewSignedBlock      = QueryForEvent(EventSignedBlock)
 	EventQueryPolka               = QueryForEvent(EventPolka)
 	EventQueryRelock              = QueryForEvent(EventRelock)
 	EventQueryTimeoutPropose      = QueryForEvent(EventTimeoutPropose)


### PR DESCRIPTION
## Description

In PR #940, a SignedBlockEvent was introduced which would be consumed by bridge nodes whenever a consensus node committed a block. The event joins the blocks header and data fields with the seen commit and validator set. However the validator set that was being sent was not at height h of the header, but height h + 1. Hence when there were validator set changes, bridge nodes reported a validator hash mismatch. This was because `state.Validators` had already been updated to the following height. To fix this, we use `state.LastValidators` instead.  


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

