### PR TITLE
chore: improve docs for `Data` struct

### DIFF
--- a/proto/tendermint/crypto/keys.pb.go
+++ b/proto/tendermint/crypto/keys.pb.go
@@ -27,7 +27,6 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // PublicKey defines the keys available for use with Validators
 type PublicKey struct {
 	// Types that are valid to be assigned to Sum:
-	//
 	//	*PublicKey_Ed25519
 	//	*PublicKey_Secp256K1
 	Sum isPublicKey_Sum `protobuf_oneof:"sum"`

--- a/proto/tendermint/mempool/types.pb.go
+++ b/proto/tendermint/mempool/types.pb.go
@@ -156,7 +156,6 @@ func (m *WantTx) GetTxKey() []byte {
 
 type Message struct {
 	// Types that are valid to be assigned to Sum:
-	//
 	//	*Message_Txs
 	//	*Message_SeenTx
 	//	*Message_WantTx

--- a/proto/tendermint/p2p/conn.pb.go
+++ b/proto/tendermint/p2p/conn.pb.go
@@ -158,7 +158,6 @@ func (m *PacketMsg) GetData() []byte {
 
 type Packet struct {
 	// Types that are valid to be assigned to Sum:
-	//
 	//	*Packet_PacketPing
 	//	*Packet_PacketPong
 	//	*Packet_PacketMsg

--- a/proto/tendermint/statesync/types.pb.go
+++ b/proto/tendermint/statesync/types.pb.go
@@ -24,7 +24,6 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Message struct {
 	// Types that are valid to be assigned to Sum:
-	//
 	//	*Message_SnapshotsRequest
 	//	*Message_SnapshotsResponse
 	//	*Message_ChunkRequest

--- a/proto/tendermint/types/types.pb.go
+++ b/proto/tendermint/types/types.pb.go
@@ -415,17 +415,21 @@ func (m *Header) GetProposerAddress() []byte {
 	return nil
 }
 
-// Data contains the set of transactions included in the block
+// Data contains all the information needed for a consensus full node to
+// reconstruct an extended data square.
 type Data struct {
-	// Txs that will be applied by state @ block.Height+1.
-	// NOTE: not all txs here are valid.  We're just agreeing on the order first.
-	// This means that block.AppHash does not include these txs.
+	// Txs that will be applied to state in block.Height + 1 because deferred execution.
+	// This means that the block.AppHash of this block does not include these txs.
+	// NOTE: not all txs here are valid. We're just agreeing on the order first.
 	Txs [][]byte `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
-	// field number 2 is reserved for intermediate state roots
-	// field number 3 was previously used for evidence
-	Blobs      []Blob `protobuf:"bytes,4,rep,name=blobs,proto3" json:"blobs"`
+	// Blobs are the data blobs included in the original data square.
+	Blobs []Blob `protobuf:"bytes,4,rep,name=blobs,proto3" json:"blobs"`
+	// SquareSize is the number of rows in the original data square.
 	SquareSize uint64 `protobuf:"varint,5,opt,name=square_size,json=squareSize,proto3" json:"square_size,omitempty"`
-	Hash       []byte `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
+	// Hash is the root of a binary Merkle tree where the leaves of the tree are
+	// the row and column roots of an extended data square. Hash is often referred
+	// to as the "data root".
+	Hash []byte `protobuf:"bytes,6,opt,name=hash,proto3" json:"hash,omitempty"`
 }
 
 func (m *Data) Reset()         { *m = Data{} }

--- a/proto/tendermint/types/types.proto
+++ b/proto/tendermint/types/types.proto
@@ -81,17 +81,26 @@ message Header {
   bytes proposer_address = 14;  // original proposer of the block
 }
 
-// Data contains the set of transactions included in the block
+// Data contains all the information needed for a consensus full node to
+// reconstruct an extended data square.
 message Data {
-  // Txs that will be applied by state @ block.Height+1.
-  // NOTE: not all txs here are valid.  We're just agreeing on the order first.
-  // This means that block.AppHash does not include these txs.
+  // Txs that will be applied to state in block.Height + 1 because deferred execution.
+  // This means that the block.AppHash of this block does not include these txs.
+  // NOTE: not all txs here are valid. We're just agreeing on the order first.
   repeated bytes txs = 1;
 
   // field number 2 is reserved for intermediate state roots
   // field number 3 was previously used for evidence
+
+  // Blobs are the data blobs included in the original data square.
   repeated Blob blobs       = 4 [(gogoproto.nullable) = false];
+
+  // SquareSize is the number of rows in the original data square.
   uint64        square_size = 5;
+
+  // Hash is the root of a binary Merkle tree where the leaves of the tree are
+  // the row and column roots of an extended data square. Hash is often referred
+  // to as the "data root".
   bytes         hash        = 6;
 }
 


### PR DESCRIPTION
Extremely optional PR to improve the docs for the `Data` struct b/c I got confused about the `Data.hash` field.

Note: this changes introduces a slight diff from the docs in cometbft [here](https://github.com/cometbft/cometbft/blob/5989a7314fea2b47efcd8747e9f9c9b6ebd1f6e0/proto/tendermint/types/types.proto#L84-L90)