### PR TITLE
feat: Return error when fetched blocks are different than the provided list of heights

### DIFF
--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -184,6 +184,9 @@ func DataCommitment(ctx *rpctypes.Context, firstBlock uint64, lastBlock uint64) 
 	}
 	heights := generateHeightsList(firstBlock, lastBlock)
 	blockResults := fetchBlocks(heights, len(heights), 0)
+	if len(blockResults) != len(heights) {
+		return nil, fmt.Errorf("couldn't fetch all the blocks in the provided range")
+	}
 	root, err := hashDataRootTuples(blockResults)
 	if err != nil {
 		return nil, err
@@ -206,6 +209,9 @@ func DataRootInclusionProof(
 	}
 	heights := generateHeightsList(beginBlock, endBlock)
 	blockResults := fetchBlocks(heights, len(heights), 0)
+	if len(blockResults) != len(heights) {
+		return nil, fmt.Errorf("couldn't fetch all the blocks in the provided range")
+	}
 	proof, err := proveDataRootTuples(blockResults, height)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

## Description

We use the `fetchBlock` function to get the list of blocks to create the data root tuple. 

The issue is that if some block is not available for some reason, the `fetchBlock` will just skip it and continue to the next one. This would end up returning an invalid data root tuple.

This PR throws an error if the returned number of blocks is different from the provided heights list so that the QGB errors in this scenario and the validator doesn't sign invalid data.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

