### PR TITLE
fix: register EventDataSignedBlock in tendermint's json lib

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -48,6 +48,7 @@ type TMEventData interface {
 
 func init() {
 	cmtjson.RegisterType(EventDataNewBlock{}, "tendermint/event/NewBlock")
+	cmtjson.RegisterType(EventDataSignedBlock{}, "tendermint/event/NewSignedBlock")
 	cmtjson.RegisterType(EventDataNewBlockHeader{}, "tendermint/event/NewBlockHeader")
 	cmtjson.RegisterType(EventDataNewEvidence{}, "tendermint/event/NewEvidence")
 	cmtjson.RegisterType(EventDataTx{}, "tendermint/event/Tx")


### PR DESCRIPTION
## Description

registers the new event with the json lib. This fixes the bug where websocket subscriptions to EventDataSignedBlock fail but don't error.

