### PR TITLE
fix: stop locking mid loop for large genesis files

### DIFF
--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -165,7 +165,8 @@ func InitGenesisChunks() error {
 	if err != nil {
 		return err
 	}
-
+	mut.Lock()
+	defer mut.Unlock()
 	for i := 0; i < len(data); i += genesisChunkSize {
 		end := i + genesisChunkSize
 
@@ -173,8 +174,6 @@ func InitGenesisChunks() error {
 			end = len(data)
 		}
 
-		mut.Lock()
-		defer mut.Unlock()
 		globalEnv.genChunks = append(globalEnv.genChunks, base64.StdEncoding.EncodeToString(data[i:end]))
 	}
 


### PR DESCRIPTION
## Description

we missed a typo/bug in [#869](https://github.com/celestiaorg/celestia-core/pull/869/commits/c569855a3e10b8f93512b6b1ef6c0c845f920bfe) :sweat_smile: , which causes the node to lock during start for networks with large genesises. Personally I'm still of the opinion that those mutexes should be removed entirely since afaiu they don't help if we're we're running multiple in process nodes, but we can do that in a different PR
