### PR TITLE
fix: use same source of now

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
 const (
@@ -1030,7 +1032,7 @@ func (cfg *ConsensusConfig) Precommit(round int32) time.Duration {
 // NextStartTime adds the TargetHeightDuration to the provided starting time.
 func (cfg *ConsensusConfig) NextStartTime(t time.Time) time.Time {
 	newStartTime := t.Add(cfg.TargetHeightDuration)
-	now := time.Now()
+	now := tmtime.Now()
 	if newStartTime.Before(now) {
 		return now
 	}


### PR DESCRIPTION
`NextStartTime` should use the same source of time.Now() that is used to calculate how long to sleep before starting the next height

Note, I don't think this fixes the problem of the high block interval variance that we're seeing on mocha. 