### PR TITLE
feat: remove square size from qgb commitment creation

### DIFF
--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -126,26 +126,23 @@ func TestBlockResults(t *testing.T) {
 func TestEncodeDataRootTuple(t *testing.T) {
 	height := uint64(2)
 	dataRoot, err := hex.DecodeString("82dc1607d84557d3579ce602a45f5872e821c36dbda7ec926dfa17ebc8d5c013")
-	squareSize := uint64(64)
 	require.NoError(t, err)
 
 	expectedEncoding, err := hex.DecodeString(
 		// hex representation of height padded to 32 bytes
 		"0000000000000000000000000000000000000000000000000000000000000002" +
 			// data root
-			"82dc1607d84557d3579ce602a45f5872e821c36dbda7ec926dfa17ebc8d5c013" +
-			// original square size
-			"0000000000000000000000000000000000000000000000000000000000000040",
+			"82dc1607d84557d3579ce602a45f5872e821c36dbda7ec926dfa17ebc8d5c013",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, expectedEncoding)
 
-	actualEncoding, err := EncodeDataRootTuple(height, *(*[32]byte)(dataRoot), squareSize)
+	actualEncoding, err := EncodeDataRootTuple(height, *(*[32]byte)(dataRoot))
 	require.NoError(t, err)
 	require.NotNil(t, actualEncoding)
 
 	// Check that the length of packed data is correct
-	assert.Equal(t, len(actualEncoding), 96)
+	assert.Equal(t, len(actualEncoding), 64)
 	assert.Equal(t, expectedEncoding, actualEncoding)
 }
 
@@ -191,7 +188,6 @@ func TestDataCommitmentResults(t *testing.T) {
 				encodedTuple, err := EncodeDataRootTuple(
 					uint64(blocks[tc.beginQuery+i].Height),
 					*(*[32]byte)(blocks[tc.beginQuery+i].DataHash),
-					blocks[tc.beginQuery+i].SquareSize,
 				)
 				require.NoError(t, err)
 				dataRootEncodedTuples[i] = encodedTuple
@@ -266,7 +262,6 @@ func TestDataRootInclusionProofResults(t *testing.T) {
 				encodedTuple, err := EncodeDataRootTuple(
 					uint64(blocks[tc.firstQuery+i].Height),
 					*(*[32]byte)(blocks[tc.firstQuery+i].DataHash),
-					blocks[tc.firstQuery+i].SquareSize,
 				)
 				require.NoError(t, err)
 				dataRootEncodedTuples[i] = encodedTuple


### PR DESCRIPTION
## Description

Closes https://github.com/celestiaorg/celestia-core/issues/1040

After merging this one, I will cherry-pick this change for main. Then, I will open a separate PR for main to remove the square size and the data hash from the `Data` struct.

---


#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

