### PR TITLE
feat: traces block height and timestamp for InfluxDB

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -457,7 +457,7 @@ func (cs *State) OpenWAL(walFile string) (WAL, error) {
 	return wal, nil
 }
 
-//------------------------------------------------------------
+// ------------------------------------------------------------
 // Public interface for passing messages into the consensus state, possibly causing a state transition.
 // If peerID == "", the msg is considered internal.
 // Messages are added to the appropriate queue (peer or internal).
@@ -521,7 +521,7 @@ func (cs *State) SetProposalAndBlock(
 	return nil
 }
 
-//------------------------------------------------------------
+// ------------------------------------------------------------
 // internal functions for managing the state
 
 func (cs *State) updateHeight(height int64) {
@@ -716,7 +716,7 @@ func (cs *State) newStep() {
 	}
 }
 
-//-----------------------------------------
+// -----------------------------------------
 // the main go routines
 
 // receiveRoutine handles messages which may cause state transitions.
@@ -981,7 +981,7 @@ func (cs *State) handleTxsAvailable() {
 	}
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // State functions
 // Used internally by handleTimeout and handleMsg to make state transitions
 
@@ -1712,6 +1712,10 @@ func (cs *State) finalizeCommit(height int64) {
 	// must be called before we update state
 	cs.recordMetrics(height, block)
 
+	// TODO log block.time
+	// blockTime := block.Header.Time
+	// block.Header.Height
+
 	// NewHeightStep!
 	cs.updateToState(stateCopy)
 
@@ -1730,6 +1734,7 @@ func (cs *State) finalizeCommit(height int64) {
 	// * cs.Height has been increment to height+1
 	// * cs.Step is now cstypes.RoundStepNewHeight
 	// * cs.StartTime is set to when we will start round0.
+
 }
 
 func (cs *State) pruneBlocks(retainHeight int64) (uint64, error) {
@@ -1836,7 +1841,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 
 func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	// Already have one
@@ -1991,7 +1996,7 @@ func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 		// If the vote height is off, we'll just ignore it,
 		// But if it's a conflicting sig, add it to the cs.evpool.
 		// If it's otherwise invalid, punish peer.
-		//nolint: gocritic
+		// nolint: gocritic
 		if voteErr, ok := err.(*types.ErrVoteConflictingVotes); ok {
 			if cs.privValidatorPubKey == nil {
 				return false, errPubKeyIsNotSet
@@ -2366,7 +2371,7 @@ func (cs *State) calculatePrevoteMessageDelayMetrics() {
 	}
 }
 
-//---------------------------------------------------------
+// ---------------------------------------------------------
 
 func CompareHRS(h1 int64, r1 int32, s1 cstypes.RoundStepType, h2 int64, r2 int32, s2 cstypes.RoundStepType) int {
 	if h1 < h2 {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1995,7 +1995,7 @@ func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 		// If the vote height is off, we'll just ignore it,
 		// But if it's a conflicting sig, add it to the cs.evpool.
 		// If it's otherwise invalid, punish peer.
-		// nolint: gocritic
+		//nolint: gocritic
 		if voteErr, ok := err.(*types.ErrVoteConflictingVotes); ok {
 			if cs.privValidatorPubKey == nil {
 				return false, errPubKeyIsNotSet

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1712,9 +1712,7 @@ func (cs *State) finalizeCommit(height int64) {
 	// must be called before we update state
 	cs.recordMetrics(height, block)
 
-	// TODO log block.time
-	// blockTime := block.Header.Time
-	// block.Header.Height
+	schema.WriteBlock(cs.traceClient, block.Header.Height, block.Header.Time)
 
 	// NewHeightStep!
 	cs.updateToState(stateCopy)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1712,6 +1712,7 @@ func (cs *State) finalizeCommit(height int64) {
 	// must be called before we update state
 	cs.recordMetrics(height, block)
 
+	// trace some metadata about the block
 	schema.WriteBlock(cs.traceClient, block.Header.Height, block.Header.Time)
 
 	// NewHeightStep!

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -457,7 +457,7 @@ func (cs *State) OpenWAL(walFile string) (WAL, error) {
 	return wal, nil
 }
 
-// ------------------------------------------------------------
+//------------------------------------------------------------
 // Public interface for passing messages into the consensus state, possibly causing a state transition.
 // If peerID == "", the msg is considered internal.
 // Messages are added to the appropriate queue (peer or internal).
@@ -521,7 +521,7 @@ func (cs *State) SetProposalAndBlock(
 	return nil
 }
 
-// ------------------------------------------------------------
+//------------------------------------------------------------
 // internal functions for managing the state
 
 func (cs *State) updateHeight(height int64) {
@@ -716,7 +716,7 @@ func (cs *State) newStep() {
 	}
 }
 
-// -----------------------------------------
+//-----------------------------------------
 // the main go routines
 
 // receiveRoutine handles messages which may cause state transitions.
@@ -981,7 +981,7 @@ func (cs *State) handleTxsAvailable() {
 	}
 }
 
-// -----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // State functions
 // Used internally by handleTimeout and handleMsg to make state transitions
 
@@ -1733,7 +1733,6 @@ func (cs *State) finalizeCommit(height int64) {
 	// * cs.Height has been increment to height+1
 	// * cs.Step is now cstypes.RoundStepNewHeight
 	// * cs.StartTime is set to when we will start round0.
-
 }
 
 func (cs *State) pruneBlocks(retainHeight int64) (uint64, error) {
@@ -1840,7 +1839,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
 }
 
-// -----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	// Already have one
@@ -2370,7 +2369,7 @@ func (cs *State) calculatePrevoteMessageDelayMetrics() {
 	}
 }
 
-// ---------------------------------------------------------
+//---------------------------------------------------------
 
 func CompareHRS(h1 int64, r1 int32, s1 cstypes.RoundStepType, h2 int64, r2 int32, s2 cstypes.RoundStepType) int {
 	if h1 < h2 {

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -88,7 +88,7 @@ const (
 	// BlockTable is the name of the table that stores metadata about consensus blocks.
 	// following schema:
 	//
-	//  | time  | height |
+	//  | time  | height | timestamp |
 	BlockTable = "consensus_block"
 
 	// TimestampFieldKey is the name of the field that stores the time at which

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -1,10 +1,11 @@
 package schema
 
 import (
+	"time"
+
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/pkg/trace"
-	"time"
 )
 
 // ConsensusTables returns the list of tables that are used for consensus

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -90,7 +90,7 @@ const (
 	// following schema:
 	//
 	//  | time  | height | timestamp |
-	BlockTable = "consensus_block"
+	BlockTable = "consensus_block_time"
 
 	// TimestampFieldKey is the name of the field that stores the time at which
 	// the block is proposed.

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -4,6 +4,7 @@ import (
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/pkg/trace"
+	"time"
 )
 
 // ConsensusTables returns the list of tables that are used for consensus
@@ -12,6 +13,7 @@ func ConsensusTables() []string {
 	return []string{
 		RoundStateTable,
 		BlockPartsTable,
+		BlockTable,
 	}
 }
 
@@ -79,5 +81,24 @@ func WriteBlockPart(
 		BlockPartIndexFieldKey: index,
 		PeerFieldKey:           peer,
 		TransferTypeFieldKey:   transferType,
+	})
+}
+
+const (
+	// BlockTable is the name of the table that stores metadata about consensus blocks.
+	// following schema:
+	//
+	//  | time  | height |
+	BlockTable = "consensus_block"
+
+	// TimestampFieldKey is the name of the field that stores the time at which
+	// the block is proposed.
+	TimestampFieldKey = "timestamp"
+)
+
+func WriteBlock(client *trace.Client, height int64, blockTimestamp time.Time) {
+	client.WritePoint(BlockTable, map[string]interface{}{
+		HeightFieldKey:    height,
+		TimestampFieldKey: blockTimestamp,
 	})
 }


### PR DESCRIPTION
## Description

To accurately gauge block time, it's essential to track the timestamps of committed blocks. The modifications made in this PR incorporate this feature.

Incremental work toward https://github.com/celestiaorg/celestia-core/issues/1056


