### PR TITLE
Add high priority broadcast routine

### DIFF
--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -769,3 +769,12 @@ func (txmp *TxMempool) notifyTxsAvailable() {
 		}
 	}
 }
+
+// HasTx returns true if the mempool contains the given transaction.
+func (txmp *TxMempool) HasTx(tx types.Tx) bool {
+	txmp.mtx.RLock()
+	defer txmp.mtx.RUnlock()
+
+	_, ok := txmp.txByKey[tx.Key()]
+	return ok
+}

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -333,6 +333,13 @@ func (memR *Reactor) broadcastPriorityTxRoutine(peer p2p.Peer) {
 					time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)
 					continue
 				}
+				schema.WriteMempoolTx(
+					memR.traceClient,
+					peer.ID(),
+					memTx.tx,
+					schema.TransferTypeUpload,
+					schema.V1VersionFieldValue,
+				)
 			}
 		}
 	}

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -249,11 +249,11 @@ func (memR *Reactor) priorityIntervalRoutine() {
 	lastRoutine := time.Now()
 	for {
 		// Sleep until the next interval.
-		time.Sleep(mempoolPriorityInterval - time.Since(lastRoutine))
-		lastRoutine = time.Now()
-
-		if !memR.IsRunning() {
+		select {
+		case <-memR.Quit():
 			return
+		case <-time.After(mempoolPriorityInterval - time.Since(lastRoutine)):
+			lastRoutine = time.Now()
 		}
 
 		// Sort txes by priority.
@@ -311,6 +311,11 @@ func (memR *Reactor) broadcastPriorityTxRoutine(peer p2p.Peer) {
 
 		// Loop through all the high priority txs.
 		for _, memTx := range memR.sortedTxs {
+			// Check that tx is still in mempool.
+			if !memR.mempool.HasTx(memTx.tx) {
+				continue
+			}
+
 			// Allow for a lag of 1 block.
 			if peerState.GetHeight() < memTx.height-1 {
 				time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)


### PR DESCRIPTION
This PR adds a high priority broadcast routine in the v1 reactor. By implementing this as a separate routine that essentially acts as a sidecar, we attempt to avoid any invasive changes to the original mempool that may have unintended consequences that require further testing.

This creates a separate broadcast routine with a separate P2P channel that periodically every `mempoolPriorityInterval`, sorts the transactions, reaps `mempoolPriorityBroadcastMaxBytes`, and triggers a sidecar broadcast routine in all peers.

Addresses #1069