### PR TITLE
feat: includes peer_id as a label in the MessageSendBytesTotal and MessageReceiveBytesTotal Prometheus metrics

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -63,13 +63,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_receive_bytes_total",
 			Help:      "Number of bytes received from a given peer.",
-		}, append(labels, "message_type", "peer_id", "chID")).With(labelsAndValues...),
+		}, append(labels, "peer_id", "chID")).With(labelsAndValues...),
 		PeerSendBytesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_send_bytes_total",
 			Help:      "Number of bytes sent to a given peer.",
-		}, append(labels, "message_type", "peer_id", "chID")).With(labelsAndValues...),
+		}, append(labels, "peer_id", "chID")).With(labelsAndValues...),
 		PeerPendingSendBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -87,13 +87,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "message_receive_bytes_total",
 			Help:      "Number of bytes of each message type received.",
-		}, append(labels, "message_type", "chID")).With(labelsAndValues...),
+		}, append(labels, "message_type", "chID", "peer_id")).With(labelsAndValues...),
 		MessageSendBytesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "message_send_bytes_total",
 			Help:      "Number of bytes of each message type sent.",
-		}, append(labels, "message_type", "chID")).With(labelsAndValues...),
+		}, append(labels, "message_type", "chID", "peer_id")).With(labelsAndValues...),
 	}
 }
 

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -63,13 +63,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_receive_bytes_total",
 			Help:      "Number of bytes received from a given peer.",
-		}, append(labels, "peer_id", "chID")).With(labelsAndValues...),
+		}, append(labels, "message_type", "peer_id", "chID")).With(labelsAndValues...),
 		PeerSendBytesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_send_bytes_total",
 			Help:      "Number of bytes sent to a given peer.",
-		}, append(labels, "peer_id", "chID")).With(labelsAndValues...),
+		}, append(labels, "message_type", "peer_id", "chID")).With(labelsAndValues...),
 		PeerPendingSendBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -100,7 +100,7 @@ func TrySendEnvelopeShim(p Peer, e Envelope, lg log.Logger) bool {
 	return p.TrySend(e.ChannelID, msgBytes)
 }
 
-// ----------------------------------------------------------
+//----------------------------------------------------------
 
 // peerConn contains the raw connection and its config.
 type peerConn struct {
@@ -231,7 +231,7 @@ func (p *peer) String() string {
 	return fmt.Sprintf("Peer{%v %v in}", p.mconn, p.ID())
 }
 
-// ---------------------------------------------------
+//---------------------------------------------------
 // Implements service.Service
 
 // SetLogger implements BaseService.
@@ -272,7 +272,7 @@ func (p *peer) OnStop() {
 	}
 }
 
-// ---------------------------------------------------
+//---------------------------------------------------
 // Implements Peer
 
 // ID returns the peer's ID - the hex encoded hash of its pubkey.
@@ -458,7 +458,7 @@ func (p *peer) GetRemovalFailed() bool {
 	return p.removalAttemptFailed
 }
 
-// ---------------------------------------------------
+//---------------------------------------------------
 // methods only used for testing
 // TODO: can we remove these?
 
@@ -480,7 +480,7 @@ func (p *peer) CanSend(chID byte) bool {
 	return p.mconn.CanSend(chID)
 }
 
-// ---------------------------------------------------
+//---------------------------------------------------
 
 func PeerMetrics(metrics *Metrics) PeerOption {
 	return func(p *peer) {
@@ -505,7 +505,7 @@ func (p *peer) metricsReporter() {
 	}
 }
 
-// ------------------------------------------------------------------
+//------------------------------------------------------------------
 // helper funcs
 
 func createMConnection(

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -100,7 +100,7 @@ func TrySendEnvelopeShim(p Peer, e Envelope, lg log.Logger) bool {
 	return p.TrySend(e.ChannelID, msgBytes)
 }
 
-//----------------------------------------------------------
+// ----------------------------------------------------------
 
 // peerConn contains the raw connection and its config.
 type peerConn struct {
@@ -231,7 +231,7 @@ func (p *peer) String() string {
 	return fmt.Sprintf("Peer{%v %v in}", p.mconn, p.ID())
 }
 
-//---------------------------------------------------
+// ---------------------------------------------------
 // Implements service.Service
 
 // SetLogger implements BaseService.
@@ -272,7 +272,7 @@ func (p *peer) OnStop() {
 	}
 }
 
-//---------------------------------------------------
+// ---------------------------------------------------
 // Implements Peer
 
 // ID returns the peer's ID - the hex encoded hash of its pubkey.
@@ -450,7 +450,7 @@ func (p *peer) GetRemovalFailed() bool {
 	return p.removalAttemptFailed
 }
 
-//---------------------------------------------------
+// ---------------------------------------------------
 // methods only used for testing
 // TODO: can we remove these?
 
@@ -472,7 +472,7 @@ func (p *peer) CanSend(chID byte) bool {
 	return p.mconn.CanSend(chID)
 }
 
-//---------------------------------------------------
+// ---------------------------------------------------
 
 func PeerMetrics(metrics *Metrics) PeerOption {
 	return func(p *peer) {
@@ -497,7 +497,7 @@ func (p *peer) metricsReporter() {
 	}
 }
 
-//------------------------------------------------------------------
+// ------------------------------------------------------------------
 // helper funcs
 
 func createMConnection(

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -331,8 +331,12 @@ func (p *peer) SendEnvelope(e Envelope) bool {
 	}
 	res := p.Send(e.ChannelID, msgBytes)
 	if res {
-		p.metrics.MessageSendBytesTotal.With("message_type",
-			metricLabelValue, "chID", fmt.Sprintf("%#x", e.ChannelID)).Add(float64(len(msgBytes)))
+		labels := []string{
+			"message_type", metricLabelValue,
+			"chID", fmt.Sprintf("%#x", e.ChannelID),
+			"peer_id", string(p.ID()),
+		}
+		p.metrics.MessageSendBytesTotal.With(labels...).Add(float64(len(msgBytes)))
 	}
 	return res
 }
@@ -381,8 +385,12 @@ func (p *peer) TrySendEnvelope(e Envelope) bool {
 	}
 	res := p.TrySend(e.ChannelID, msgBytes)
 	if res {
-		p.metrics.MessageSendBytesTotal.With("message_type",
-			metricLabelValue, "chID", fmt.Sprintf("%#x", e.ChannelID)).Add(float64(len(msgBytes)))
+		labels := []string{
+			"message_type", metricLabelValue,
+			"chID", fmt.Sprintf("%#x", e.ChannelID),
+			"peer_id", string(p.ID()),
+		}
+		p.metrics.MessageSendBytesTotal.With(labels...).Add(float64(len(msgBytes)))
 	}
 	return res
 }
@@ -523,19 +531,22 @@ func createMConnection(
 		if err != nil {
 			panic(fmt.Errorf("unmarshaling message: %s into type: %s", err, reflect.TypeOf(mt)))
 		}
-		labels := []string{
-			"peer_id", string(p.ID()),
-			"chID", fmt.Sprintf("%#x", chID),
-		}
+
 		if w, ok := msg.(Unwrapper); ok {
 			msg, err = w.Unwrap()
 			if err != nil {
 				panic(fmt.Errorf("unwrapping message: %s", err))
 			}
 		}
+
+		labels := []string{
+			"peer_id", string(p.ID()),
+			"chID", fmt.Sprintf("%#x", chID),
+			"message_type", p.mlc.ValueToMetricLabel(msg),
+		}
+
 		p.metrics.PeerReceiveBytesTotal.With(labels...).Add(float64(len(msgBytes)))
-		p.metrics.MessageReceiveBytesTotal.With("message_type",
-			p.mlc.ValueToMetricLabel(msg), "chID", fmt.Sprintf("%#x", chID)).Add(float64(len(msgBytes)))
+		p.metrics.MessageReceiveBytesTotal.With(labels...).Add(float64(len(msgBytes)))
 		if nr, ok := reactor.(EnvelopeReceiver); ok {
 			nr.ReceiveEnvelope(Envelope{
 				ChannelID: chID,

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -542,11 +542,10 @@ func createMConnection(
 		labels := []string{
 			"peer_id", string(p.ID()),
 			"chID", fmt.Sprintf("%#x", chID),
-			"message_type", p.mlc.ValueToMetricLabel(msg),
 		}
 
 		p.metrics.PeerReceiveBytesTotal.With(labels...).Add(float64(len(msgBytes)))
-		p.metrics.MessageReceiveBytesTotal.With(labels...).Add(float64(len(msgBytes)))
+		p.metrics.MessageReceiveBytesTotal.With(append(labels, "message_type", p.mlc.ValueToMetricLabel(msg))...).Add(float64(len(msgBytes)))
 		if nr, ok := reactor.(EnvelopeReceiver); ok {
 			nr.ReceiveEnvelope(Envelope{
 				ChannelID: chID,


### PR DESCRIPTION
Inline with https://github.com/celestiaorg/celestia-core/issues/1077

Our past experimentation showed that none of the current Prometheus traffic related metrics encompass all the information regarding the message type, peer ID and channel ID. This deficiency can be addressed by incorporating peer IDs for `message_receive_bytes_total` and `message_send_bytes_total`.  This PR provides this feature.

I tested it by executing a local validator node and examining the Prometheus metrics endpoint. Here's an example of the output:

```
cometbft_p2p_message_send_bytes_total{chID="0x40", chain_id="mocha-4", message_type="blockchain_StatusResponse", peer_id="cb7adca6fbaabc5336c5eebbc1312390a2bb9d2d", version="1.0.0-rc0-278-g4c452c5f4"} 8
```