### PR TITLE
feat: mempools should correctly respect time based TTL

### DIFF
--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -50,7 +50,8 @@ type TxMempool struct {
 	txsAvailable         chan struct{} // one value sent per height when mempool is not empty
 	preCheck             mempool.PreCheckFunc
 	postCheck            mempool.PostCheckFunc
-	height               int64 // the latest height passed to Update
+	height               int64     // the latest height passed to Update
+	lastPurgeTime        time.Time // the last time we attempted to purge transactions via the TTL
 
 	txs        *clist.CList // valid transactions (passed CheckTx)
 	txByKey    map[types.TxKey]*clist.CElement
@@ -723,6 +724,17 @@ func (txmp *TxMempool) canAddTx(wtx *WrappedTx) error {
 	return nil
 }
 
+// CheckToPurgeExpiredTxs checks if there has been adequate time since the last time
+// the txpool looped through all transactions and if so, performs a purge of any transaction
+// that has expired according to the TTLDuration. This is thread safe.
+func (txmp *TxMempool) CheckToPurgeExpiredTxs() {
+	txmp.mtx.Lock()
+	defer txmp.mtx.Unlock()
+	if txmp.config.TTLDuration > 0 && time.Since(txmp.lastPurgeTime) > txmp.config.TTLDuration {
+		txmp.purgeExpiredTxs(txmp.height)
+	}
+}
+
 // purgeExpiredTxs removes all transactions from the mempool that have exceeded
 // their respective height or time-based limits as of the given blockHeight.
 // Transactions removed by this operation are not removed from the cache.
@@ -752,6 +764,8 @@ func (txmp *TxMempool) purgeExpiredTxs(blockHeight int64) {
 		}
 		cur = next
 	}
+
+	txmp.lastPurgeTime = now
 }
 
 func (txmp *TxMempool) notifyTxsAvailable() {

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -117,6 +117,22 @@ func (memR *Reactor) OnStart() error {
 	if !memR.config.Broadcast {
 		memR.Logger.Info("Tx broadcasting is disabled")
 	}
+
+	// run a separate go routine to check for time based TTLs
+	if memR.mempool.config.TTLDuration > 0 {
+		go func() {
+			ticker := time.NewTicker(memR.mempool.config.TTLDuration)
+			for {
+				select {
+				case <-ticker.C:
+					memR.mempool.CheckToPurgeExpiredTxs()
+				case <-memR.Quit():
+					return
+				}
+			}
+		}()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
TTLs are currently only checked on `Update` which is only when a block is committed. In the rare event that a block takes several rounds to commit (because of a faulty transaction that is halting the chain), a transaction can outlast the TTLDuration that was set by the node operator.

This PR initiates a separate go routine for both the `v1` and `cat` mempools that will routinely check for expired transactions and remove them regardless of when `Update` is called