### PR TITLE
feat: tracks block time using a Prometheus gauge metric type

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -178,7 +178,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "block_time_seconds",
 			Help:      "Duration between this block and the preceding one.",
-		}, append(labels, "block_height")).With(labelsAndValues...),
+		}, labels).With(labelsAndValues...),
 		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -272,6 +272,7 @@ func NopMetrics() *Metrics {
 		ByzantineValidatorsPower: discard.NewGauge(),
 
 		BlockIntervalSeconds: discard.NewHistogram(),
+		BlockTimeSeconds:     discard.NewGauge(),
 
 		NumTxs:                    discard.NewGauge(),
 		BlockSizeBytes:            discard.NewGauge(),

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -48,6 +48,8 @@ type Metrics struct {
 
 	// Time between this and the last block.
 	BlockIntervalSeconds metrics.Histogram
+	// Block time in seconds.
+	BlockTimeSeconds metrics.Gauge
 
 	// Number of transactions.
 	NumTxs metrics.Gauge
@@ -57,9 +59,9 @@ type Metrics struct {
 	TotalTxs metrics.Gauge
 	// The latest block height.
 	CommittedHeight metrics.Gauge
-	// Whether or not a node is fast syncing. 1 if yes, 0 if no.
+	// Whether a node is fast syncing. 1 if yes, 0 if no.
 	FastSyncing metrics.Gauge
-	// Whether or not a node is state syncing. 1 if yes, 0 if no.
+	// Whether a node is state syncing. 1 if yes, 0 if no.
 	StateSyncing metrics.Gauge
 
 	// Number of blockparts transmitted by peer.
@@ -170,6 +172,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "block_interval_seconds",
 			Help:      "Time between this and the last block.",
+		}, labels).With(labelsAndValues...),
+		BlockTimeSeconds: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "block_time_seconds",
+			Help:      "Duration between this block and the preceding one.",
 		}, labels).With(labelsAndValues...),
 		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -178,7 +178,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "block_time_seconds",
 			Help:      "Duration between this block and the preceding one.",
-		}, labels).With(labelsAndValues...),
+		}, append(labels, "block_height")).With(labelsAndValues...),
 		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2006,7 +2006,7 @@ func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 		// If the vote height is off, we'll just ignore it,
 		// But if it's a conflicting sig, add it to the cs.evpool.
 		// If it's otherwise invalid, punish peer.
-		// nolint: gocritic
+		//nolint: gocritic
 		if voteErr, ok := err.(*types.ErrVoteConflictingVotes); ok {
 			if cs.privValidatorPubKey == nil {
 				return false, errPubKeyIsNotSet

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1832,8 +1832,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 		if lastBlockMeta != nil {
 			elapsedTime := block.Time.Sub(lastBlockMeta.Header.Time).Seconds()
 			cs.metrics.BlockIntervalSeconds.Observe(elapsedTime)
-			cs.metrics.BlockTimeSeconds.With("block_height",
-				fmt.Sprintf("%d", block.Height)).Set(elapsedTime)
+			cs.metrics.BlockTimeSeconds.Set(elapsedTime)
 
 		}
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1846,7 +1846,6 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.NumTxs.Set(float64(len(block.Data.Txs)))
 	cs.metrics.TotalTxs.Add(float64(len(block.Data.Txs)))
 	cs.metrics.BlockSizeBytes.Set(float64(blockSize))
-	// cs.metrics.BlockTimeSeconds
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
 }
 

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"time"
 
@@ -1671,7 +1672,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 			elapsedTime := block.Time.Sub(lastBlockMeta.Header.Time).Seconds()
 			cs.metrics.BlockIntervalSeconds.Observe(elapsedTime)
 			cs.metrics.BlockTimeSeconds.With("block_height",
-				fmt.Sprintf("%d", block.Height)).Set(elapsedTime)
+				strconv.FormatInt(block.Height, 10)).Set(elapsedTime)
 
 		}
 	}

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1778,7 +1778,7 @@ func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 		// If the vote height is off, we'll just ignore it,
 		// But if it's a conflicting sig, add it to the cs.evpool.
 		// If it's otherwise invalid, punish peer.
-		// nolint: gocritic
+		//nolint: gocritic
 		if voteErr, ok := err.(*types.ErrVoteConflictingVotes); ok {
 			if cs.privValidatorPubKey == nil {
 				return false, errPubKeyIsNotSet

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"reflect"
 	"runtime/debug"
-	"strconv"
 	"sync"
 	"time"
 
@@ -1671,8 +1670,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 		if lastBlockMeta != nil {
 			elapsedTime := block.Time.Sub(lastBlockMeta.Header.Time).Seconds()
 			cs.metrics.BlockIntervalSeconds.Observe(elapsedTime)
-			cs.metrics.BlockTimeSeconds.With("block_height",
-				strconv.FormatInt(block.Height, 10)).Set(elapsedTime)
+			cs.metrics.BlockTimeSeconds.Set(elapsedTime)
 
 		}
 	}

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1893,7 +1893,7 @@ func (cs *State) signAddVote(msgType cmtproto.SignedMsgType, hash []byte, header
 	}
 	// if !cs.replayMode {
 	cs.Logger.Error("Error signing vote", "height", cs.Height, "round", cs.Round, "vote", vote, "err", err)
-	// }
+	//}
 	return nil
 }
 

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1668,9 +1668,11 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	if height > 1 {
 		lastBlockMeta := cs.blockStore.LoadBlockMeta(height - 1)
 		if lastBlockMeta != nil {
-			cs.metrics.BlockIntervalSeconds.Observe(
-				block.Time.Sub(lastBlockMeta.Header.Time).Seconds(),
-			)
+			elapsedTime := block.Time.Sub(lastBlockMeta.Header.Time).Seconds()
+			cs.metrics.BlockIntervalSeconds.Observe(elapsedTime)
+			cs.metrics.BlockTimeSeconds.With("block_height",
+				fmt.Sprintf("%d", block.Height)).Set(elapsedTime)
+
 		}
 	}
 
@@ -1776,7 +1778,7 @@ func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 		// If the vote height is off, we'll just ignore it,
 		// But if it's a conflicting sig, add it to the cs.evpool.
 		// If it's otherwise invalid, punish peer.
-		//nolint: gocritic
+		// nolint: gocritic
 		if voteErr, ok := err.(*types.ErrVoteConflictingVotes); ok {
 			if cs.privValidatorPubKey == nil {
 				return false, errPubKeyIsNotSet
@@ -1892,7 +1894,7 @@ func (cs *State) signAddVote(msgType cmtproto.SignedMsgType, hash []byte, header
 	}
 	// if !cs.replayMode {
 	cs.Logger.Error("Error signing vote", "height", cs.Height, "round", cs.Round, "vote", vote, "err", err)
-	//}
+	// }
 	return nil
 }
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/1077

I have verified the outcome of this pull request, and the block time gauge now correctly appears in the Prometheus endpoint:

```
# HELP cometbft_consensus_block_time_seconds Duration between this block and the preceding one.
# TYPE cometbft_consensus_block_time_seconds gauge
cometbft_consensus_block_time_seconds{chain_id="mocha-4",version="1.0.0-rc16"} 11.623671263
```