### PR TITLE
fix(types): Implement nil check on commit.ValidateBasic 

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -881,6 +881,10 @@ func (commit *Commit) IsCommit() bool {
 // ValidateBasic performs basic validation that doesn't involve state data.
 // Does not actually check the cryptographic signatures.
 func (commit *Commit) ValidateBasic() error {
+	if commit == nil {
+		return errors.New("nil commit")
+	}
+
 	if commit.Height < 0 {
 		return errors.New("negative Height")
 	}


### PR DESCRIPTION
Found in celestia-node header validation check. If a malformed `ExtendedHeader` with a nil Commit is broadcasted through the network, it would cause recipients to panic. We decided the check belongs in core as ValidatorSet also does a nil check.