### PR TITLE
chore: refactors CAT mempool to use SendEnvelope instead of Send

### DIFF
--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -329,11 +329,6 @@ func (memR *Reactor) broadcastSeenTx(txKey types.TxKey) {
 		},
 	}
 
-	//bz, err := msg.Marshal()
-	//if err != nil {
-	//	panic(err)
-	//}
-
 	// Add jitter to when the node broadcasts it's seen txs to stagger when nodes
 	// in the network broadcast their seenTx messages.
 	time.Sleep(time.Duration(rand.Intn(10)*10) * time.Millisecond) //nolint:gosec
@@ -370,10 +365,6 @@ func (memR *Reactor) broadcastNewTx(wtx *wrappedTx) {
 			},
 		},
 	}
-	//bz, err := msg.Marshal()
-	//if err != nil {
-	//	panic(err)
-	//}
 
 	for id, peer := range memR.ids.GetAll() {
 		if p, ok := peer.Get(types.PeerStateKey).(PeerState); ok {

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -78,8 +78,6 @@ func TestReactorSendWantTxAfterReceiveingSeenTx(t *testing.T) {
 		Message:   msgWant,
 		ChannelID: MempoolStateChannel,
 	}
-	//msgWantB, err := msgWant.Marshal()
-	//require.NoError(t, err)
 
 	peer := genPeer()
 	peer.On("SendEnvelope", envWant).Return(true)


### PR DESCRIPTION
Closes #1099 and #1085