### PR TITLE
chore: Consolidating default SendRate and RecvRate settings for clarity and consistency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -595,6 +595,7 @@ type P2PConfig struct { //nolint: maligned
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer
 func DefaultP2PConfig() *P2PConfig {
+	defaultMConConfig := conn.DefaultMConnConfig()
 	return &P2PConfig{
 		ListenAddress:                "tcp://0.0.0.0:26656",
 		ExternalAddress:              "",
@@ -604,10 +605,10 @@ func DefaultP2PConfig() *P2PConfig {
 		MaxNumInboundPeers:           40,
 		MaxNumOutboundPeers:          10,
 		PersistentPeersMaxDialPeriod: 0 * time.Second,
-		FlushThrottleTimeout:         100 * time.Millisecond,
-		MaxPacketMsgPayloadSize:      1024,    // 1 kB
-		SendRate:                     5120000, // 5 mB/s
-		RecvRate:                     5120000, // 5 mB/s
+		FlushThrottleTimeout:         defaultMConConfig.FlushThrottle,
+		MaxPacketMsgPayloadSize:      1024, // 1 kB
+		SendRate:                     defaultMConConfig.SendRate,
+		RecvRate:                     defaultMConConfig.RecvRate,
 		PexReactor:                   true,
 		SeedMode:                     false,
 		AllowDuplicateIP:             false,

--- a/config/config.go
+++ b/config/config.go
@@ -4,11 +4,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/cometbft/cometbft/p2p/conn"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/cometbft/cometbft/p2p/conn"
 )
 
 const (

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/cometbft/cometbft/p2p/conn"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -39,9 +39,9 @@ const (
 
 	defaultSendQueueCapacity   = 1
 	defaultRecvBufferCapacity  = 4096
-	defaultRecvMessageCapacity = 22020096      // 21MB
-	defaultSendRate            = int64(512000) // 500KB/s
-	defaultRecvRate            = int64(512000) // 500KB/s
+	defaultRecvMessageCapacity = 22020096         // 21MB
+	defaultSendRate            = int64(5_120_000) // 5MB/s
+	defaultRecvRate            = int64(5_120_000) // 5MB/s
 	defaultSendTimeout         = 10 * time.Second
 	defaultPingInterval        = 60 * time.Second
 	defaultPongTimeout         = 45 * time.Second


### PR DESCRIPTION
There are two default SendRate/RecvRate settings in the codebase:
- The first one is a constant defined in the `connection.go` file, which is set to 512KB/s. You can find it in the code at this [link](https://github.com/celestiaorg/celestia-core/blob/main/p2p/conn/connection.go#L43).
- The second default value is set in the `config.go` file, which configures various P2P settings. Among these configurations, the SendRate and RecvRate default to 5MB/s. You can locate this in the code at this [link](https://github.com/celestiaorg/celestia-core/blob/main/config/config.go#L609).

When a node is running, the SendRate and RecvRate values that take effect are the ones specified in the `config.go` file, which is 5MB/s.

This PR aims to consolidate these two scattered default values. By doing so, it ensures that when developers consult the code, there will be no confusion regarding the default settings for these parameters.