### PR TITLE
chore: updates PR and issue templates to properly reference celestia-core

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,7 @@ labels: bug, needs-triage
 Please fill in as much of the template below as you can.
 
 If you have general questions, please create a new discussion:
-https://github.com/cometbft/cometbft/discussions
+https://github.com/celestiaorg/celestia-core/discussions
 
 Be ready for followup questions, and please respond in a timely manner. We might
 ask you to provide additional logs and data (CometBFT & App).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Ask a question
-    url: https://github.com/cometbft/cometbft/discussions
+    url: https://github.com/celestiaorg/celestia-core/discussions
     about: Please ask and answer questions here

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,11 +4,11 @@ about: Create a proposal to request a feature
 labels: enhancement, needs-triage
 ---
 
-<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
-v                            ✰  Thanks for opening an issue! ✰    
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
+v                            ✰  Thanks for opening an issue! ✰
 v    Before smashing the submit button please review the template.
-v    Word of caution: poorly thought-out proposals may be rejected 
-v                     without deliberation 
+v    Word of caution: poorly thought-out proposals may be rejected
+v                     without deliberation
 ☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
 
 ## Feature Request
@@ -21,7 +21,7 @@ v                     without deliberation
 
 <!-- Why do we need this feature?
 What problems may be addressed by introducing this feature?
-What benefits does CometBFT stand to gain by including this feature?
+What benefits does Celestia-core stand to gain by including this feature?
 Are there any disadvantages of including this feature? -->
 
 ### Proposal

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -4,10 +4,10 @@ about: Create a proposal to request a change to the protocol
 labels: protocol-change, needs-triage
 ---
 
-<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
-v                            ✰  Thanks for opening an issue! ✰    
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
+v                            ✰  Thanks for opening an issue! ✰
 v    Before smashing the submit button please review the template.
-v    Word of caution: Under-specified proposals may be rejected summarily 
+v    Word of caution: Under-specified proposals may be rejected summarily
 ☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
 
 ## Protocol Change Proposal
@@ -20,7 +20,7 @@ v    Word of caution: Under-specified proposals may be rejected summarily
 
 <!-- Why do we need this change?
 What problems may be addressed by introducing this change?
-What benefits does CometBFT stand to gain by including this change?
+What benefits does Celestia-core stand to gain by including this change?
 Are there any disadvantages of including this change? -->
 
 ### Proposal

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,20 @@
 ## Description
 
 _Please add a description of the changes that this PR introduces and the files that
-are the most critical to review._ 
+are the most critical to review._
 
 If this PR is non-trivial/large/complex, please ensure that you have either
 created an issue that the team's had a chance to respond to, or had some
 discussion with the team prior to submitting substantial pull requests. The team
-can be reached via GitHub Discussions or the Cosmos Network Discord server in
-the #cometbft channel. GitHub Discussions is preferred over Discord as it
-allows us to keep track of conversations topically.
-https://github.com/cometbft/cometbft/discussions
+can be reached via GitHub Discussions:
+https://github.com/celestiaorg/celestia-core/discussions
 
 If the work in this PR is not aligned with the team's current priorities, please
 be advised that it may take some time before it is merged - especially if it has
 not yet been discussed with the team.
 
 See the project board for the team's current priorities:
-https://github.com/orgs/cometbft/projects/1
+https://github.com/orgs/celestiaorg/projects/24
 
 -->
 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -5,6 +5,6 @@ labels: needs-triage
 <!--
 
 If you want to ask a general question, please create a new discussion instead of
-an issue: https://github.com/cometbft/cometbft/discussions
+an issue: https://github.com/celestiaorg/celestia-core/discussions
 
 -->


### PR DESCRIPTION
Some revisions were needed in the Github PR and issue templates to update links and wording, ensuring they refer to the celestia-core repository instead of cometbft.