### PR TITLE
fix!: change the instrumentation config to circumvent viper bug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -66,7 +67,7 @@ var (
 	// This global var is filled by an init function in the schema package. This
 	// allows for the schema package to contain all the relevant logic while
 	// avoiding import cycles.
-	DefaultInfluxTables = []string{}
+	DefaultInfluxTables = ""
 )
 
 // Config defines the top level configuration for a CometBFT node
@@ -1199,7 +1200,7 @@ type InstrumentationConfig struct {
 
 	// InfluxTables is the list of tables that will be traced. See the
 	// pkg/trace/schema for a complete list of tables.
-	InfluxTables []string `mapstructure:"influx_tables"`
+	InfluxTables string `mapstructure:"influx_tables"`
 
 	// PyroscopeURL is the pyroscope url used to establish a connection with a
 	// pyroscope continuous profiling server.
@@ -1212,7 +1213,7 @@ type InstrumentationConfig struct {
 	// pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 	// inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
 	// block_count, block_duration.
-	PyroscopeProfileTypes []string `mapstructure:"pyroscope_profile_types"`
+	PyroscopeProfileTypes string `mapstructure:"pyroscope_profile_types"`
 }
 
 // DefaultInstrumentationConfig returns a default configuration for metrics
@@ -1230,7 +1231,7 @@ func DefaultInstrumentationConfig() *InstrumentationConfig {
 		InfluxTables:         DefaultInfluxTables,
 		PyroscopeURL:         "",
 		PyroscopeTrace:       false,
-		PyroscopeProfileTypes: []string{
+		PyroscopeProfileTypes: strings.Join([]string{
 			"cpu",
 			"alloc_objects",
 			"inuse_objects",
@@ -1240,6 +1241,7 @@ func DefaultInstrumentationConfig() *InstrumentationConfig {
 			"block_count",
 			"block_duration",
 		},
+			","),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1199,7 +1199,8 @@ type InstrumentationConfig struct {
 	InfluxBatchSize int `mapstructure:"influx_batch_size"`
 
 	// InfluxTables is the list of tables that will be traced. See the
-	// pkg/trace/schema for a complete list of tables.
+	// pkg/trace/schema for a complete list of tables. It is represented as a
+	// comma separate string. For example: "consensus_round_state,mempool_tx".
 	InfluxTables string `mapstructure:"influx_tables"`
 
 	// PyroscopeURL is the pyroscope url used to establish a connection with a
@@ -1212,7 +1213,8 @@ type InstrumentationConfig struct {
 	// PyroscopeProfileTypes is a list of profile types to be traced with
 	// pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 	// inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
-	// block_count, block_duration.
+	// block_count, block_duration. It is represented as a comma separate
+	// string. For example: "goroutines,alloc_objects".
 	PyroscopeProfileTypes string `mapstructure:"pyroscope_profile_types"`
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -559,7 +559,7 @@ influx_batch_size = {{ .Instrumentation.InfluxBatchSize }}
 
 # The list of tables that are updated when tracing. All available tables and
 # their schema can be found in the pkg/trace/schema package. It is represented as a
-// comma separate string. For example: "consensus_round_state,mempool_tx".
+# comma separate string. For example: "consensus_round_state,mempool_tx".
 influx_tables = "{{ .Instrumentation.InfluxTables }}"
 
 # The URL of the pyroscope instance to use for continuous profiling.

--- a/config/toml.go
+++ b/config/toml.go
@@ -559,7 +559,7 @@ influx_batch_size = {{ .Instrumentation.InfluxBatchSize }}
 
 # The list of tables that are updated when tracing. All available tables and
 # their schema can be found in the pkg/trace/schema package.
-influx_tables = {{ .Instrumentation.InfluxTables }}
+influx_tables = "{{ .Instrumentation.InfluxTables }}"
 
 # The URL of the pyroscope instance to use for continuous profiling.
 # If empty, continuous profiling is disabled.
@@ -573,7 +573,7 @@ pyroscope_trace = {{ .Instrumentation.PyroscopeTrace }}
 # pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 # inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
 # block_count, block_duration.
-pyroscope_profile_types = {{ .Instrumentation.PyroscopeProfileTypes }}
+pyroscope_profile_types = "{{ .Instrumentation.PyroscopeProfileTypes }}"
 
 `
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -559,7 +559,7 @@ influx_batch_size = {{ .Instrumentation.InfluxBatchSize }}
 
 # The list of tables that are updated when tracing. All available tables and
 # their schema can be found in the pkg/trace/schema package.
-influx_tables = [{{ range .Instrumentation.InfluxTables }}{{ printf "%q, " . }}{{end}}]
+influx_tables = {{ .Instrumentation.InfluxTables }}
 
 # The URL of the pyroscope instance to use for continuous profiling.
 # If empty, continuous profiling is disabled.
@@ -573,7 +573,7 @@ pyroscope_trace = {{ .Instrumentation.PyroscopeTrace }}
 # pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 # inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
 # block_count, block_duration.
-pyroscope_profile_types = [{{ range .Instrumentation.PyroscopeProfileTypes }}{{ printf "%q, " . }}{{end}}]
+pyroscope_profile_types = {{ .Instrumentation.PyroscopeProfileTypes }}
 
 `
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -574,7 +574,7 @@ pyroscope_trace = {{ .Instrumentation.PyroscopeTrace }}
 # pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 # inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
 # block_count, block_duration. It is represented as a comma separate
-// string. For example: "goroutines,alloc_objects".
+# string. For example: "goroutines,alloc_objects".
 pyroscope_profile_types = "{{ .Instrumentation.PyroscopeProfileTypes }}"
 
 `

--- a/config/toml.go
+++ b/config/toml.go
@@ -558,7 +558,8 @@ influx_org = "{{ .Instrumentation.InfluxOrg }}"
 influx_batch_size = {{ .Instrumentation.InfluxBatchSize }}
 
 # The list of tables that are updated when tracing. All available tables and
-# their schema can be found in the pkg/trace/schema package.
+# their schema can be found in the pkg/trace/schema package. It is represented as a
+// comma separate string. For example: "consensus_round_state,mempool_tx".
 influx_tables = "{{ .Instrumentation.InfluxTables }}"
 
 # The URL of the pyroscope instance to use for continuous profiling.
@@ -572,7 +573,8 @@ pyroscope_trace = {{ .Instrumentation.PyroscopeTrace }}
 # pyroscope_profile_types is a list of profile types to be traced with
 # pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 # inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
-# block_count, block_duration.
+# block_count, block_duration. It is represented as a comma separate
+// string. For example: "goroutines,alloc_objects".
 pyroscope_profile_types = "{{ .Instrumentation.PyroscopeProfileTypes }}"
 
 `

--- a/node/tracing.go
+++ b/node/tracing.go
@@ -76,8 +76,9 @@ func tracerProviderDebug() (*sdktrace.TracerProvider, error) {
 	return sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(exp))), nil
 }
 
-func toPyroscopeProfiles(profiles []string) []pyroscope.ProfileType {
-	pts := make([]pyroscope.ProfileType, 0, len(profiles))
+func toPyroscopeProfiles(profiles string) []pyroscope.ProfileType {
+	parsedProfiles := splitAndTrimEmpty(profiles, ",", " ")
+	pts := make([]pyroscope.ProfileType, 0, len(parsedProfiles))
 	for _, p := range profiles {
 		pts = append(pts, pyroscope.ProfileType(p))
 	}

--- a/pkg/trace/client.go
+++ b/pkg/trace/client.go
@@ -156,6 +156,14 @@ func stringToMap(tables string) map[string]struct{} {
 	return m
 }
 
+// splitAndTrimEmpty slices s into all subslices separated by sep and returns a
+// slice of the string s with all leading and trailing Unicode code points
+// contained in cutset removed. If sep is empty, SplitAndTrim splits after each
+// UTF-8 sequence. First part is equivalent to strings.SplitN with a count of
+// -1.  also filter out empty strings, only return non-empty strings.
+//
+// NOTE: this is copy pasted from the config pacakage to avoid a circular
+// dependency. See the function of the same name for tests.
 func splitAndTrimEmpty(s, sep, cutset string) []string {
 	if s == "" {
 		return []string{}

--- a/pkg/trace/schema/tables.go
+++ b/pkg/trace/schema/tables.go
@@ -1,9 +1,13 @@
 package schema
 
-import "github.com/tendermint/tendermint/config"
+import (
+	"strings"
+
+	"github.com/tendermint/tendermint/config"
+)
 
 func init() {
-	config.DefaultInfluxTables = AllTables()
+	config.DefaultInfluxTables = strings.Join(AllTables(), ",")
 }
 
 func AllTables() []string {

--- a/test/e2e/pkg/infrastructure.go
+++ b/test/e2e/pkg/infrastructure.go
@@ -49,7 +49,7 @@ type InfrastructureData struct {
 	PyroscopeTrace bool `json:"pyroscope_trace,omitempty"`
 
 	// PyroscopeProfileTypes is the list of profile types to collect.
-	PyroscopeProfileTypes []string `json:"pyroscope_profile_types,omitempty"`
+	PyroscopeProfileTypes string `json:"pyroscope_profile_types,omitempty"`
 }
 
 // InstanceData contains the relevant information for a machine instance backing

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -110,7 +110,7 @@ type Node struct {
 	InfluxDBToken         string
 	PyroscopeURL          string
 	PyroscopeTrace        bool
-	PyroscopeProfileTypes []string
+	PyroscopeProfileTypes string
 }
 
 // LoadTestnet loads a testnet from a manifest file, using the filename to


### PR DESCRIPTION
## Description

There's an viper property or potential bug that stops us from overriding the default values for slices of strings. The "solution" atm is to use a string and parse it later like animals later. Unfortunately I think this is breaking since we're changing what a config is doing so tbh I'm not sure if we can ever include this in v1. If that's the case then we might want to consider not merging this to v0.34.x-celestia and only to main.

closes #1141 

