### PR TITLE
fix!: change the instrumentation config to circumvent viper bug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cometbft/cometbft/p2p/conn"
@@ -68,7 +69,7 @@ var (
 	// This global var is filled by an init function in the schema package. This
 	// allows for the schema package to contain all the relevant logic while
 	// avoiding import cycles.
-	DefaultInfluxTables = []string{}
+	DefaultInfluxTables = ""
 )
 
 // Config defines the top level configuration for a CometBFT node
@@ -1202,7 +1203,7 @@ type InstrumentationConfig struct {
 
 	// InfluxTables is the list of tables that will be traced. See the
 	// pkg/trace/schema for a complete list of tables.
-	InfluxTables []string `mapstructure:"influx_tables"`
+	InfluxTables string `mapstructure:"influx_tables"`
 
 	// PyroscopeURL is the pyroscope url used to establish a connection with a
 	// pyroscope continuous profiling server.
@@ -1215,7 +1216,7 @@ type InstrumentationConfig struct {
 	// pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 	// inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
 	// block_count, block_duration.
-	PyroscopeProfileTypes []string `mapstructure:"pyroscope_profile_types"`
+	PyroscopeProfileTypes string `mapstructure:"pyroscope_profile_types"`
 }
 
 // DefaultInstrumentationConfig returns a default configuration for metrics
@@ -1233,7 +1234,7 @@ func DefaultInstrumentationConfig() *InstrumentationConfig {
 		InfluxTables:         DefaultInfluxTables,
 		PyroscopeURL:         "",
 		PyroscopeTrace:       false,
-		PyroscopeProfileTypes: []string{
+		PyroscopeProfileTypes: strings.Join([]string{
 			"cpu",
 			"alloc_objects",
 			"inuse_objects",
@@ -1243,6 +1244,7 @@ func DefaultInstrumentationConfig() *InstrumentationConfig {
 			"block_count",
 			"block_duration",
 		},
+			","),
 	}
 }
 

--- a/node/tracing.go
+++ b/node/tracing.go
@@ -76,8 +76,9 @@ func tracerProviderDebug() (*sdktrace.TracerProvider, error) {
 	return sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(exp))), nil
 }
 
-func toPyroscopeProfiles(profiles []string) []pyroscope.ProfileType {
-	pts := make([]pyroscope.ProfileType, 0, len(profiles))
+func toPyroscopeProfiles(profiles string) []pyroscope.ProfileType {
+	parsedProfiles := splitAndTrimEmpty(profiles, ",", " ")
+	pts := make([]pyroscope.ProfileType, 0, len(parsedProfiles))
 	for _, p := range profiles {
 		pts = append(pts, pyroscope.ProfileType(p))
 	}

--- a/pkg/trace/client.go
+++ b/pkg/trace/client.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cometbft/cometbft/config"
@@ -81,7 +82,7 @@ func NewClient(cfg *config.InstrumentationConfig, logger log.Logger, chainID, no
 		cancel:  cancel,
 		chainID: chainID,
 		nodeID:  nodeID,
-		tables:  sliceToMap(cfg.InfluxTables),
+		tables:  stringToMap(cfg.InfluxTables),
 	}
 	if cfg.InfluxURL == "" {
 		return cli, nil
@@ -146,10 +147,27 @@ func (c *Client) WritePoint(table string, fields map[string]interface{}) {
 	writeAPI.WritePoint(p)
 }
 
-func sliceToMap(tables []string) map[string]struct{} {
+func stringToMap(tables string) map[string]struct{} {
+	parsedTables := splitAndTrimEmpty(tables, ",", " ")
 	m := make(map[string]struct{})
-	for _, s := range tables {
+	for _, s := range parsedTables {
 		m[s] = struct{}{}
 	}
 	return m
+}
+
+func splitAndTrimEmpty(s, sep, cutset string) []string {
+	if s == "" {
+		return []string{}
+	}
+
+	spl := strings.Split(s, sep)
+	nonEmptyStrings := make([]string, 0, len(spl))
+	for i := 0; i < len(spl); i++ {
+		element := strings.Trim(spl[i], cutset)
+		if element != "" {
+			nonEmptyStrings = append(nonEmptyStrings, element)
+		}
+	}
+	return nonEmptyStrings
 }

--- a/pkg/trace/schema/tables.go
+++ b/pkg/trace/schema/tables.go
@@ -1,9 +1,13 @@
 package schema
 
-import "github.com/cometbft/cometbft/config"
+import (
+	"strings"
+
+	"github.com/cometbft/cometbft/config"
+)
 
 func init() {
-	config.DefaultInfluxTables = AllTables()
+	config.DefaultInfluxTables = strings.Join(AllTables(), ",")
 }
 
 func AllTables() []string {

--- a/test/e2e/pkg/infrastructure.go
+++ b/test/e2e/pkg/infrastructure.go
@@ -49,7 +49,7 @@ type InfrastructureData struct {
 	PyroscopeTrace bool `json:"pyroscope_trace,omitempty"`
 
 	// PyroscopeProfileTypes is the list of profile types to collect.
-	PyroscopeProfileTypes []string `json:"pyroscope_profile_types,omitempty"`
+	PyroscopeProfileTypes string `json:"pyroscope_profile_types,omitempty"`
 }
 
 // InstanceData contains the relevant information for a machine instance backing

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -110,7 +110,7 @@ type Node struct {
 	InfluxDBToken         string
 	PyroscopeURL          string
 	PyroscopeTrace        bool
-	PyroscopeProfileTypes []string
+	PyroscopeProfileTypes string
 }
 
 // LoadTestnet loads a testnet from a manifest file, using the filename to


### PR DESCRIPTION
## Description

There's an viper [property or potential bug](https://github.com/spf13/viper/issues/1366) that stops us from overriding the default values for slices of strings. The "solution" atm is to use a string and parse it later like animals later.

closes #1141 

