### PR TITLE
docs: add Celestia-ContributorGitPOAP sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,9 @@ coherence in the larger context. If you are not comfortable with writing an ADR,
 you can open a less-formal issue and the maintainers will help you turn it into
 an ADR.
 
+Once your pull requests are merged to one of celestiaorg's GitHub repositories, you will be automatically awared  the right to mint a [Celestia Contributor GitPOAP](https://www.gitpoap.io/gh/celestiaorg/celestia-core). (You can check which repositories here: [Celestia Contributor GitPOAP](https://www.gitpoap.io/gh/celestiaorg/celestia-core))
+
+
 > How to pick a number for the ADR?
 
 Find the largest existing ADR number and bump it by 1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ coherence in the larger context. If you are not comfortable with writing an ADR,
 you can open a less-formal issue and the maintainers will help you turn it into
 an ADR.
 
-Once your pull requests are merged to one of celestiaorg's GitHub repositories, you will be automatically awared  the right to mint a [Celestia Contributor GitPOAP](https://www.gitpoap.io/gh/celestiaorg/celestia-core). (You can check which repositories here: [Celestia Contributor GitPOAP](https://www.gitpoap.io/gh/celestiaorg/celestia-core))
+Once your pull request is merged to an eligible celestiaorg GitHub repository, you will be rewarded the ability to mint a [GitPOAP](https://www.gitpoap.io). You can check which repositories are eligible at [gitpoap/celestiaorg](https://www.gitpoap.io/gh/celestiaorg)
 
 
 > How to pick a number for the ADR?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,6 @@ an ADR.
 
 Once your pull request is merged to an eligible celestiaorg GitHub repository, you will be rewarded the ability to mint a [GitPOAP](https://www.gitpoap.io). You can check which repositories are eligible at [gitpoap/celestiaorg](https://www.gitpoap.io/gh/celestiaorg)
 
-
 > How to pick a number for the ADR?
 
 Find the largest existing ADR number and bump it by 1.


### PR DESCRIPTION
Add Celestia Contributor GitPOPA sections to CONTRIBUTING
Close https://github.com/celestiaorg/celestia-core/issues/1155



- [ ✅] Tests written/updated
- [ ✅] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ✅] Updated relevant documentation (`docs/` or `spec/`) and code comments

