### PR TITLE
docs: fix link to install.md

### DIFF
--- a/docs/app-dev/getting-started.md
+++ b/docs/app-dev/getting-started.md
@@ -90,7 +90,7 @@ abci-cli kvstore
 
 In another terminal, we can start CometBFT. You should already have the
 CometBFT binary installed. If not, follow the steps from
-[here](../introduction/install.md). If you have never run CometBFT
+[here](../guides/install.md). If you have never run CometBFT
 before, use:
 
 ```sh


### PR DESCRIPTION
## Description

original link is broken:
<img width="1171" alt="image" src="https://github.com/celestiaorg/celestia-core/assets/152680487/c929be24-5e67-4ad0-ade1-3e67e20422dd">


-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

