### PR TITLE
fix: make priority calculations consistent for TestTxMempool_ReapMaxBytes

### DIFF
--- a/mempool/cat/pool_test.go
+++ b/mempool/cat/pool_test.go
@@ -40,7 +40,7 @@ type testTx struct {
 }
 
 func newTx(i int, peerID uint16, msg []byte, priority int64) []byte {
-	return []byte(fmt.Sprintf("sender-%d-%d=%X=%d", i, peerID, msg, priority))
+	return []byte(fmt.Sprintf("sender-%03d-%d=%X=%d", i, peerID, msg, priority))
 }
 
 func newDefaultTx(msg string) types.Tx {
@@ -196,7 +196,7 @@ func TestTxPool_Size(t *testing.T) {
 	txmp := setup(t, 0)
 	txs := checkTxs(t, txmp, 100, 0)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 
 	rawTxs := make([]types.Tx, len(txs))
 	for i, tx := range txs {
@@ -213,7 +213,7 @@ func TestTxPool_Size(t *testing.T) {
 	txmp.Unlock()
 
 	require.Equal(t, len(rawTxs)/2, txmp.Size())
-	require.Equal(t, int64(2850), txmp.SizeBytes())
+	require.Equal(t, int64(2900), txmp.SizeBytes())
 }
 
 func TestTxPool_Eviction(t *testing.T) {
@@ -302,7 +302,7 @@ func TestTxPool_Flush(t *testing.T) {
 	txmp := setup(t, 0)
 	txs := checkTxs(t, txmp, 100, 0)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 
 	rawTxs := make([]types.Tx, len(txs))
 	for i, tx := range txs {
@@ -327,7 +327,7 @@ func TestTxPool_ReapMaxBytesMaxGas(t *testing.T) {
 	txmp := setup(t, 0)
 	tTxs := checkTxs(t, txmp, 100, 0) // all txs request 1 gas unit
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 
 	txMap := make(map[types.TxKey]testTx)
 	priorities := make([]int64, len(tTxs))
@@ -354,14 +354,14 @@ func TestTxPool_ReapMaxBytesMaxGas(t *testing.T) {
 	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, 50)
 
 	// reap by transaction bytes only
 	reapedTxs = txmp.ReapMaxBytesMaxGas(1200, -1)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	// each tx is 57 bytes, 20 * 57 = 1140 + overhead for proto encoding
 	require.Equal(t, len(reapedTxs), 20)
 
@@ -370,7 +370,7 @@ func TestTxPool_ReapMaxBytesMaxGas(t *testing.T) {
 	reapedTxs = txmp.ReapMaxBytesMaxGas(2000, 25)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, 25)
 }
 
@@ -400,7 +400,7 @@ func TestTxPool_ReapMaxTxs(t *testing.T) {
 	txmp := setup(t, 0)
 	txs := checkTxs(t, txmp, 100, 0)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 
 	txMap := make(map[types.TxKey]int64)
 	for _, tx := range txs {
@@ -419,21 +419,21 @@ func TestTxPool_ReapMaxTxs(t *testing.T) {
 	reapedTxs := txmp.ReapMaxTxs(-1)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, len(txs))
 
 	// reap a single transaction
 	reapedTxs = txmp.ReapMaxTxs(1)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, 1)
 
 	// reap half of the transactions
 	reapedTxs = txmp.ReapMaxTxs(len(txs) / 2)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, len(txs)/2)
 }
 

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -122,7 +122,7 @@ func checkTxs(t *testing.T, txmp *TxMempool, numTxs int, peerID uint16) []testTx
 		priority := int64(rng.Intn(9999-1000) + 1000)
 
 		txs[i] = testTx{
-			tx:       []byte(fmt.Sprintf("sender-%d-%d=%X=%d", i, peerID, prefix, priority)),
+			tx:       []byte(fmt.Sprintf("sender-%03d-%d=%X=%d", i, peerID, prefix, priority)),
 			priority: priority,
 		}
 		require.NoError(t, txmp.CheckTx(txs[i].tx, nil, txInfo))
@@ -306,11 +306,11 @@ func TestTxMempool_Flush(t *testing.T) {
 }
 
 func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
+	totalSizeBytes := int64(5800)
 	txmp := setup(t, 0)
 	tTxs := checkTxs(t, txmp, 100, 0) // all txs request 1 gas unit
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
-
+	require.Equal(t, totalSizeBytes, txmp.SizeBytes())
 	txMap := make(map[types.TxKey]testTx)
 	priorities := make([]int64, len(tTxs))
 	for i, tTx := range tTxs {
@@ -336,14 +336,14 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, totalSizeBytes, txmp.SizeBytes())
 	require.Len(t, reapedTxs, 50)
 
 	// reap by transaction bytes only
 	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, totalSizeBytes, txmp.SizeBytes())
 	require.GreaterOrEqual(t, len(reapedTxs), 16)
 
 	// Reap by both transaction bytes and gas, where the size yields 31 reaped
@@ -351,7 +351,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, totalSizeBytes, txmp.SizeBytes())
 	require.Len(t, reapedTxs, 25)
 }
 

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -189,7 +189,7 @@ func TestTxMempool_Size(t *testing.T) {
 	txmp := setup(t, 0)
 	txs := checkTxs(t, txmp, 100, 0)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 
 	rawTxs := make([]types.Tx, len(txs))
 	for i, tx := range txs {

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -306,6 +306,10 @@ func TestTxMempool_Flush(t *testing.T) {
 }
 
 func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
+	// totalSizeBytes is the expected size of the mempool after adding 100 txs
+	// this value is highly dependant upon the size of the txs and the overhead
+	// introduced in the mempool. This number will need to be adjusted if
+	// changes are made to any of those things.
 	totalSizeBytes := int64(5800)
 	txmp := setup(t, 0)
 	tTxs := checkTxs(t, txmp, 100, 0) // all txs request 1 gas unit

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -206,7 +206,7 @@ func TestTxMempool_Size(t *testing.T) {
 	txmp.Unlock()
 
 	require.Equal(t, len(rawTxs)/2, txmp.Size())
-	require.Equal(t, int64(2850), txmp.SizeBytes())
+	require.Equal(t, int64(2900), txmp.SizeBytes())
 }
 
 func TestTxMempool_Eviction(t *testing.T) {
@@ -284,7 +284,7 @@ func TestTxMempool_Flush(t *testing.T) {
 	txmp := setup(t, 0)
 	txs := checkTxs(t, txmp, 100, 0)
 	require.Equal(t, len(txs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 
 	rawTxs := make([]types.Tx, len(txs))
 	for i, tx := range txs {
@@ -385,7 +385,7 @@ func TestTxMempool_ReapMaxTxs(t *testing.T) {
 	txmp := setup(t, 0)
 	tTxs := checkTxs(t, txmp, 100, 0)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 
 	txMap := make(map[types.TxKey]testTx)
 	priorities := make([]int64, len(tTxs))
@@ -412,21 +412,21 @@ func TestTxMempool_ReapMaxTxs(t *testing.T) {
 	reapedTxs := txmp.ReapMaxTxs(-1)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, len(tTxs))
 
 	// reap a single transaction
 	reapedTxs = txmp.ReapMaxTxs(1)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, 1)
 
 	// reap half of the transactions
 	reapedTxs = txmp.ReapMaxTxs(len(tTxs) / 2)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
+	require.Equal(t, int64(5800), txmp.SizeBytes())
 	require.Len(t, reapedTxs, len(tTxs)/2)
 }
 


### PR DESCRIPTION
## Description

This test is currently hyper flakey because it doesn't calculate priorities consistently due to the txs being different sizes.

closes #1132 