### PR TITLE
chore: cleanup go.mod file require sections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,24 +5,38 @@ go 1.21.5
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/ChainSafe/go-schnorrkel v1.0.0
+	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/adlio/schema v1.3.3
+	github.com/btcsuite/btcd/btcec/v2 v2.2.1
+	github.com/btcsuite/btcd/btcutil v1.1.2
+	github.com/bufbuild/buf v1.9.0
+	github.com/celestiaorg/nmt v0.20.0
+	github.com/cometbft/cometbft-db v0.7.0
+	github.com/creachadair/taskgroup v0.3.2
 	github.com/fortytw2/leaktest v1.3.0
+	github.com/go-git/go-git/v5 v5.11.0
 	github.com/go-kit/kit v0.12.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-logfmt/logfmt v0.5.1
 	github.com/gofrs/uuid v4.3.0+incompatible
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.3
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/orderedcode v0.0.1
+	github.com/google/uuid v1.3.1
 	github.com/gorilla/websocket v1.5.0
+	github.com/grafana/pyroscope-go v1.0.3
 	github.com/gtank/merlin v0.1.1
+	github.com/influxdata/influxdb-client-go/v2 v2.12.3
+	github.com/informalsystems/tm-load-test v1.3.0
 	github.com/lib/pq v1.10.6
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/minio/highwayhash v1.0.2
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
+	github.com/pyroscope-io/otel-profiling-go v0.4.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/rs/cors v1.8.2
 	github.com/sasha-s/go-deadlock v0.3.1
@@ -30,45 +44,16 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.4
-)
-
-require (
-	github.com/google/uuid v1.3.1
-	golang.org/x/crypto v0.17.0
-	golang.org/x/net v0.19.0
-	google.golang.org/grpc v1.59.0
-)
-
-require (
-	github.com/gogo/protobuf v1.3.2
-	github.com/informalsystems/tm-load-test v1.3.0
-)
-
-require (
-	github.com/bufbuild/buf v1.9.0
-	github.com/creachadair/taskgroup v0.3.2
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-)
-
-require (
-	github.com/Masterminds/semver/v3 v3.2.0
-	github.com/btcsuite/btcd/btcec/v2 v2.2.1
-	github.com/btcsuite/btcd/btcutil v1.1.2
-	github.com/celestiaorg/nmt v0.20.0
-	github.com/cometbft/cometbft-db v0.7.0
-	github.com/go-git/go-git/v5 v5.11.0
 	github.com/vektra/mockery/v2 v2.14.0
-	gonum.org/v1/gonum v0.8.2
-	google.golang.org/protobuf v1.31.0
-)
-
-require (
-	github.com/grafana/pyroscope-go v1.0.3
-	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/pyroscope-io/otel-profiling-go v0.4.0
 	go.opentelemetry.io/otel v1.18.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.18.0
 	go.opentelemetry.io/otel/sdk v1.18.0
+	golang.org/x/crypto v0.17.0
+	golang.org/x/net v0.19.0
+	gonum.org/v1/gonum v0.8.2
+	google.golang.org/grpc v1.59.0
+	google.golang.org/protobuf v1.31.0
 )
 
 require (


### PR DESCRIPTION
This PR does not change any of the dependency, it only reorders the go.mod file into a direct and undirect import section, as go versions do since 1.17.

The reason your go.mod file got so many require sections is because during the 1.16 to 1.17 go.mod styling transition you had different contributors updating the go.mod file with pre 1.17 and post 1.17 releases of go.

See https://go.dev/doc/modules/gomod-ref:
> At go 1.17 or higher:

section for a description of what changed.