### PR TITLE
fix: don't gossip data if we're the proposer until the proposal is completely sent over the internal queue

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -577,10 +577,13 @@ OUTER_LOOP:
 		}
 
 		isProposer := conR.conS.isProposer(conR.conS.privValidatorPubKey.Address())
+		conR.conS.mtx.RLock()
+		completeProposal := conR.conS.Proposal != nil || conR.conS.ProposalBlock != nil
+		conR.conS.mtx.RUnlock()
 
 		// if we are the proposer wait for proposal to be complete before
 		// sending anything. This ensures block parts are distributed randomly.
-		if isProposer && !conR.conS.isProposalComplete() {
+		if isProposer && !completeProposal {
 			time.Sleep(10 * time.Millisecond)
 			continue OUTER_LOOP
 		}

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -566,8 +566,6 @@ func (conR *Reactor) getRoundState() *cstypes.RoundState {
 	return conR.rs
 }
 
-var UseProposalFix = true
-
 func (conR *Reactor) gossipDataRoutine(peer p2p.Peer, ps *PeerState) {
 	logger := conR.Logger.With("peer", peer)
 
@@ -582,7 +580,7 @@ OUTER_LOOP:
 
 		// if we are the proposer wait for proposal to be complete before
 		// sending anything. This ensures block parts are distributed randomly.
-		if isProposer && UseProposalFix && !conR.conS.isProposalComplete() {
+		if isProposer && !conR.conS.isProposalComplete() {
 			time.Sleep(10 * time.Millisecond)
 			continue OUTER_LOOP
 		}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1186,6 +1186,8 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 // Returns true if the proposal block is complete &&
 // (if POLRound was proposed, we have +2/3 prevotes from there).
 func (cs *State) isProposalComplete() bool {
+	cs.mtx.RLock()
+	defer cs.mtx.RUnlock()
 	if cs.Proposal == nil || cs.ProposalBlock == nil {
 		return false
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1186,8 +1186,6 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 // Returns true if the proposal block is complete &&
 // (if POLRound was proposed, we have +2/3 prevotes from there).
 func (cs *State) isProposalComplete() bool {
-	cs.mtx.RLock()
-	defer cs.mtx.RUnlock()
 	if cs.Proposal == nil || cs.ProposalBlock == nil {
 		return false
 	}


### PR DESCRIPTION
## Description

This PR closes #1145 by using the commit mentioned there to make the proposer wait until the entire block has been received over the internal queue before beginning to gossip the block. It should be noted that in theory this should increase the throughput of block prop significantly, there currently is another bottleneck that is stopping this, and other changes, from improving meaningfully contributing to increasing throughput.

