### PR TITLE
fix: pass version when converting between proto consensus params types

### DIFF
--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -105,6 +105,7 @@ func (tm2pb) ConsensusParams(params *cmtproto.ConsensusParams) *abci.ConsensusPa
 		},
 		Evidence:  &params.Evidence,
 		Validator: &params.Validator,
+		Version:   &params.Version,
 	}
 }
 


### PR DESCRIPTION
## Description

closes #1201 this issue only affects v0.34.x
