### PR TITLE
feat!: traces gossiped votes in the InfluxDB 

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1073,8 +1073,6 @@ type PeerState struct {
 	mtx   sync.Mutex             // NOTE: Modify below using setters, never directly.
 	PRS   cstypes.PeerRoundState `json:"round_state"` // Exposed.
 	Stats *peerStateStats        `json:"stats"`       // Exposed.
-
-	traceClient *trace.Client
 }
 
 // peerStateStats holds internal statistics for a peer.
@@ -1100,7 +1098,6 @@ func NewPeerState(peer p2p.Peer) *PeerState {
 			CatchupCommitRound: -1,
 		},
 		Stats: &peerStateStats{},
-		//traceClient: &trace.Client{},
 	}
 }
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -817,7 +817,7 @@ func (conR *Reactor) gossipVotesForHeight(
 ) bool {
 	var vote *types.Vote
 	defer func() {
-		if vote != nil {
+		if vote != nil { // if a vote is sent, trace it
 			schema.WriteVote(conR.traceClient, rs.Height, rs.Round, vote,
 				ps.peer.ID(), schema.TransferTypeUpload)
 		}

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -136,7 +136,7 @@ const (
 	// voting traces. Follows this schema:
 	//
 	// | time | height | round | vote_type | vote_height | vote_round
-	// | vote_block_id| vote_timestamp
+	// | vote_block_id| vote_unix_millisecond_timestamp
 	// | vote_validator_address | vote_validator_index | peer
 	// | transfer_type |
 	VoteTable = "consensus_vote"

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -156,7 +156,7 @@ const (
 // schema:
 //
 // | time | height | round | vote_type | vote_height | vote_round
-// | vote_block_id| vote_timestamp
+// | vote_block_id| vote_unix_millisecond_timestamp
 // | vote_validator_address | vote_validator_index | peer
 // | transfer_type |
 func WriteVote(client *trace.Client,

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -145,7 +145,7 @@ const (
 	VoteHeightFieldKey       = "vote_height"
 	VoteRoundFieldKey        = "vote_round"
 	VoteBlockIDFieldKey      = "vote_block_id"
-	VoteTimestampFieldKey    = "vote_timestamp"
+	VoteTimestampFieldKey    = "vote_unix_millisecond_timestamp"
 	ValidatorAddressFieldKey = "vote_validator_address"
 	ValidatorIndexFieldKey   = "vote_validator_index"
 )
@@ -160,8 +160,8 @@ const (
 // | vote_validator_address | vote_validator_index | peer
 // | transfer_type |
 func WriteVote(client *trace.Client,
-	height int64, // height of the current peer when it received the vote
-	round int32, // round of the current peer when it received the vote
+	height int64, // height of the current peer when it received/sent the vote
+	round int32, // round of the current peer when it received/sent the vote
 	vote *types.Vote, // vote received by the current peer
 	peer p2p.ID, // the peer from which it received the vote or the peer to which it sent the vote
 	transferType string, // download (received) or upload(sent)

--- a/pkg/trace/schema/consensus.go
+++ b/pkg/trace/schema/consensus.go
@@ -148,14 +148,6 @@ const (
 	VoteTimestampFieldKey    = "vote_timestamp"
 	ValidatorAddressFieldKey = "vote_validator_address"
 	ValidatorIndexFieldKey   = "vote_validator_index"
-
-	//	Type             cmtproto.SignedMsgType `json:"type"`
-	//	Height           int64                  `json:"height"`
-	//	Round            int32                  `json:"round"`    // assume there will not be greater than 2_147_483_647 rounds
-	//	BlockID          BlockID                `json:"block_id"` // zero if vote is nil.
-	//	Timestamp        time.Time              `json:"timestamp"`
-	//	ValidatorAddress Address                `json:"validator_address"`
-	//	ValidatorIndex
 )
 
 // WriteVote writes a tracing point for a vote using the predetermined

--- a/pkg/trace/schema/tables.go
+++ b/pkg/trace/schema/tables.go
@@ -24,7 +24,8 @@ const (
 	// value.
 	PeerFieldKey = "peer"
 
-	// TransferTypeFieldKey is the tracing field key for the class of a tx.
+	// TransferTypeFieldKey is the tracing field key for the class of a tx
+	// and votes.
 	TransferTypeFieldKey = "transfer_type"
 
 	// TransferTypeDownload is a tracing field value for receiving some


### PR DESCRIPTION
Closes #1200
This is deemed a breaking change because it modifies the signature of the `PickSendVote` public method within the `PeerState` type.