### PR TITLE
feat: add more consensus metrics on rejected proposals

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -315,6 +315,8 @@ func (cs *State) OnStart() error {
 		}
 	}
 
+	cs.metrics.StartHeight.Set(float64(cs.Height))
+
 	// we need the timeoutRoutine for replay so
 	// we don't block on the tick chan.
 	// NOTE: we will get a build up of garbage go routines
@@ -1281,6 +1283,7 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 	// If ProposalBlock is nil, prevote nil.
 	if cs.ProposalBlock == nil {
 		logger.Debug("prevote step: ProposalBlock is nil")
+		cs.metrics.TimedOutProposals.Add(1)
 		cs.signAddVote(cmtproto.PrevoteType, nil, types.PartSetHeader{})
 		return
 	}
@@ -1297,12 +1300,14 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 	stateMachineValidBlock, err := cs.blockExec.ProcessProposal(cs.ProposalBlock, cs.state)
 	if err != nil {
 		cs.Logger.Error("state machine returned an error when trying to process proposal block", "err", err)
+		return
 	}
 
 	// Vote nil if application invalidated the block
 	if !stateMachineValidBlock {
 		// The app says we must vote nil
 		logger.Error("prevote step: the application deems this block to be mustVoteNil", "err", err)
+		cs.metrics.ApplicationRejectedProposals.Add(1)
 		cs.signAddVote(cmtproto.PrevoteType, nil, types.PartSetHeader{})
 		return
 	}


### PR DESCRIPTION
## Description

This adds two counters to the consensus metrics:

- ApplicationRejectedProposals
- TimedOutProposals

It also adds a third `StartHeight` which is set once upon start so we know how many heights the metrics have been running for

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

