### PR TITLE
fix: use genesis file app version  if it is set

### DIFF
--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -252,15 +252,10 @@ func (h *Handshaker) Handshake(proxyApp proxy.AppConns) (string, error) {
 	}
 	appHash := res.LastBlockAppHash
 
-	h.logger.Info("ABCI Handshake App Info",
-		"height", blockHeight,
-		"hash", appHash,
-		"software-version", res.Version,
-		"protocol-version", res.AppVersion,
-	)
-
-	// Only set the version if there is no existing state.
-	if h.initialState.LastBlockHeight == 0 {
+	appVersion := h.initialState.Version.Consensus.App
+	// set app version if it's not set via genesis
+	if h.initialState.LastBlockHeight == 0 && appVersion == 0 && res.AppVersion != 0 {
+		appVersion = res.AppVersion
 		h.initialState.Version.Consensus.App = res.AppVersion
 	}
 
@@ -271,7 +266,10 @@ func (h *Handshaker) Handshake(proxyApp proxy.AppConns) (string, error) {
 	}
 
 	h.logger.Info("Completed ABCI Handshake - CometBFT and App are synced",
-		"appHeight", blockHeight, "appHash", appHash)
+		"appHeight", blockHeight,
+		"appHash", appHash,
+		"appVersion", appVersion,
+	)
 
 	// TODO: (on restart) replay mempool
 

--- a/state/state.go
+++ b/state/state.go
@@ -23,10 +23,7 @@ var (
 
 //-----------------------------------------------------------------------------
 
-// InitStateVersion sets the Consensus.Block and Software versions,
-// but leaves the Consensus.App version blank.
-// The Consensus.App version will be set during the Handshake, once
-// we hear from the app what protocol version it is running.
+// InitStateVersion sets the Consensus.Block, Consensus.App and Software versions
 func InitStateVersion(appVersion uint64) cmtstate.Version {
 	return cmtstate.Version{
 		Consensus: cmtversion.Consensus{

--- a/state/state.go
+++ b/state/state.go
@@ -27,12 +27,14 @@ var (
 // but leaves the Consensus.App version blank.
 // The Consensus.App version will be set during the Handshake, once
 // we hear from the app what protocol version it is running.
-var InitStateVersion = cmtstate.Version{
-	Consensus: cmtversion.Consensus{
-		Block: version.BlockProtocol,
-		App:   0,
-	},
-	Software: version.TMCoreSemVer,
+func InitStateVersion(appVersion uint64) cmtstate.Version {
+	return cmtstate.Version{
+		Consensus: cmtversion.Consensus{
+			Block: version.BlockProtocol,
+			App:   appVersion,
+		},
+		Software: version.TMCoreSemVer,
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -331,8 +333,13 @@ func MakeGenesisState(genDoc *types.GenesisDoc) (State, error) {
 		nextValidatorSet = types.NewValidatorSet(validators).CopyIncrementProposerPriority(1)
 	}
 
+	appVersion := uint64(0)
+	if genDoc.ConsensusParams != nil {
+		appVersion = genDoc.ConsensusParams.Version.App
+	}
+
 	return State{
-		Version:       InitStateVersion,
+		Version:       InitStateVersion(appVersion),
 		ChainID:       genDoc.ChainID,
 		InitialHeight: genDoc.InitialHeight,
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -21,6 +21,7 @@ import (
 	cmtstate "github.com/cometbft/cometbft/proto/tendermint/state"
 	sm "github.com/cometbft/cometbft/state"
 	"github.com/cometbft/cometbft/types"
+	"github.com/cometbft/cometbft/version"
 )
 
 // setupTestCase does setup common to all test cases.
@@ -71,6 +72,21 @@ func TestMakeGenesisStateNilValidators(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 0, len(state.Validators.Validators))
 	require.Equal(t, 0, len(state.NextValidators.Validators))
+}
+
+func TestMakeGenesisStateSetsAppVersion(t *testing.T) {
+	cp := types.DefaultConsensusParams()
+	appVersion := uint64(5)
+	cp.Version.App = appVersion
+	doc := types.GenesisDoc{
+		ChainID:         "dummy",
+		ConsensusParams: cp,
+	}
+	require.Nil(t, doc.ValidateAndComplete())
+	state, err := sm.MakeGenesisState(&doc)
+	require.Nil(t, err)
+	require.Equal(t, appVersion, state.Version.Consensus.App)
+	require.Equal(t, version.BlockProtocol, state.Version.Consensus.Block)
 }
 
 // TestStateSaveLoad tests saving and loading State from a db.


### PR DESCRIPTION
## Description

Closes: #1226

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

