### PR TITLE
fix: use a separate lookup map for reserving txs

### DIFF
--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -80,6 +80,17 @@ func TestStoreReservingTxs(t *testing.T) {
 	require.False(t, store.has(key))
 }
 
+func TestReadReserved(t *testing.T) {
+	store := newStore()
+	tx := types.Tx("tx1")
+	store.reserve(tx.Key())
+
+	assert.Nil(t, store.get(tx.Key()))
+	assert.False(t, store.has(tx.Key()))
+	assert.Len(t, store.getAllKeys(), 0)
+	assert.Len(t, store.getAllTxs(), 0)
+}
+
 func TestStoreConcurrentAccess(t *testing.T) {
 	store := newStore()
 

--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -85,10 +85,10 @@ func TestReadReserved(t *testing.T) {
 	tx := types.Tx("tx1")
 	store.reserve(tx.Key())
 
-	assert.Nil(t, store.get(tx.Key()))
-	assert.False(t, store.has(tx.Key()))
-	assert.Len(t, store.getAllKeys(), 0)
-	assert.Len(t, store.getAllTxs(), 0)
+	require.Nil(t, store.get(tx.Key()))
+	require.False(t, store.has(tx.Key()))
+	require.Len(t, store.getAllKeys(), 0)
+	require.Len(t, store.getAllTxs(), 0)
 }
 
 func TestStoreConcurrentAccess(t *testing.T) {

--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -54,7 +54,7 @@ func TestStoreReservingTxs(t *testing.T) {
 
 	// reserve a tx
 	store.reserve(key)
-	require.True(t, store.has(key))
+	require.True(t, store.isReserved(key))
 	// should not update the total bytes
 	require.Zero(t, store.totalBytes())
 
@@ -73,7 +73,7 @@ func TestStoreReservingTxs(t *testing.T) {
 
 	// reserve the tx again
 	store.reserve(key)
-	require.True(t, store.has(key))
+	require.True(t, store.isReserved(key))
 
 	// release should remove the tx
 	store.release(key)


### PR DESCRIPTION
This is an alternative to #1267 that solves the current problem with reserving transactions by using a separate lookup map as suggested by @rootulp.