### PR TITLE
chore: aligns MaxBlockSizeBytes constant with calculated block size for square size 512

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// MaxBlockSizeBytes is the maximum permitted size of the blocks.
-	MaxBlockSizeBytes = 104857600 // 100MB
+	MaxBlockSizeBytes = 126353408 // 120.5 MiB
 
 	// BlockPartSizeBytes is the size of one block part.
 	BlockPartSizeBytes uint32 = 65536 // 64kB


### PR DESCRIPTION
This PR corrects the `MaxBlockSizeBytes` constant to match the expected maximum block size for a square size of `512`, which is `126353408`, based on the calculation [formula in the celestia-app repo](https://github.com/celestiaorg/celestia-app/blob/926605c7be3d99ed55a559df289ac9c8337c2948/pkg/appconsts/initial_consts.go#L14). Previously, the constant did not accurately reflect the block size from any square size.