### PR TITLE
feat!: wrap ShareProof in ResultShareProof

### DIFF
--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -591,7 +591,7 @@ func (c *Client) ProveShares(
 	height uint64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
+) (*ctypes.ResultShareProof, error) {
 	res, err := c.next.ProveShares(ctx, height, startShare, endShare)
 	return res, err
 }

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -573,8 +573,8 @@ func (c *baseRPCClient) ProveShares(
 	height uint64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
-	result := new(types.ShareProof)
+) (*ctypes.ResultShareProof, error) {
+	result := new(ctypes.ResultShareProof)
 	params := map[string]interface{}{
 		"height":     height,
 		"startShare": startShare,
@@ -582,9 +582,9 @@ func (c *baseRPCClient) ProveShares(
 	}
 	_, err := c.caller.Call(ctx, "prove_shares", params, result)
 	if err != nil {
-		return types.ShareProof{}, err
+		return nil, err
 	}
-	return *result, nil
+	return result, nil
 }
 
 func (c *baseRPCClient) TxSearch(

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -83,7 +83,7 @@ type SignClient interface {
 	Validators(ctx context.Context, height *int64, page, perPage *int) (*ctypes.ResultValidators, error)
 	Tx(ctx context.Context, hash []byte, prove bool) (*ctypes.ResultTx, error)
 
-	ProveShares(_ context.Context, height uint64, startShare uint64, endShare uint64) (types.ShareProof, error)
+	ProveShares(_ context.Context, height uint64, startShare uint64, endShare uint64) (*ctypes.ResultShareProof, error)
 
 	// TxSearch defines a method to search for a paginated set of transactions by
 	// DeliverTx event search criteria.

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -215,7 +215,7 @@ func (c *Local) ProveShares(
 	height uint64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
+) (*ctypes.ResultShareProof, error) {
 	return core.ProveShares(c.ctx, int64(height), startShare, endShare)
 }
 

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -40,12 +40,13 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 	height := r.Height
 	index := r.Index
 
-	var shareProof *ctypes.ResultShareProof
+	var shareProof types.ShareProof
 	if prove {
-		shareProof, err = proveTx(height, index)
+		proof, err := proveTx(height, index)
 		if err != nil {
 			return nil, err
 		}
+		shareProof = proof.Proof
 	}
 
 	return &ctypes.ResultTx{
@@ -54,7 +55,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 		Index:    index,
 		TxResult: r.Result,
 		Tx:       r.Tx,
-		Proof:    shareProof.Proof,
+		Proof:    shareProof,
 	}, nil
 }
 
@@ -123,12 +124,13 @@ func TxSearch(
 	for i := skipCount; i < skipCount+pageSize; i++ {
 		r := results[i]
 
-		var shareProof *ctypes.ResultShareProof
+		var shareProof types.ShareProof
 		if prove {
-			shareProof, err = proveTx(r.Height, r.Index)
+			proof, err := proveTx(r.Height, r.Index)
 			if err != nil {
 				return nil, err
 			}
+			shareProof = proof.Proof
 		}
 
 		apiResults = append(apiResults, &ctypes.ResultTx{
@@ -137,7 +139,7 @@ func TxSearch(
 			Index:    r.Index,
 			TxResult: r.Result,
 			Tx:       r.Tx,
-			Proof:    shareProof.Proof,
+			Proof:    shareProof,
 		})
 	}
 

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -40,7 +40,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 	height := r.Height
 	index := r.Index
 
-	var shareProof types.ShareProof
+	var shareProof *ctypes.ResultShareProof
 	if prove {
 		shareProof, err = proveTx(height, index)
 		if err != nil {
@@ -54,7 +54,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 		Index:    index,
 		TxResult: r.Result,
 		Tx:       r.Tx,
-		Proof:    shareProof,
+		Proof:    shareProof.Proof,
 	}, nil
 }
 
@@ -123,7 +123,7 @@ func TxSearch(
 	for i := skipCount; i < skipCount+pageSize; i++ {
 		r := results[i]
 
-		var shareProof types.ShareProof
+		var shareProof *ctypes.ResultShareProof
 		if prove {
 			shareProof, err = proveTx(r.Height, r.Index)
 			if err != nil {
@@ -137,14 +137,14 @@ func TxSearch(
 			Index:    r.Index,
 			TxResult: r.Result,
 			Tx:       r.Tx,
-			Proof:    shareProof,
+			Proof:    shareProof.Proof,
 		})
 	}
 
 	return &ctypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
 }
 
-func proveTx(height int64, index uint32) (types.ShareProof, error) {
+func proveTx(height int64, index uint32) (*ctypes.ResultShareProof, error) {
 	var (
 		pShareProof cmtproto.ShareProof
 		shareProof  types.ShareProof
@@ -152,24 +152,24 @@ func proveTx(height int64, index uint32) (types.ShareProof, error) {
 	env := GetEnvironment()
 	rawBlock, err := loadRawBlock(env.BlockStore, height)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	res, err := env.ProxyAppQuery.QuerySync(abcitypes.RequestQuery{
 		Data: rawBlock,
 		Path: fmt.Sprintf(consts.TxInclusionProofQueryPath, index),
 	})
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	err = pShareProof.Unmarshal(res.Value)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	shareProof, err = types.ShareProofFromProto(pShareProof)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
-	return shareProof, nil
+	return &ctypes.ResultShareProof{Proof: shareProof}, nil
 }
 
 // ProveShares creates an NMT proof for a set of shares to a set of rows. It is
@@ -179,7 +179,7 @@ func ProveShares(
 	height int64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
+) (*ctypes.ResultShareProof, error) {
 	var (
 		pShareProof cmtproto.ShareProof
 		shareProof  types.ShareProof
@@ -187,29 +187,29 @@ func ProveShares(
 	env := GetEnvironment()
 	rawBlock, err := loadRawBlock(env.BlockStore, height)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	res, err := env.ProxyAppQuery.QuerySync(abcitypes.RequestQuery{
 		Data: rawBlock,
 		Path: fmt.Sprintf(consts.ShareInclusionProofQueryPath, startShare, endShare),
 	})
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	if res.Value == nil && res.Log != "" {
 		// we can make the assumption that for custom queries, if the value is nil
 		// and some logs have been emitted, then an error happened.
-		return types.ShareProof{}, errors.New(res.Log)
+		return nil, errors.New(res.Log)
 	}
 	err = pShareProof.Unmarshal(res.Value)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	shareProof, err = types.ShareProofFromProto(pShareProof)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
-	return shareProof, nil
+	return &ctypes.ResultShareProof{Proof: shareProof}, nil
 }
 
 func loadRawBlock(bs state.BlockStore, height int64) ([]byte, error) {

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -281,5 +281,5 @@ type ResultEvent struct {
 
 // ResultShareProof API proof response of a set of shares
 type ResultShareProof struct {
-	Proof types.ShareProof
+	Proof types.ShareProof `json:"proof"`
 }

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -278,3 +278,8 @@ type ResultEvent struct {
 	Data   types.TMEventData   `json:"data"`
 	Events map[string][]string `json:"events"`
 }
+
+// ResultShareProof API proof response of a set of shares
+type ResultShareProof struct {
+	Proof types.ShareProof
+}


### PR DESCRIPTION
## Description

This PR wraps the `ShareProof` into a `ResultShareProof` in the API. However, It doesn't change the custom query response since it's internal data and there is no need to wrap it.

Closes https://github.com/celestiaorg/celestia-core/issues/1306
