### PR TITLE
chore: introduces constants for tracer push configs environment variable names (manual backport #1324)

### DIFF
--- a/pkg/trace/local_tracer.go
+++ b/pkg/trace/local_tracer.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	tracePushBucketName = "TRACE_PUSH_BUCKET_NAME"
-	tracePushRegion     = "TRACE_PUSH_REGION"
-	tracePushAccessKey  = "TRACE_PUSH_ACCESS_KEY"
-	tracePushSecretKey  = "TRACE_PUSH_SECRET_KEY"
-	tracePushDelay      = "TRACE_PUSH_DELAY"
+	PushBucketName = "TRACE_PUSH_BUCKET_NAME"
+	PushRegion     = "TRACE_PUSH_REGION"
+	PushAccessKey  = "TRACE_PUSH_ACCESS_KEY"
+	PushSecretKey  = "TRACE_PUSH_SECRET_KEY"
+	PushDelay      = "TRACE_PUSH_DELAY"
 )
 
 // Event wraps some trace data with metadata that dictates the table and things
@@ -117,11 +117,11 @@ func NewLocalTracer(cfg *config.Config, logger log.Logger, chainID, nodeID strin
 
 // GetPushConfigFromEnv reads the required environment variables to push trace
 func GetPushConfigFromEnv() (S3Config, error) {
-	bucketName := os.Getenv(tracePushBucketName)
-	region := os.Getenv(tracePushRegion)
-	accessKey := os.Getenv(tracePushAccessKey)
-	secretKey := os.Getenv(tracePushSecretKey)
-	pushDelay, err := strconv.ParseInt(os.Getenv(tracePushDelay), 10, 64)
+	bucketName := os.Getenv(PushBucketName)
+	region := os.Getenv(PushRegion)
+	accessKey := os.Getenv(PushAccessKey)
+	secretKey := os.Getenv(PushSecretKey)
+	pushDelay, err := strconv.ParseInt(os.Getenv(PushDelay), 10, 64)
 	if err != nil {
 		return S3Config{}, err
 	}

--- a/pkg/trace/local_tracer.go
+++ b/pkg/trace/local_tracer.go
@@ -17,7 +17,7 @@ const (
 	PushBucketName = "TRACE_PUSH_BUCKET_NAME"
 	PushRegion     = "TRACE_PUSH_REGION"
 	PushAccessKey  = "TRACE_PUSH_ACCESS_KEY"
-	PushSecretKey  = "TRACE_PUSH_SECRET_KEY"
+	PushKey        = "TRACE_PUSH_SECRET_KEY"
 	PushDelay      = "TRACE_PUSH_DELAY"
 )
 
@@ -120,7 +120,7 @@ func GetPushConfigFromEnv() (S3Config, error) {
 	bucketName := os.Getenv(PushBucketName)
 	region := os.Getenv(PushRegion)
 	accessKey := os.Getenv(PushAccessKey)
-	secretKey := os.Getenv(PushSecretKey)
+	secretKey := os.Getenv(PushKey)
 	pushDelay, err := strconv.ParseInt(os.Getenv(PushDelay), 10, 64)
 	if err != nil {
 		return S3Config{}, err

--- a/pkg/trace/local_tracer.go
+++ b/pkg/trace/local_tracer.go
@@ -13,6 +13,14 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 )
 
+const (
+	TRACE_PUSH_BUCKET_NAME = "TRACE_PUSH_BUCKET_NAME"
+	TRACE_PUSH_REGION      = "TRACE_PUSH_REGION"
+	TRACE_PUSH_ACCESS_KEY  = "TRACE_PUSH_ACCESS_KEY"
+	TRACE_PUSH_SECRET_KEY  = "TRACE_PUSH_SECRET_KEY"
+	TRACE_PUSH_DELAY       = "TRACE_PUSH_DELAY"
+)
+
 // Event wraps some trace data with metadata that dictates the table and things
 // like the chainID and nodeID.
 type Event[T any] struct {
@@ -109,11 +117,11 @@ func NewLocalTracer(cfg *config.Config, logger log.Logger, chainID, nodeID strin
 
 // GetPushConfigFromEnv reads the required environment variables to push trace
 func GetPushConfigFromEnv() (S3Config, error) {
-	bucketName := os.Getenv("TRACE_PUSH_BUCKET_NAME")
-	region := os.Getenv("TRACE_PUSH_REGION")
-	accessKey := os.Getenv("TRACE_PUSH_ACCESS_KEY")
-	secretKey := os.Getenv("TRACE_PUSH_SECRET_KEY")
-	pushDelay, err := strconv.ParseInt(os.Getenv("TRACE_PUSH_DELAY"), 10, 64)
+	bucketName := os.Getenv(TRACE_PUSH_BUCKET_NAME)
+	region := os.Getenv(TRACE_PUSH_REGION)
+	accessKey := os.Getenv(TRACE_PUSH_ACCESS_KEY)
+	secretKey := os.Getenv(TRACE_PUSH_SECRET_KEY)
+	pushDelay, err := strconv.ParseInt(os.Getenv(TRACE_PUSH_DELAY), 10, 64)
 	if err != nil {
 		return S3Config{}, err
 	}

--- a/pkg/trace/local_tracer.go
+++ b/pkg/trace/local_tracer.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	TRACE_PUSH_BUCKET_NAME = "TRACE_PUSH_BUCKET_NAME"
-	TRACE_PUSH_REGION      = "TRACE_PUSH_REGION"
-	TRACE_PUSH_ACCESS_KEY  = "TRACE_PUSH_ACCESS_KEY"
-	TRACE_PUSH_SECRET_KEY  = "TRACE_PUSH_SECRET_KEY"
-	TRACE_PUSH_DELAY       = "TRACE_PUSH_DELAY"
+	tracePushBucketName = "TRACE_PUSH_BUCKET_NAME"
+	tracePushRegion     = "TRACE_PUSH_REGION"
+	tracePushAccessKey  = "TRACE_PUSH_ACCESS_KEY"
+	tracePushSecretKey  = "TRACE_PUSH_SECRET_KEY"
+	tracePushDelay      = "TRACE_PUSH_DELAY"
 )
 
 // Event wraps some trace data with metadata that dictates the table and things
@@ -117,11 +117,11 @@ func NewLocalTracer(cfg *config.Config, logger log.Logger, chainID, nodeID strin
 
 // GetPushConfigFromEnv reads the required environment variables to push trace
 func GetPushConfigFromEnv() (S3Config, error) {
-	bucketName := os.Getenv(TRACE_PUSH_BUCKET_NAME)
-	region := os.Getenv(TRACE_PUSH_REGION)
-	accessKey := os.Getenv(TRACE_PUSH_ACCESS_KEY)
-	secretKey := os.Getenv(TRACE_PUSH_SECRET_KEY)
-	pushDelay, err := strconv.ParseInt(os.Getenv(TRACE_PUSH_DELAY), 10, 64)
+	bucketName := os.Getenv(tracePushBucketName)
+	region := os.Getenv(tracePushRegion)
+	accessKey := os.Getenv(tracePushAccessKey)
+	secretKey := os.Getenv(tracePushSecretKey)
+	pushDelay, err := strconv.ParseInt(os.Getenv(tracePushDelay), 10, 64)
 	if err != nil {
 		return S3Config{}, err
 	}

--- a/pkg/trace/local_tracer_test.go
+++ b/pkg/trace/local_tracer_test.go
@@ -123,11 +123,11 @@ func TestLocalTracerServerPull(t *testing.T) {
 
 // TestReadPushConfigFromConfigFile tests reading the push config from the environment variables.
 func TestReadPushConfigFromEnvVars(t *testing.T) {
-	os.Setenv(tracePushBucketName, "bucket")
-	os.Setenv(tracePushRegion, "region")
-	os.Setenv(tracePushAccessKey, "access")
-	os.Setenv(tracePushSecretKey, "secret")
-	os.Setenv(tracePushDelay, "10")
+	os.Setenv(PushBucketName, "bucket")
+	os.Setenv(PushRegion, "region")
+	os.Setenv(PushAccessKey, "access")
+	os.Setenv(PushSecretKey, "secret")
+	os.Setenv(PushDelay, "10")
 
 	lt := setupLocalTracer(t, 0)
 	require.Equal(t, "bucket", lt.s3Config.BucketName)

--- a/pkg/trace/local_tracer_test.go
+++ b/pkg/trace/local_tracer_test.go
@@ -123,11 +123,11 @@ func TestLocalTracerServerPull(t *testing.T) {
 
 // TestReadPushConfigFromConfigFile tests reading the push config from the environment variables.
 func TestReadPushConfigFromEnvVars(t *testing.T) {
-	os.Setenv("TRACE_PUSH_BUCKET_NAME", "bucket")
-	os.Setenv("TRACE_PUSH_REGION", "region")
-	os.Setenv("TRACE_PUSH_ACCESS_KEY", "access")
-	os.Setenv("TRACE_PUSH_SECRET_KEY", "secret")
-	os.Setenv("TRACE_PUSH_DELAY", "10")
+	os.Setenv(tracePushBucketName, "bucket")
+	os.Setenv(tracePushRegion, "region")
+	os.Setenv(tracePushAccessKey, "access")
+	os.Setenv(tracePushSecretKey, "secret")
+	os.Setenv(tracePushDelay, "10")
 
 	lt := setupLocalTracer(t, 0)
 	require.Equal(t, "bucket", lt.s3Config.BucketName)

--- a/pkg/trace/local_tracer_test.go
+++ b/pkg/trace/local_tracer_test.go
@@ -126,7 +126,7 @@ func TestReadPushConfigFromEnvVars(t *testing.T) {
 	os.Setenv(PushBucketName, "bucket")
 	os.Setenv(PushRegion, "region")
 	os.Setenv(PushAccessKey, "access")
-	os.Setenv(PushSecretKey, "secret")
+	os.Setenv(PushKey, "secret")
 	os.Setenv(PushDelay, "10")
 
 	lt := setupLocalTracer(t, 0)


### PR DESCRIPTION
Introduced constants for the tracer push configuration environment variables to reduce errors when setting and reading these variables in the code, particularly in downstream repositories.

Manual backport of https://github.com/celestiaorg/celestia-core/pull/1324