### PR TITLE
feat: support writing only internal messages to WAL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -941,10 +941,10 @@ func (cfg *FastSyncConfig) ValidateBasic() error {
 // including timeouts and details about the WAL and the block structure.
 type ConsensusConfig struct {
 	RootDir string `mapstructure:"home"`
-	// Experimental: If set to true, only internal messages will be written
+	// If set to true, only internal messages will be written
 	// to the WAL. External messages like votes, proposals
 	// block parts, will not be written
-	// Default: false
+	// Default: true
 	OnlyInternalWal bool   `mapstructure:"only_internal_wal"`
 	WalPath         string `mapstructure:"wal_file"`
 	walFile         string // overrides WalPath if set

--- a/config/config.go
+++ b/config/config.go
@@ -944,6 +944,7 @@ type ConsensusConfig struct {
 	// Experimental: If set to true, only internal messages will be written
 	// to the WAL. External messages like votes, proposals
 	// block parts, will not be written
+	// Default: false
 	OnlyInternalWal bool   `mapstructure:"only_internal_wal"`
 	WalPath         string `mapstructure:"wal_file"`
 	walFile         string // overrides WalPath if set

--- a/config/config.go
+++ b/config/config.go
@@ -941,8 +941,12 @@ func (cfg *FastSyncConfig) ValidateBasic() error {
 // including timeouts and details about the WAL and the block structure.
 type ConsensusConfig struct {
 	RootDir string `mapstructure:"home"`
-	WalPath string `mapstructure:"wal_file"`
-	walFile string // overrides WalPath if set
+	// Experimental: If set to true, only internal messages will be written
+	// to the WAL. External messages like votes, proposals
+	// block parts, will not be written
+	OnlyInternalWal bool   `mapstructure:"only_internal_wal"`
+	WalPath         string `mapstructure:"wal_file"`
+	walFile         string // overrides WalPath if set
 
 	// How long we wait for a proposal block before prevoting nil
 	TimeoutPropose time.Duration `mapstructure:"timeout_propose"`

--- a/config/config.go
+++ b/config/config.go
@@ -984,6 +984,7 @@ type ConsensusConfig struct {
 // DefaultConsensusConfig returns a default configuration for the consensus service
 func DefaultConsensusConfig() *ConsensusConfig {
 	return &ConsensusConfig{
+		OnlyInternalWal:             true,
 		WalPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
 		TimeoutPropose:              3000 * time.Millisecond,
 		TimeoutProposeDelta:         500 * time.Millisecond,

--- a/config/toml.go
+++ b/config/toml.go
@@ -456,6 +456,12 @@ version = "{{ .FastSync.Version }}"
 #######################################################
 [consensus]
 
+# Experimental: if set to "true", only internal messages will be
+# written to the WAL. External messages like votes, proposal,
+# block parts, will not be written.
+# Use at your own risk!
+only_internal_wal = "{{ .Consensus.OnlyInternalWal }}"
+
 wal_file = "{{ js .Consensus.WalPath }}"
 
 # How long we wait for a proposal block before prevoting nil

--- a/config/toml.go
+++ b/config/toml.go
@@ -456,10 +456,9 @@ version = "{{ .FastSync.Version }}"
 #######################################################
 [consensus]
 
-# Experimental: if set to "true", only internal messages will be
+# If set to "true", only internal messages will be
 # written to the WAL. External messages like votes, proposal,
 # block parts, will not be written.
-# Use at your own risk!
 only_internal_wal = "{{ .Consensus.OnlyInternalWal }}"
 
 wal_file = "{{ js .Consensus.WalPath }}"

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -773,11 +773,11 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			cs.handleTxsAvailable()
 
 		case mi = <-cs.peerMsgQueue:
-			//if !cs.config.OnlyInternalWal {
-			//	if err := cs.wal.Write(mi); err != nil {
-			//		cs.Logger.Error("failed writing to WAL", "err", err)
-			//	}
-			//}
+			if !cs.config.OnlyInternalWal {
+				if err := cs.wal.Write(mi); err != nil {
+					cs.Logger.Error("failed writing to WAL", "err", err)
+				}
+			}
 
 			// handles proposals, block parts, votes
 			// may generate internal events (votes, complete proposals, 2/3 majorities)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -773,11 +773,11 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			cs.handleTxsAvailable()
 
 		case mi = <-cs.peerMsgQueue:
-			if !cs.config.OnlyInternalWal {
-				if err := cs.wal.Write(mi); err != nil {
-					cs.Logger.Error("failed writing to WAL", "err", err)
-				}
-			}
+			//if !cs.config.OnlyInternalWal {
+			//	if err := cs.wal.Write(mi); err != nil {
+			//		cs.Logger.Error("failed writing to WAL", "err", err)
+			//	}
+			//}
 
 			// handles proposals, block parts, votes
 			// may generate internal events (votes, complete proposals, 2/3 majorities)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -776,7 +776,6 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			if !cs.config.OnlyInternalWal {
 				if err := cs.wal.Write(mi); err != nil {
 					cs.Logger.Error("failed writing to WAL", "err", err)
-					os.Exit(1)
 				}
 			}
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -776,6 +776,7 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			if !cs.config.OnlyInternalWal {
 				if err := cs.wal.Write(mi); err != nil {
 					cs.Logger.Error("failed writing to WAL", "err", err)
+					os.Exit(1)
 				}
 			}
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -773,8 +773,10 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			cs.handleTxsAvailable()
 
 		case mi = <-cs.peerMsgQueue:
-			if err := cs.wal.Write(mi); err != nil {
-				cs.Logger.Error("failed writing to WAL", "err", err)
+			if !cs.config.OnlyInternalWal {
+				if err := cs.wal.Write(mi); err != nil {
+					cs.Logger.Error("failed writing to WAL", "err", err)
+				}
 			}
 
 			// handles proposals, block parts, votes


### PR DESCRIPTION
## Description

Closes https://github.com/celestiaorg/celestia-core/issues/1247

This PR adds a configuration flag to limit the WAL to only contain internal messages.

This is useful because, as perceived in experiments, external_messages_WAL_writes ~= number_of_validators * internal_messages_WAL_writes, it reduces significantly the number of writes on the WAL. This makes sense because, by default, the WAL contains: votes, block parts, proposals, etc, from all the peers. In the meantime what we really need is the validator's own messages, and especially signature, not to double sign (To be confirmed because I guess, unless there is some bug in the signing process or some weird uncommon issue, the signature should be the same for each round).

~The configuration is added as experimental and is turned off by default.~

The configuration is enabled by default.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

