### PR TITLE
fix!: trace file seeking

### DIFF
--- a/pkg/trace/buffered_file.go
+++ b/pkg/trace/buffered_file.go
@@ -69,7 +69,7 @@ func (f *bufferedFile) startReading() error {
 }
 
 // stopReading stops reading from the file and resets the seek point to the end
-// of the file.
+// of the file to stop ignoring writes.
 func (f *bufferedFile) stopReading() error {
 	f.mut.Lock()
 	defer f.mut.Unlock()

--- a/pkg/trace/buffered_file.go
+++ b/pkg/trace/buffered_file.go
@@ -2,14 +2,26 @@ package trace
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 )
 
+// bufferedFile is a file that is being written to and read from. It is thread
+// safe, however, when reading from the file, writes will be ignored.
 type bufferedFile struct {
-	mut *sync.RWMutex
+	// reading protects the file from being written to while it is being read
+	// from. This is needed beyond in addition to the mutex so that writes can
+	// be ignored while reading.
+	reading atomic.Bool
+
+	// mut protects the buffered writer.
+	mut *sync.Mutex
+
 	// file is the file that is being written to.
 	file *os.File
+
 	// writer is the buffered writer that is writing to the file.
 	wr *bufio.Writer
 }
@@ -17,40 +29,68 @@ type bufferedFile struct {
 // newbufferedFile creates a new buffered file that writes to the given file.
 func newbufferedFile(file *os.File) *bufferedFile {
 	return &bufferedFile{
-		mut:  &sync.RWMutex{},
-		file: file,
-		wr:   bufio.NewWriter(file),
+		file:    file,
+		wr:      bufio.NewWriter(file),
+		reading: atomic.Bool{},
+		mut:     &sync.Mutex{},
 	}
 }
 
-// Write writes the given bytes to the file.
+// Write writes the given bytes to the file. If the file is currently being read
+// from, the write will be lost.
 func (f *bufferedFile) Write(b []byte) (int, error) {
+	if f.reading.Load() {
+		return 0, nil
+	}
 	f.mut.Lock()
 	defer f.mut.Unlock()
 	return f.wr.Write(b)
 }
 
-// Flush flushes the writer to the file.
-func (f *bufferedFile) Flush() error {
+func (f *bufferedFile) startReading() error {
+	f.reading.Store(true)
 	f.mut.Lock()
 	defer f.mut.Unlock()
-	return f.wr.Flush()
+
+	err := f.wr.Flush()
+	if err != nil {
+		return err
+	}
+
+	_, err = f.file.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-// File returns a new copy of *os.File.
-func (f *bufferedFile) File() (*os.File, error) {
-	err := f.Flush()
+func (f *bufferedFile) stopReading() error {
+	defer f.reading.Store(false)
+	_, err := f.file.Seek(0, io.SeekEnd)
+	return err
+}
+
+// File returns the underlying file with the seek point reset. The caller should
+// not close the file. The caller must call the returned function when they are
+// done reading from the file. This function resets the seek point to where it
+// was being written to.
+func (f *bufferedFile) File() (*os.File, func() error, error) {
+	err := f.startReading()
 	if err != nil {
-		return nil, err
+		return nil, func() error { return nil }, err
 	}
-	f.mut.RLock()
-	defer f.mut.RUnlock()
-	return os.Open(f.file.Name())
+	err = f.wr.Flush()
+	if err != nil {
+		return nil, func() error { return nil }, err
+	}
+
+	return f.file, f.stopReading, nil
 }
 
 // Close closes the file.
 func (f *bufferedFile) Close() error {
-	f.mut.Lock()
-	defer f.mut.Unlock()
+	// set reading to true to prevent writes while closing the file.
+	f.reading.Store(true)
 	return f.file.Close()
 }

--- a/pkg/trace/buffered_file.go
+++ b/pkg/trace/buffered_file.go
@@ -68,6 +68,8 @@ func (f *bufferedFile) startReading() error {
 	return nil
 }
 
+// stopReading stops reading from the file and resets the seek point to the end
+// of the file.
 func (f *bufferedFile) stopReading() error {
 	f.mut.Lock()
 	defer f.mut.Unlock()

--- a/pkg/trace/fileserver.go
+++ b/pkg/trace/fileserver.go
@@ -36,11 +36,12 @@ func (lt *LocalTracer) getTableHandler() http.HandlerFunc {
 			return
 		}
 
-		f, err := lt.ReadTable(inputString)
+		f, done, err := lt.readTable(inputString)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to read table: %v", err), http.StatusInternalServerError)
 			return
 		}
+		defer done()
 
 		// Use the pump function to continuously read from the file and write to
 		// the response writer
@@ -236,19 +237,19 @@ func (lt *LocalTracer) pushLoop() {
 
 func (lt *LocalTracer) PushAll() error {
 	for table := range lt.fileMap {
-		f, err := lt.ReadTable(table)
+		f, done, err := lt.readTable(table)
 		if err != nil {
 			return err
 		}
-		defer f.Close()
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 3; i++ {
 			err = PushS3(lt.chainID, lt.nodeID, lt.s3Config, f)
 			if err == nil {
 				break
 			}
 			lt.logger.Error("failed to push table", "table", table, "error", err)
-			time.Sleep(time.Second * time.Duration(rand.Intn(10))) //nolint:gosec
+			time.Sleep(time.Second * time.Duration(rand.Intn(3)))
 		}
+		done()
 	}
 	return nil
 }

--- a/pkg/trace/fileserver.go
+++ b/pkg/trace/fileserver.go
@@ -41,7 +41,7 @@ func (lt *LocalTracer) getTableHandler() http.HandlerFunc {
 			http.Error(w, fmt.Sprintf("failed to read table: %v", err), http.StatusInternalServerError)
 			return
 		}
-		defer done()
+		defer done() //nolint:errcheck
 
 		// Use the pump function to continuously read from the file and write to
 		// the response writer
@@ -247,9 +247,12 @@ func (lt *LocalTracer) PushAll() error {
 				break
 			}
 			lt.logger.Error("failed to push table", "table", table, "error", err)
-			time.Sleep(time.Second * time.Duration(rand.Intn(3)))
+			time.Sleep(time.Second * time.Duration(rand.Intn(3))) //nolint:gosec
 		}
-		done()
+		err = done()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/trace/local_tracer_test.go
+++ b/pkg/trace/local_tracer_test.go
@@ -42,30 +42,42 @@ func TestLocalTracerReadWrite(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	f, err := client.ReadTable(testEventTable)
+	f, done, err := client.readTable(testEventTable)
 	require.NoError(t, err)
 
 	// write at the same time as reading to test thread safety this test will be
-	// flakey if this is not being handled correctly
+	// flakey if this is not being handled correctly. Since we're reading from
+	// the file, we expect these write to be ignored.
 	migenees := testEvent{"Migennes", 620}
 	pontivy := testEvent{"Pontivy", 720}
 	client.Write(migenees)
 	client.Write(pontivy)
 
+	// wait to ensure that the write have been processed (and ignored in this case)
+	time.Sleep(100 * time.Millisecond)
+
 	events, err := DecodeFile[testEvent](f)
 	require.NoError(t, err)
+	done()
+
+	// even though we've written twice, we expect only the first two events to be
+	// be written to the file. When reading the file, all writes are ignored.
 	require.GreaterOrEqual(t, len(events), 2)
 	require.Equal(t, annecy, events[0].Msg)
 	require.Equal(t, paris, events[1].Msg)
-	f.Close()
+
+	// write again to the file and read it back this time, we expect the writes
+	// to be written since we've called the done() function.
+	client.Write(migenees)
+	client.Write(pontivy)
 
 	time.Sleep(100 * time.Millisecond)
 
-	f, err = client.ReadTable(testEventTable)
+	f, done, err = client.readTable(testEventTable)
 	require.NoError(t, err)
-	defer f.Close()
 	events, err = DecodeFile[testEvent](f)
 	require.NoError(t, err)
+	done()
 	require.Len(t, events, 4)
 	require.Equal(t, migenees, events[2].Msg)
 	require.Equal(t, pontivy, events[3].Msg)
@@ -96,11 +108,11 @@ func TestLocalTracerServerPull(t *testing.T) {
 	err = GetTable(url, testEventTable, newDir)
 	require.NoError(t, err)
 
-	originalFile, err := client.ReadTable(testEventTable)
+	originalFile, done, err := client.readTable(testEventTable)
 	require.NoError(t, err)
-	defer originalFile.Close()
 	originalBz, err := io.ReadAll(originalFile)
 	require.NoError(t, err)
+	done()
 
 	path := path.Join(newDir, testEventTable+".jsonl")
 	downloadedFile, err := os.Open(path)

--- a/pkg/trace/local_tracer_test.go
+++ b/pkg/trace/local_tracer_test.go
@@ -58,7 +58,8 @@ func TestLocalTracerReadWrite(t *testing.T) {
 
 	events, err := DecodeFile[testEvent](f)
 	require.NoError(t, err)
-	done()
+	err = done()
+	require.NoError(t, err)
 
 	// even though we've written twice, we expect only the first two events to be
 	// be written to the file. When reading the file, all writes are ignored.
@@ -77,7 +78,8 @@ func TestLocalTracerReadWrite(t *testing.T) {
 	require.NoError(t, err)
 	events, err = DecodeFile[testEvent](f)
 	require.NoError(t, err)
-	done()
+	err = done()
+	require.NoError(t, err)
 	require.Len(t, events, 4)
 	require.Equal(t, migenees, events[2].Msg)
 	require.Equal(t, pontivy, events[3].Msg)
@@ -112,7 +114,8 @@ func TestLocalTracerServerPull(t *testing.T) {
 	require.NoError(t, err)
 	originalBz, err := io.ReadAll(originalFile)
 	require.NoError(t, err)
-	done()
+	err = done()
+	require.NoError(t, err)
 
 	path := path.Join(newDir, testEventTable+".jsonl")
 	downloadedFile, err := os.Open(path)

--- a/pkg/trace/tracer.go
+++ b/pkg/trace/tracer.go
@@ -18,7 +18,6 @@ type Entry interface {
 // Tracer defines the methods for a client that can write and read trace data.
 type Tracer interface {
 	Write(Entry)
-	ReadTable(table string) (*os.File, error)
 	IsCollecting(table string) bool
 	Stop()
 }


### PR DESCRIPTION
## Description

This PR backports the fix to the writing and reading of traced files. This enables them to get push correctly every time instead of occasionally get cut from the seek being set to the beginning of the file. 

it also changes the api by unexporting a function that doesn't need to be exported or included in the interface.

these changes are included in the upcoming #1295 

