### PR TITLE
feat: use a dynamic timeout commit modelled on the size of the block

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -672,9 +672,9 @@ func (cs *State) updateToState(state sm.State) {
 		// to be gathered for the first block.
 		// And alternative solution that relies on clocks:
 		// cs.StartTime = state.LastBlockTime.Add(timeoutCommit)
-		cs.StartTime = cs.config.Commit(cmttime.Now())
+		cs.StartTime = cs.config.Commit(cmttime.Now(), 0)
 	} else {
-		cs.StartTime = cs.config.Commit(cs.CommitTime)
+		cs.StartTime = cs.config.Commit(cs.CommitTime, cs.ProposalBlockParts.ByteSize())
 	}
 
 	cs.Validators = validators

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -900,9 +900,9 @@ func (cs *State) updateToState(state sm.State) {
 		// to be gathered for the first block.
 		// And alternative solution that relies on clocks:
 		// cs.StartTime = state.LastBlockTime.Add(timeoutCommit)
-		cs.StartTime = cs.config.Commit(cmttime.Now())
+		cs.StartTime = cs.config.Commit(cmttime.Now(), 0)
 	} else {
-		cs.StartTime = cs.config.Commit(cs.CommitTime)
+		cs.StartTime = cs.config.Commit(cs.CommitTime, cs.ProposalBlockParts.ByteSize())
 	}
 
 	cs.Validators = validators


### PR DESCRIPTION
This is meant to show a quick way for implementing a dynamic timeout commit aimed at achieving more consistent block times. The approach is to model how the size of the block effects commit speed. This example PR uses a 8MB block as the upper bound which would reduce the timeout commit propotionally by up to 4 seconds. We obviously need to model what linear formula best fits the celestia network.