### PR TITLE
docs: add the prove shares endpoint to openapi specs

### DIFF
--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -67,7 +67,7 @@ info:
     name: Apache 2.0
     url: https://github.com/cometbft/cometbft/blob/v0.34.x/LICENSE
 servers:
-  - url: https://public-celestia-rpc.numia.xyz
+  - url: https://rpc.cosmos.directory/cosmoshub
     description: Interact with the CometBFT RPC from a public node in the Cosmos registry
   - url: http://localhost:26657
     description: Interact with CometBFT RPC node running locally

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1006,9 +1006,9 @@ paths:
     get:
       summary: Prove shares for a given share range
       description: |
-        Generates a shares to data root inclusion proof
-        for a set of shares referenced by their range and
-        the block height they belong to.
+        Generates a proof of inclusion for a range of shares to the data root.
+        Note: shares are referenced by their range: startShare to endShare.
+        The share range is end exclusive.
 
         The share range is end exclusive.
       operationId: prove_shares

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -67,7 +67,7 @@ info:
     name: Apache 2.0
     url: https://github.com/cometbft/cometbft/blob/v0.34.x/LICENSE
 servers:
-  - url: https://rpc.cosmos.directory/cosmoshub
+  - url: https://public-celestia-rpc.numia.xyz
     description: Interact with the CometBFT RPC from a public node in the Cosmos registry
   - url: http://localhost:26657
     description: Interact with CometBFT RPC node running locally
@@ -1002,6 +1002,50 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /prove_shares:
+    get:
+      summary: Prove shares for a given share range
+      description: |
+        Generates a shares to data root inclusion proof
+        for a set of shares referenced by their range and
+        the block height they belong to.
+
+        The share range is end exclusive.
+      operationId: prove_shares
+      tags:
+        - Info
+      parameters:
+        - in: query
+          name: height
+          description: The block height
+          schema:
+            type: integer
+            default: 1
+            example: 1
+        - in: query
+          name: startShare
+          description: The starting share index
+          schema:
+            type: integer
+            default: 1
+            example: 1
+        - in: query
+          name: endShare
+          description: The ending share index
+          schema:
+            type: integer
+            default: 1
+            example: 1
+      responses:
+        '200':
+          description: Successfully retrieved the share proof
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResultShareProof'
+        '500':
+          description: Internal server error
+
   /data_commitment:
     get:
       summary: Generates a data commitment for a range of blocks

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1025,7 +1025,7 @@ paths:
           description: The starting share index
           schema:
             type: integer
-            default: 1
+            default: 0
             example: 1
         - in: query
           name: endShare

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1026,7 +1026,7 @@ paths:
           schema:
             type: integer
             default: 0
-            example: 1
+            example: 0
         - in: query
           name: endShare
           description: The end exclusive ending share index

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1009,8 +1009,6 @@ paths:
         Generates a proof of inclusion for a range of shares to the data root.
         Note: shares are referenced by their range: startShare to endShare.
         The share range is end exclusive.
-
-        The share range is end exclusive.
       operationId: prove_shares
       tags:
         - Info

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1031,7 +1031,7 @@ paths:
             example: 1
         - in: query
           name: endShare
-          description: The ending share index
+          description: The end exclusive ending share index
           schema:
             type: integer
             default: 1


### PR DESCRIPTION
## Description

Adds the prove shares endpoint to the openapi specs