### PR TITLE
feat!: Backport wrap ShareProof in ResultShareProof (#1313)

### DIFF
--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -586,7 +586,7 @@ func (c *Client) ProveShares(
 	height uint64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
+) (*ctypes.ResultShareProof, error) {
 	res, err := c.next.ProveShares(ctx, height, startShare, endShare)
 	return res, err
 }

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -555,8 +555,8 @@ func (c *baseRPCClient) ProveShares(
 	height uint64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
-	result := new(types.ShareProof)
+) (*ctypes.ResultShareProof, error) {
+	result := new(ctypes.ResultShareProof)
 	params := map[string]interface{}{
 		"height":     height,
 		"startShare": startShare,
@@ -564,9 +564,9 @@ func (c *baseRPCClient) ProveShares(
 	}
 	_, err := c.caller.Call(ctx, "prove_shares", params, result)
 	if err != nil {
-		return types.ShareProof{}, err
+		return nil, err
 	}
-	return *result, nil
+	return result, nil
 }
 
 func (c *baseRPCClient) TxSearch(

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -83,7 +83,7 @@ type SignClient interface {
 	Validators(ctx context.Context, height *int64, page, perPage *int) (*ctypes.ResultValidators, error)
 	Tx(ctx context.Context, hash []byte, prove bool) (*ctypes.ResultTx, error)
 
-	ProveShares(_ context.Context, height uint64, startShare uint64, endShare uint64) (types.ShareProof, error)
+	ProveShares(_ context.Context, height uint64, startShare uint64, endShare uint64) (*ctypes.ResultShareProof, error)
 
 	// TxSearch defines a method to search for a paginated set of transactions by
 	// DeliverTx event search criteria.

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -215,7 +215,7 @@ func (c *Local) ProveShares(
 	height uint64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
+) (*ctypes.ResultShareProof, error) {
 	return core.ProveShares(c.ctx, int64(height), startShare, endShare)
 }
 

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -42,10 +42,11 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 
 	var shareProof types.ShareProof
 	if prove {
-		shareProof, err = proveTx(height, index)
+		proof, err := proveTx(height, index)
 		if err != nil {
 			return nil, err
 		}
+		shareProof = proof.Proof
 	}
 
 	return &ctypes.ResultTx{
@@ -125,10 +126,11 @@ func TxSearch(
 
 		var shareProof types.ShareProof
 		if prove {
-			shareProof, err = proveTx(r.Height, r.Index)
+			proof, err := proveTx(r.Height, r.Index)
 			if err != nil {
 				return nil, err
 			}
+			shareProof = proof.Proof
 		}
 
 		apiResults = append(apiResults, &ctypes.ResultTx{
@@ -144,7 +146,7 @@ func TxSearch(
 	return &ctypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
 }
 
-func proveTx(height int64, index uint32) (types.ShareProof, error) {
+func proveTx(height int64, index uint32) (*ctypes.ResultShareProof, error) {
 	var (
 		pShareProof cmtproto.ShareProof
 		shareProof  types.ShareProof
@@ -152,24 +154,24 @@ func proveTx(height int64, index uint32) (types.ShareProof, error) {
 	env := GetEnvironment()
 	rawBlock, err := loadRawBlock(env.BlockStore, height)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	res, err := env.ProxyAppQuery.QuerySync(abcitypes.RequestQuery{
 		Data: rawBlock,
 		Path: fmt.Sprintf(consts.TxInclusionProofQueryPath, index),
 	})
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	err = pShareProof.Unmarshal(res.Value)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	shareProof, err = types.ShareProofFromProto(pShareProof)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
-	return shareProof, nil
+	return &ctypes.ResultShareProof{Proof: shareProof}, nil
 }
 
 // ProveShares creates an NMT proof for a set of shares to a set of rows. It is
@@ -179,7 +181,7 @@ func ProveShares(
 	height int64,
 	startShare uint64,
 	endShare uint64,
-) (types.ShareProof, error) {
+) (*ctypes.ResultShareProof, error) {
 	var (
 		pShareProof cmtproto.ShareProof
 		shareProof  types.ShareProof
@@ -187,29 +189,29 @@ func ProveShares(
 	env := GetEnvironment()
 	rawBlock, err := loadRawBlock(env.BlockStore, height)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	res, err := env.ProxyAppQuery.QuerySync(abcitypes.RequestQuery{
 		Data: rawBlock,
 		Path: fmt.Sprintf(consts.ShareInclusionProofQueryPath, startShare, endShare),
 	})
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	if res.Value == nil && res.Log != "" {
 		// we can make the assumption that for custom queries, if the value is nil
 		// and some logs have been emitted, then an error happened.
-		return types.ShareProof{}, errors.New(res.Log)
+		return nil, errors.New(res.Log)
 	}
 	err = pShareProof.Unmarshal(res.Value)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
 	shareProof, err = types.ShareProofFromProto(pShareProof)
 	if err != nil {
-		return shareProof, err
+		return nil, err
 	}
-	return shareProof, nil
+	return &ctypes.ResultShareProof{Proof: shareProof}, nil
 }
 
 func loadRawBlock(bs state.BlockStore, height int64) ([]byte, error) {

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -272,3 +272,8 @@ type ResultEvent struct {
 	Data   types.TMEventData   `json:"data"`
 	Events map[string][]string `json:"events"`
 }
+
+// ResultShareProof API proof response of a set of shares
+type ResultShareProof struct {
+	Proof types.ShareProof `json:"proof"`
+}


### PR DESCRIPTION
## Description

This PR wraps the `ShareProof` into a `ResultShareProof` in the API. However, It doesn't change the custom query response since it's internal data and there is no need to wrap it.

Closes https://github.com/celestiaorg/celestia-core/issues/1306

(cherry picked from commit c89f6f9dbd63c5a117d75b4aba3d37a08feca167)

## Description

Backporting this PR to v.0.34.x-celestia

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

