### PR TITLE
chore: increase the data commitment blocks limit in the API (Backport #1268)

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -41,5 +41,7 @@ var (
 	NewBaseHashFunc = sha256.New
 
 	// DataCommitmentBlocksLimit is the limit to the number of blocks we can generate a data commitment for.
+	// Deprecated: this is no longer used as we're moving towards Blobstream X. However, we're leaving it
+	// here for backwards compatibility purpose until it's removed in the next breaking release.
 	DataCommitmentBlocksLimit = 1000
 )

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	cmtmath "github.com/tendermint/tendermint/libs/math"
 	cmtquery "github.com/tendermint/tendermint/libs/pubsub/query"
-	"github.com/tendermint/tendermint/pkg/consts"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	blockidxnull "github.com/tendermint/tendermint/state/indexer/block/null"
@@ -333,6 +332,10 @@ func EncodeDataRootTuple(height uint64, dataRoot [32]byte) ([]byte, error) {
 	return append(paddedHeight, dataRoot[:]...), nil
 }
 
+// dataCommitmentBlocksLimit The maximum number of blocks to be used to create a data commitment.
+// It's a local parameter to protect the API from creating unnecessarily large commitments.
+const dataCommitmentBlocksLimit = 10_000 // ~33 hours of blocks assuming 12-second blocks.
+
 // validateDataCommitmentRange runs basic checks on the asc sorted list of
 // heights that will be used subsequently in generating data commitments over
 // the defined set of heights.
@@ -342,8 +345,8 @@ func validateDataCommitmentRange(start uint64, end uint64) error {
 	}
 	env := GetEnvironment()
 	heightsRange := end - start
-	if heightsRange > uint64(consts.DataCommitmentBlocksLimit) {
-		return fmt.Errorf("the query exceeds the limit of allowed blocks %d", consts.DataCommitmentBlocksLimit)
+	if heightsRange > uint64(dataCommitmentBlocksLimit) {
+		return fmt.Errorf("the query exceeds the limit of allowed blocks %d", dataCommitmentBlocksLimit)
 	}
 	if heightsRange == 0 {
 		return fmt.Errorf("cannot create the data commitments for an empty set of blocks")


### PR DESCRIPTION
## Description

This is done to support 33 hours batches of attestations in the API without having to make a breaking change

