### PR TITLE
perf(crypto/merkle): reduce allocations in HashFromByteSlices

### DIFF
--- a/crypto/merkle/tree.go
+++ b/crypto/merkle/tree.go
@@ -12,6 +12,10 @@ func HashFromByteSlices(items [][]byte) []byte {
 		return emptyHash()
 	case 1:
 		return leafHash(items[0])
+	case 2:
+		left := leafHash(items[0])
+		right := leafHash(items[1])
+		return innerHash(left, right)
 	default:
 		k := getSplitPoint(int64(len(items)))
 		left := HashFromByteSlices(items[:k])

--- a/crypto/merkle/tree_test.go
+++ b/crypto/merkle/tree_test.go
@@ -116,7 +116,7 @@ func TestHashAlternatives(t *testing.T) {
 }
 
 func BenchmarkHashAlternatives(b *testing.B) {
-	total := 100
+	total := 101
 
 	items := make([][]byte, total)
 	for i := 0; i < total; i++ {


### PR DESCRIPTION
## Description

Reduce allocations in `HashAlternatives` by adding `case 2` which is very common and doesn't require 2 additional recursive calls. As a result 20% less allocations and 10% less CPU time.

```
celestia-core % go-perftuner bstat a.txt b.txt                                  
args: [a.txt b.txt]name                           old time/op    new time/op    delta
HashAlternatives/recursive-10    31.6µs ± 3%    27.9µs ± 0%  -11.66%  (p=0.002 n=6+6)
HashAlternatives/iterative-10    32.3µs ± 3%    31.9µs ± 2%        ~  (p=0.240 n=6+6)

name                           old alloc/op   new alloc/op   delta
HashAlternatives/recursive-10    25.4kB ± 0%    22.2kB ± 0%  -12.59%  (p=0.002 n=6+6)
HashAlternatives/iterative-10    28.1kB ± 0%    28.1kB ± 0%        ~  (all equal)

name                           old allocs/op  new allocs/op  delta
HashAlternatives/recursive-10       497 ± 0%       397 ± 0%  -20.12%  (p=0.002 n=6+6)
HashAlternatives/iterative-10       498 ± 0%       498 ± 0%        ~  (all equal)
```

Also, changing benchmark by 1 digit: instead of 100 nodes create 101 to cover all code branches (a bit better code coverage).

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

