### PR TITLE
Add ABCI method timing histogram metric

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -96,6 +96,9 @@ type Metrics struct {
 
 	// The amount of proposals that failed to be received in time
 	TimedOutProposals metrics.Counter
+
+	// Timings for each of the ABCI methods.
+	ABCIMethodTimingSeconds metrics.Histogram
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -267,6 +270,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "timed_out_proposals",
 			Help:      "Number of proposals that failed to be received in time",
 		}, labels).With(labelsAndValues...),
+		ABCIMethodTimingSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "abci_connection_method_timing_seconds",
+			Help:      "Timings for each of the ABCI methods.",
+		}, append(labels, "method", "type")).With(labelsAndValues...),
 	}
 }
 
@@ -304,6 +313,7 @@ func NopMetrics() *Metrics {
 		FullPrevoteMessageDelay:      discard.NewGauge(),
 		ApplicationRejectedProposals: discard.NewCounter(),
 		TimedOutProposals:            discard.NewCounter(),
+		ABCIMethodTimingSeconds:      discard.NewHistogram(),
 	}
 }
 


### PR DESCRIPTION
This PR introduces a new histogram metric, `abci_connection_method_timing_seconds`, to measure the timings for each of the `ABCI methods`. This metric will help in tracking and analysing the performance of various `ABCI methods` by providing detailed timing information. The metric includes labels for method and type to allow for granular analysis of the data.


Changes Introduced
--

- `New Metric`: The `abci_connection_method_timing_seconds` histogram metric is added to capture the duration of ABCI method calls.
- `Metrics Struct Update`: The Metrics struct is updated to include the new histogram metric.
- `Prometheus Metrics Initialization`: The PrometheusMetrics function is updated to initialize the new histogram metric with appropriate labels.
- `No-Op Metrics Update`: The NopMetrics function is updated to include a no-op version of the new histogram metric.

Files to Review
---
`metrics.go`: This file contains the primary changes for adding the new metric. It includes updates to the Metrics struct, the PrometheusMetrics function, and the NopMetrics function.

Importance
---

Tracking the performance of ABCI methods is crucial for understanding and optimizing the behavior of the system. By adding this metric, we provide operators and developers with a tool to gain insights into the timing of different ABCI method executions, which can help in identifying bottlenecks and improving the overall efficiency of the system.