### PR TITLE
feat: enhances S3Download to filter by traced table names

### DIFF
--- a/pkg/trace/fileserver.go
+++ b/pkg/trace/fileserver.go
@@ -259,8 +259,8 @@ func (lt *LocalTracer) PushAll() error {
 
 // S3Download downloads files that match some prefix from an S3 bucket to a
 // local directory dst.
-// tableNames is a list of traced jsonl file names to download. If it is empty, all traces are downloaded.
-// tableNames should not have .jsonl suffix.
+// fileNames is a list of traced jsonl file names to download. If it is empty, all traces are downloaded.
+// fileNames should not have .jsonl suffix.
 func S3Download(dst, prefix string, fileNames []string, cfg S3Config) error {
 	// Ensure local directory structure exists
 	err := os.MkdirAll(dst, os.ModePerm)

--- a/pkg/trace/fileserver.go
+++ b/pkg/trace/fileserver.go
@@ -327,6 +327,7 @@ func S3Download(dst, prefix string, fileNames []string, cfg S3Config) error {
 
 					// Copy the contents of the S3 object to the local file
 					if _, err := io.Copy(f, resp.Body); err != nil {
+						f.Close()
 						return false
 					}
 


### PR DESCRIPTION
This PR updates the `S3Download` implementation to allow specifying the names of the traced tables when downloading from an S3 bucket. This enhancement enables file filtering and reduces the amount of data downloaded. It is a desirable feature when interacting with the traced data of large network tests. If no table name is provided, then `S3Download` downloads all the traced tables. 