### PR TITLE
chore: bumps go version to 1.22.4 in v0.34.x-celestia

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,6 +1,6 @@
 # Use a build arg to ensure that both stages use the same,
 # hopefully current, go version.
-ARG GOLANG_BASE_IMAGE=golang:1.22.3-alpine
+ARG GOLANG_BASE_IMAGE=golang:1.22.4-alpine
 
 # stage 1 Generate CometBFT Binary
 FROM --platform=$BUILDPLATFORM $GOLANG_BASE_IMAGE as builder

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This repo intends on preserving the minimal possible diff with [cometbft/cometbf
 - **specific to Celestia**: consider if [celestia-app](https://github.com/celestiaorg/celestia-app) is a better target
 - **not specific to Celestia**: consider making the contribution upstream in CometBFT
 
-1. [Install Go](https://go.dev/doc/install) 1.22.3+
+1. [Install Go](https://go.dev/doc/install) 1.22.4+
 2. Fork this repo
 3. Clone your fork
 4. Find an issue to work on (see [good first issues](https://github.com/celestiaorg/celestia-core/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/scripts/proto-gen.sh
+++ b/scripts/proto-gen.sh
@@ -10,7 +10,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Run inside Docker to install the correct versions of the required tools
 # without polluting the local system.
-docker run --rm -i -v "$PWD":/w --workdir=/w golang:1.22.3-alpine sh <<"EOF"
+docker run --rm -i -v "$PWD":/w --workdir=/w golang:1.22.4-alpine sh <<"EOF"
 apk add git make
 
 go install github.com/bufbuild/buf/cmd/buf

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3
+FROM golang:1.22.4
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.22.3-bullseye
+FROM golang:1.22.4-bullseye
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null


### PR DESCRIPTION
This together with https://github.com/celestiaorg/celestia-core/pull/1378 close https://github.com/celestiaorg/celestia-core/issues/1377