### PR TITLE
ci: add ability to backport to main

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -27,3 +27,12 @@ pull_request_rules:
       backport:
         branches:
           - v0.34.x-celestia
+
+  - name: Backport to main
+    conditions:
+      - label=S:backport-to-main
+      - merged
+    actions:
+      backport:
+        branches:
+          - main


### PR DESCRIPTION
## Motivation

I just merged two PRs to v0.34.x-celestia that should probably be backported to `main` if we're still maintaining `main`.
