### PR TITLE
chore: adds logs for the state of the trace pull server

### DIFF
--- a/pkg/trace/fileserver.go
+++ b/pkg/trace/fileserver.go
@@ -97,6 +97,7 @@ func (lt *LocalTracer) servePullData() {
 	if err != nil {
 		lt.logger.Error("trace pull server failure", "err", err)
 	}
+	lt.logger.Info("trace pull server started", "address", lt.cfg.Instrumentation.TracePullAddress)
 }
 
 // GetTable downloads a table from the server and saves it to the given directory. It uses a multipart

--- a/pkg/trace/local_tracer.go
+++ b/pkg/trace/local_tracer.go
@@ -96,6 +96,7 @@ func NewLocalTracer(cfg *config.Config, logger log.Logger, chainID, nodeID strin
 
 	go lt.drainCanal()
 	if cfg.Instrumentation.TracePullAddress != "" {
+		logger.Info("starting pull server", "address", cfg.Instrumentation.TracePullAddress)
 		go lt.servePullData()
 	}
 


### PR DESCRIPTION
As part of migrating to Knuu for the celestia-app e2e tests, I debugged the tracing feature which required adding log messages to verify that the tracer pull server is up and running. This PR includes those log messages, which previously lived in a custom branch and were not available to everyone.
Part of https://github.com/celestiaorg/celestia-app/issues/3557