### PR TITLE
chore: use `embed` pkg to split long template to file

### DIFF
--- a/test/e2e/pkg/infra/docker/docker-compose.yaml.tpl
+++ b/test/e2e/pkg/infra/docker/docker-compose.yaml.tpl
@@ -1,0 +1,72 @@
+version: '2.4'
+
+networks:
+  {{ .Name }}:
+    labels:
+      e2e: true
+    driver: bridge
+{{- if .IPv6 }}
+    enable_ipv6: true
+{{- end }}
+    ipam:
+      driver: default
+      config:
+      - subnet: {{ .IP }}
+
+services:
+{{- range .Nodes }}
+  {{ .Name }}:
+    labels:
+      e2e: true
+    container_name: {{ .Name }}
+    image: {{ .Version }}
+{{- if eq .ABCIProtocol "builtin" }}
+    entrypoint: /usr/bin/entrypoint-builtin
+{{- else if .Misbehaviors }}
+    entrypoint: /usr/bin/entrypoint-maverick
+    command: ["node", "--misbehaviors", "{{ misbehaviorsToString .Misbehaviors }}"]
+{{- end }}
+    init: true
+    ports:
+    - 26656
+    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
+{{- if .PrometheusProxyPort }}
+    - {{ .PrometheusProxyPort }}:26660
+{{- end }}
+    - 6060
+    volumes:
+    - ./{{ .Name }}:/cometbft
+    - ./{{ .Name }}:/tendermint
+    networks:
+      {{ $.Name }}:
+        ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .IP }}
+{{- if ne .Version $.UpgradeVersion}}
+
+  {{ .Name }}_u:
+    labels:
+      e2e: true
+    container_name: {{ .Name }}_u
+    image: {{ $.UpgradeVersion }}
+{{- if eq .ABCIProtocol "builtin" }}
+    entrypoint: /usr/bin/entrypoint-builtin
+{{- else if .Misbehaviors }}
+    entrypoint: /usr/bin/entrypoint-maverick
+    command: ["node", "--misbehaviors", "{{ misbehaviorsToString .Misbehaviors }}"]
+{{- end }}
+    init: true
+    ports:
+    - 26656
+    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
+{{- if .PrometheusProxyPort }}
+    - {{ .PrometheusProxyPort }}:26660
+{{- end }}
+    - 6060
+    volumes:
+    - ./{{ .Name }}:/cometbft
+    - ./{{ .Name }}:/tendermint
+    networks:
+      {{ $.Name }}:
+        ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .IP }}
+{{- end }}
+
+{{end}}

--- a/test/e2e/pkg/infra/docker/docker.go
+++ b/test/e2e/pkg/infra/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"bytes"
+	_ "embed"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -34,6 +35,9 @@ func (p *Provider) Setup() error {
 	return nil
 }
 
+//go:embed docker-compose.yaml.tpl
+var dockerComposeTemplate string
+
 // dockerComposeBytes generates a Docker Compose config file for a testnet and returns the
 // file as bytes to be written out to disk.
 func dockerComposeBytes(testnet *e2e.Testnet) ([]byte, error) {
@@ -51,78 +55,7 @@ func dockerComposeBytes(testnet *e2e.Testnet) ([]byte, error) {
 			}
 			return str
 		},
-	}).Parse(`version: '2.4'
-
-networks:
-  {{ .Name }}:
-    labels:
-      e2e: true
-    driver: bridge
-{{- if .IPv6 }}
-    enable_ipv6: true
-{{- end }}
-    ipam:
-      driver: default
-      config:
-      - subnet: {{ .IP }}
-
-services:
-{{- range .Nodes }}
-  {{ .Name }}:
-    labels:
-      e2e: true
-    container_name: {{ .Name }}
-    image: {{ .Version }}
-{{- if eq .ABCIProtocol "builtin" }}
-    entrypoint: /usr/bin/entrypoint-builtin
-{{- else if .Misbehaviors }}
-    entrypoint: /usr/bin/entrypoint-maverick
-    command: ["node", "--misbehaviors", "{{ misbehaviorsToString .Misbehaviors }}"]
-{{- end }}
-    init: true
-    ports:
-    - 26656
-    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
-{{- if .PrometheusProxyPort }}
-    - {{ .PrometheusProxyPort }}:26660
-{{- end }}
-    - 6060
-    volumes:
-    - ./{{ .Name }}:/cometbft
-    - ./{{ .Name }}:/tendermint
-    networks:
-      {{ $.Name }}:
-        ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .IP }}
-{{- if ne .Version $.UpgradeVersion}}
-
-  {{ .Name }}_u:
-    labels:
-      e2e: true
-    container_name: {{ .Name }}_u
-    image: {{ $.UpgradeVersion }}
-{{- if eq .ABCIProtocol "builtin" }}
-    entrypoint: /usr/bin/entrypoint-builtin
-{{- else if .Misbehaviors }}
-    entrypoint: /usr/bin/entrypoint-maverick
-    command: ["node", "--misbehaviors", "{{ misbehaviorsToString .Misbehaviors }}"]
-{{- end }}
-    init: true
-    ports:
-    - 26656
-    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
-{{- if .PrometheusProxyPort }}
-    - {{ .PrometheusProxyPort }}:26660
-{{- end }}
-    - 6060
-    volumes:
-    - ./{{ .Name }}:/cometbft
-    - ./{{ .Name }}:/tendermint
-    networks:
-      {{ $.Name }}:
-        ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .IP }}
-{{- end }}
-
-{{end}}`)
+	}).Parse(dockerComposeTemplate)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Splitting long content template into file is more friendly for reading, also for IDE rendering.

BTW: I noticed that `config/toml.go` has introduced the similar changes in upstream `cometbft/comebft`, so I didn't update it.