### PR TITLE
feat: metric for counting rejected transactions

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -144,6 +144,11 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 		panic(err)
 	}
 
+	rejectedTxs := len(rpp.Txs) - len(block.Txs)
+	if rejectedTxs > 0 {
+		blockExec.metrics.RejectedTransactions.Add(float64(rejectedTxs))
+	}
+
 	// Celestia passes the data root back as the last transaction
 	if len(rpp.Txs) < 1 {
 		panic("state machine returned an invalid prepare proposal response: expected at least 1 transaction")

--- a/state/execution.go
+++ b/state/execution.go
@@ -153,7 +153,8 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 		panic(fmt.Sprintf("state machine returned an invalid prepare proposal response: expected last transaction to be a hash, got %d bytes", len(rpp.Txs[len(rpp.Txs)-2])))
 	}
 
-	rejectedTxs := len(rpp.Txs) - len(block.Txs)
+	// don't count the last tx in rpp.Txs which is data root back from app
+	rejectedTxs := len(block.Txs) - (len(rpp.Txs) - 1)
 	if rejectedTxs > 0 {
 		blockExec.metrics.RejectedTransactions.Add(float64(rejectedTxs))
 	}

--- a/state/execution.go
+++ b/state/execution.go
@@ -144,11 +144,6 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 		panic(err)
 	}
 
-	rejectedTxs := len(rpp.Txs) - len(block.Txs)
-	if rejectedTxs > 0 {
-		blockExec.metrics.RejectedTransactions.Add(float64(rejectedTxs))
-	}
-
 	// Celestia passes the data root back as the last transaction
 	if len(rpp.Txs) < 1 {
 		panic("state machine returned an invalid prepare proposal response: expected at least 1 transaction")
@@ -156,6 +151,11 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 
 	if len(rpp.Txs[len(rpp.Txs)-1]) != tmhash.Size {
 		panic(fmt.Sprintf("state machine returned an invalid prepare proposal response: expected last transaction to be a hash, got %d bytes", len(rpp.Txs[len(rpp.Txs)-2])))
+	}
+
+	rejectedTxs := len(rpp.Txs) - len(block.Txs)
+	if rejectedTxs > 0 {
+		blockExec.metrics.RejectedTransactions.Add(float64(rejectedTxs))
 	}
 
 	// update the block with the response from PrepareProposal

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -19,6 +19,8 @@ type Metrics struct {
 	BlockProcessingTime metrics.Histogram
 	// Count of times a block was rejected via ProcessProposal
 	ProcessProposalRejected metrics.Counter
+	// Count of transactions rejected by application.
+	RejectedTransactions metrics.Counter
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -43,6 +45,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "process_proposal_rejected",
 			Help:      "Count of times a block was rejected via ProcessProposal",
 		}, labels).With(labelsAndValues...),
+		RejectedTransactions: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "rejected_transactions",
+			Help:      "Count of transactions rejected by application",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -51,5 +59,6 @@ func NopMetrics() *Metrics {
 	return &Metrics{
 		BlockProcessingTime:     discard.NewHistogram(),
 		ProcessProposalRejected: discard.NewCounter(),
+		RejectedTransactions:    discard.NewCounter(),
 	}
 }


### PR DESCRIPTION
## Description

Add counter to the block executor metrics :
- RejectedTransactions

Resolves #1241

Unblocks #1007


#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

