### PR TITLE
fix: persist the correct size of the txs

### DIFF
--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -241,7 +241,7 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 		for _, tx := range protoTxs {
 			ntx := types.Tx(tx)
 			key := ntx.Key()
-			schema.WriteMempoolTx(memR.traceClient, string(e.Src.ID()), key[:], schema.Download)
+			schema.WriteMempoolTx(memR.traceClient, string(e.Src.ID()), key[:], len(tx), schema.Download)
 			// If we requested the transaction we mark it as received.
 			if memR.requests.Has(peerID, key) {
 				memR.requests.MarkReceived(peerID, key)
@@ -331,6 +331,7 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 					memR.traceClient,
 					string(e.Src.ID()),
 					txKey[:],
+					len(tx),
 					schema.Upload,
 				)
 			}

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -197,6 +197,7 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 				memR.traceClient,
 				string(e.Src.ID()),
 				ntx.Hash(),
+				len(tx),
 				schema.Download,
 			)
 			err = memR.mempool.CheckTx(ntx, nil, txInfo)
@@ -303,6 +304,7 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 					memR.traceClient,
 					string(peer.ID()),
 					memTx.tx.Hash(),
+					len(memTx.tx),
 					schema.Upload,
 				)
 			}

--- a/pkg/trace/schema/mempool.go
+++ b/pkg/trace/schema/mempool.go
@@ -35,7 +35,7 @@ func (m MempoolTx) Table() string {
 
 // WriteMempoolTx writes a tracing point for a tx using the predetermined
 // schema for mempool tracing.
-func WriteMempoolTx(client trace.Tracer, peer string, txHash []byte, transferType TransferType) {
+func WriteMempoolTx(client trace.Tracer, peer string, txHash []byte, size int, transferType TransferType) {
 	// this check is redundant to what is checked during client.Write, although it
 	// is an optimization to avoid allocations from the map of fields.
 	if !client.IsCollecting(MempoolTxTable) {
@@ -44,7 +44,7 @@ func WriteMempoolTx(client trace.Tracer, peer string, txHash []byte, transferTyp
 	client.Write(MempoolTx{
 		TxHash:       bytes.HexBytes(txHash).String(),
 		Peer:         peer,
-		Size:         len(txHash),
+		Size:         size,
 		TransferType: transferType,
 	})
 }


### PR DESCRIPTION
Currently, we use the length of the tx hash as the size. This means that all txs have the size 32. It would be more helpful that the tracing data captures the actual size of the transactions passing back and forth