### PR TITLE
chore(ci): add support for pushing proto definitions to Buf Schema Registry

### DIFF
--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -1,0 +1,20 @@
+name: buf-ci
+on:
+  push:
+    branches:
+      - main
+      - "v[0-9]+.x"
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          against: 'https://github.com/celestiaorg/celestia-core.git#branch=main'
+      - uses: bufbuild/buf-lint-action@v1

--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-breaking-action@v1
         with:
-          against: 'https://github.com/celestiaorg/celestia-core.git#branch=main'
+          against: 'https://github.com/celestiaorg/celestia-core.git#branch=v0.34.x'
       - uses: bufbuild/buf-lint-action@v1

--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-breaking-action@v1
         with:
-          against: 'https://github.com/celestiaorg/celestia-core.git#branch=v0.34.x'
+          against: 'https://github.com/celestiaorg/celestia-core.git#branch=v0.34.x-celestia'
       - uses: bufbuild/buf-lint-action@v1

--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -1,0 +1,23 @@
+name: buf-release
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: "1.44.0"
+      # Push the protobuf definitions to the BSR
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          buf_token: ${{ secrets.BUF_TOKEN }}
+      - name: "push the tag label to BSR"
+        run: |
+          set -euo pipefail
+          echo ${{ secrets.BUF_TOKEN }} | buf registry login --token-stdin
+          buf push --label ${{ github.ref_name }}

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,3 +1,0 @@
-version: v1
-directories:
-  - proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,5 +1,8 @@
 version: v1beta1
 
+modules:
+  - name: buf.build/celestia/celestia-core
+
 build:
   roots:
     - proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,8 +1,5 @@
 version: v1beta1
-
-modules:
-  - name: buf.build/celestia/celestia-core
-
+name: buf.build/celestia/celestia-core
 build:
   roots:
     - proto

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go v1.40.45
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
-	github.com/celestiaorg/nmt v0.22.1
+	github.com/celestiaorg/nmt v0.22.2
 	github.com/cometbft/cometbft-db v0.7.0
 	github.com/cometbft/cometbft-load-test v0.3.0
 	github.com/creachadair/taskgroup v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-github.com/celestiaorg/nmt v0.22.1 h1:t7fqoP5MJ8mBns5DB2XjfcPxQpS3CKMkY+v+BEkDxYc=
-github.com/celestiaorg/nmt v0.22.1/go.mod h1:ia/EpCk0enD5yO5frcxoNoFToz2Ghtk2i+blmCRjIY8=
+github.com/celestiaorg/nmt v0.22.2 h1:JmOMtZL9zWAed1hiwb9DDs+ELcKp/ZQZ3rPverge/V8=
+github.com/celestiaorg/nmt v0.22.2/go.mod h1:/7huDiSRL/d2EGhoiKctgSzmLOJoWG8yEfbFtY1+Mow=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
@@ -408,8 +408,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
-github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
-github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,5 +1,5 @@
 version: v1
-name: buf.build/tendermint/tendermint
+name: buf.build/celestiaorg/celestia-core
 deps:
   - buf.build/gogo/protobuf
 breaking:


### PR DESCRIPTION
Adds support to pushing proto definitions to BSR when releasing. 

This will be helpful to import RowProof, ShareProof, etc from downstream repos without redefining them.

I guess we can keep pushing our protos to BSR even if we decide to move these definitions to go-square 