### PR TITLE
chore: remove buf.work.yaml

### DIFF
--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,3 +1,0 @@
-version: v1
-directories:
-  - proto


### PR DESCRIPTION
deletes buf.work.yaml for the buf CI in https://github.com/celestiaorg/celestia-core/pull/1510 to work