### PR TITLE
chore: make format the whole repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,8 @@ clean_certs:
 ###############################################################################
 
 format:
-	find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s
-	find . -name '*.go' -type f -not -path "*.git*"  -not -name '*.pb.go' -not -name '*pb_test.go' | xargs goimports -w -local github.com/cometbft/cometbft
+	@echo "--> Running golangci-lint --fix"
+	@golangci-lint run --fix
 .PHONY: format
 
 lint:

--- a/blockchain/v2/reactor_test.go
+++ b/blockchain/v2/reactor_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/behaviour"

--- a/cmd/cometbft/commands/reindex_event.go
+++ b/cmd/cometbft/commands/reindex_event.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/spf13/cobra"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	cmtcfg "github.com/tendermint/tendermint/config"

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -12,10 +12,11 @@ import (
 	"testing"
 	"time"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	abci "github.com/tendermint/tendermint/abci/types"

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -8,9 +8,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/gogo/protobuf/proto"
 	gogotypes "github.com/gogo/protobuf/types"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	clist "github.com/tendermint/tendermint/libs/clist"
 	"github.com/tendermint/tendermint/libs/log"

--- a/node/node.go
+++ b/node/node.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"time"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/grafana/pyroscope-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	bcv0 "github.com/tendermint/tendermint/blockchain/v0"

--- a/p2p/trust/store_test.go
+++ b/p2p/trust/store_test.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"testing"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	"github.com/tendermint/tendermint/libs/log"
 )

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -108,9 +108,9 @@ message RequestListSnapshots {}
 
 // offers a snapshot to the application
 message RequestOfferSnapshot {
-  Snapshot snapshot = 1;  // snapshot offered by peers
-  bytes    app_hash = 2;  // light client-verified app hash for snapshot height
-  uint64 app_version = 3; // The application version at which the snapshot was taken
+  Snapshot snapshot    = 1;  // snapshot offered by peers
+  bytes    app_hash    = 2;  // light client-verified app hash for snapshot height
+  uint64   app_version = 3;  // The application version at which the snapshot was taken
 }
 
 // loads a snapshot chunk

--- a/proto/tendermint/store/types.proto
+++ b/proto/tendermint/store/types.proto
@@ -11,11 +11,11 @@ message BlockStoreState {
 // TxInfo describes the location of a tx inside a committed block
 // as well as the result of executing the transaction and the error log output.
 message TxInfo {
-  int64 height    = 1;
-  uint32 index    = 2;
+  int64  height = 1;
+  uint32 index  = 2;
   // The response code of executing the tx. 0 means
   // successfully executed, all others are error codes.
-  uint32 code     = 3;
+  uint32 code = 3;
   // The error log output generated if the transaction execution fails.
-  string error     = 4;
+  string error = 4;
 }

--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	cmtrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/types"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmtstate "github.com/tendermint/tendermint/proto/tendermint/state"

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	db "github.com/cometbft/cometbft-db"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -35,6 +34,8 @@ import (
 	"github.com/tendermint/tendermint/types"
 	cmttime "github.com/tendermint/tendermint/types/time"
 	"github.com/tendermint/tendermint/version"
+
+	db "github.com/cometbft/cometbft-db"
 )
 
 var (

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -10,8 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/google/orderedcode"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"

--- a/state/indexer/block/kv/kv_test.go
+++ b/state/indexer/block/kv/kv_test.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	db "github.com/cometbft/cometbft-db"
 	"github.com/stretchr/testify/require"
+
+	db "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -4,8 +4,9 @@ import (
 	"crypto/rand"
 	"testing"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"

--- a/state/store.go
+++ b/state/store.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/gogo/protobuf/proto"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmtmath "github.com/tendermint/tendermint/libs/math"

--- a/state/txindex/indexer_service_test.go
+++ b/state/txindex/indexer_service_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	db "github.com/cometbft/cometbft-db"
 	"github.com/stretchr/testify/require"
+
+	db "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -9,8 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/gogo/protobuf/proto"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"

--- a/store/store.go
+++ b/store/store.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/gogo/protobuf/proto"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmtsync "github.com/tendermint/tendermint/libs/sync"

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	dbm "github.com/cometbft/cometbft-db"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"

--- a/test/loadtime/cmd/load/main.go
+++ b/test/loadtime/cmd/load/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/cometbft/cometbft-load-test/pkg/loadtest"
 	"github.com/google/uuid"
+
+	"github.com/cometbft/cometbft-load-test/pkg/loadtest"
 
 	"github.com/tendermint/tendermint/test/loadtime/payload"
 )


### PR DESCRIPTION
runs `make format` and `make proto-format` to format the whole repo.

This will make it easier to format next contributions without having to touch unrelated files.