### PR TITLE
fix: rpc "no port provided" error by backporting

### DIFF
--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -85,7 +85,6 @@ func (u parsedURL) GetTrimmedHostWithPath() string {
 	return strings.ReplaceAll(u.GetHostWithPath(), "/", ".")
 }
 
-// GetDialAddress returns the endpoint to dial for the parsed URL.
 func (u parsedURL) GetDialAddress() string {
 	if !u.isUnixSocket {
 		host := u.Host
@@ -103,9 +102,8 @@ func (u parsedURL) GetDialAddress() string {
 				panic("unsupported scheme: " + u.Scheme)
 			}
 		}
-		return host
+		return "[" + host + "]" // Explicitly wrap IPv6 addresses in brackets
 	}
-	// For Unix sockets, return the full path
 	return u.GetHostWithPath()
 }
 

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -88,24 +88,27 @@ func (u parsedURL) GetTrimmedHostWithPath() string {
 	return strings.ReplaceAll(u.GetHostWithPath(), "/", ".")
 }
 
-// GetDialAddress returns the endpoint to dial for the parsed URL
+// GetDialAddress returns the endpoint to dial for the parsed URL.
 func (u parsedURL) GetDialAddress() string {
-	// if it's not a unix socket we return the host, example: localhost:443
 	if !u.isUnixSocket {
-		hasPort := endsWithPortPattern.MatchString(u.Host)
-		if !hasPort {
-			// http and ws default to port 80, https and wss default to port 443
-			// https://www.rfc-editor.org/rfc/rfc9110#section-4.2
-			// https://www.rfc-editor.org/rfc/rfc6455.html#section-3
-			if u.Scheme == protoHTTP || u.Scheme == protoWS {
-				return u.Host + `:80`
-			} else if u.Scheme == protoHTTPS || u.Scheme == protoWSS {
-				return u.Host + `:443`
+		host := u.Host
+		// Check if the host already includes a port
+		_, _, err := net.SplitHostPort(host)
+		if err != nil {
+			// Add the default port based on the scheme
+			switch u.Scheme {
+			case protoHTTP, protoWS:
+				host = net.JoinHostPort(host, "80")
+			case protoHTTPS, protoWSS:
+				host = net.JoinHostPort(host, "443")
+			default:
+				// Handle unsupported schemes explicitly
+				panic("unsupported scheme: " + u.Scheme)
 			}
 		}
-		return u.Host
+		return host
 	}
-	// otherwise we return the path of the unix socket, ex /tmp/socket
+	// For Unix sockets, return the full path
 	return u.GetHostWithPath()
 }
 

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
 	cmtsync "github.com/tendermint/tendermint/libs/sync"
@@ -24,8 +23,6 @@ const (
 	protoTCP   = "tcp"
 	protoUNIX  = "unix"
 )
-
-var endsWithPortPattern = regexp.MustCompile(`:[0-9]+$`)
 
 // Parsed URL structure
 type parsedURL struct {

--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -44,6 +44,19 @@ func Test_parsedURL(t *testing.T) {
 	}
 
 	tests := map[string]test{
+		"http endpoint": {
+			url:                  "http://example.com",
+			expectedURL:          "http://example.com",
+			expectedHostWithPath: "example.com",
+			expectedDialAddress:  "example.com:80",
+		},
+
+		"http endpoint with port": {
+			url:                  "http://example.com:8080",
+			expectedURL:          "http://example.com:8080",
+			expectedHostWithPath: "example.com:8080",
+			expectedDialAddress:  "example.com:8080",
+		},
 		"unix endpoint": {
 			url:                  "unix:///tmp/test",
 			expectedURL:          "unix://.tmp.test",
@@ -51,21 +64,21 @@ func Test_parsedURL(t *testing.T) {
 			expectedDialAddress:  "/tmp/test",
 		},
 
-		"http endpoint": {
+		"https endpoint": {
 			url:                  "https://example.com",
 			expectedURL:          "https://example.com",
 			expectedHostWithPath: "example.com",
 			expectedDialAddress:  "example.com",
 		},
 
-		"http endpoint with port": {
+		"https endpoint with port": {
 			url:                  "https://example.com:8080",
 			expectedURL:          "https://example.com:8080",
 			expectedHostWithPath: "example.com:8080",
 			expectedDialAddress:  "example.com:8080",
 		},
 
-		"http path routed endpoint": {
+		"https path routed endpoint": {
 			url:                  "https://example.com:8080/rpc",
 			expectedURL:          "https://example.com:8080/rpc",
 			expectedHostWithPath: "example.com:8080/rpc",

--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -68,7 +68,7 @@ func Test_parsedURL(t *testing.T) {
 			url:                  "https://example.com",
 			expectedURL:          "https://example.com",
 			expectedHostWithPath: "example.com",
-			expectedDialAddress:  "example.com",
+			expectedDialAddress:  "example.com:443",
 		},
 
 		"https endpoint with port": {


### PR DESCRIPTION
## Description

fixing this insanely annoying error so we can actually use rpcs