### PR TITLE
Fix typos in documentation

### DIFF
--- a/mempool/cat/spec.md
+++ b/mempool/cat/spec.md
@@ -60,7 +60,7 @@ Given this criteria, it is feasible, yet unlikely that a node receives two `Seen
 
 A `SeenTx` MAY be sent for each transaction currently in the transaction pool when a connection with a peer is first established. This acts as a mechanism for syncing pool state across peers.
 
-The `SeenTx` message MUST only be broadcasted after validation and storage. Although it is possible that a node later drops a transaction under load shedding, a `SeenTx` should give as strong guarantees as possible that the node can be relied upon by others that don't yet have the transcation to obtain it.
+The `SeenTx` message MUST only be broadcasted after validation and storage. Although it is possible that a node later drops a transaction under load shedding, a `SeenTx` should give as strong guarantees as possible that the node can be relied upon by others that don't yet have the transaction to obtain it.
 
 > **Note:**
 > Inbound transactions submitted via the RPC do not trigger a `SeenTx` message as it is assumed that the node is the first to see the transaction and by gossiping it to others it is implied that the node has seen the transaction.

--- a/pkg/trace/README.md
+++ b/pkg/trace/README.md
@@ -15,7 +15,7 @@ trace_push_batch_size = 1000
 
 # The list of tables that are updated when tracing. All available tables and
 # their schema can be found in the pkg/trace/schema package. It is represented as a
-# comma separate string. For example: "consensus_round_state,mempool_tx".
+# comma separated string. For example: "consensus_round_state,mempool_tx".
 tracing_tables = "consensus_round_state,mempool_tx"
 ```
 


### PR DESCRIPTION
## Description

This PR introduces fixes for typos in documentation files:

1. **First Commit:**
   - **File:** `spec.md`
   - **Change:** Fixed the typo `transcation` to `transaction`.
   - **Importance:** Ensures accuracy and clarity in describing transaction-related processes.

2. **Second Commit:**
   - **File:** `README.md`
   - **Change:** Fixed the typo `separate` to `separated`.
   - **Importance:** Maintains consistency in terminology and avoids confusion in the explanation.

These changes improve documentation accuracy and clarity, which is essential for better understanding and avoiding potential misinterpretations by developers.

---

#### PR checklist

- [x] Tests written/updated (N/A for documentation-only updates)
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
