### PR TITLE
Fix Typos and Update Links

### DIFF
--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -13,7 +13,7 @@ Here we cover the following components of ABCI applications:
   and the differences between `CheckTx` and `DeliverTx`.
 - [Transaction Results](#transaction-results) - rules around transaction
   results and validity
-- [Validator Set Updates](#validator-updates) - how validator sets are
+- [Updating the Validator Set](#updating-the-validator-set) - how validator sets are
   changed during `InitChain` and `EndBlock`
 - [Query](#query) - standards for using the `Query` method and proofs about the
   application state
@@ -32,10 +32,10 @@ be synchronized during `Commit`.
 In principle, each of the four ABCI connections operate concurrently with one
 another. This means applications need to ensure access to state is
 thread safe. In practice, both the
-[default in-process ABCI client](https://github.com/cometbft/cometbft/blob/v0.34.4/abci/client/local_client.go#L18)
+[default in-process ABCI client](https://github.com/cometbft/cometbft/blob/main/abci/client/local_client.go#L18)
 and the
 [default Go ABCI
-server](https://github.com/cometbft/cometbft/blob/v0.34.4/abci/server/socket_server.go#L32)
+server](https://github.com/cometbft/cometbft/blob/main/abci/server/socket_server.go#L32)
 use global locks across all connections, so they are not
 concurrent at all. This means if your app is written in Go, and compiled in-process with CometBFT
 using the default `NewLocalClient`, or run out-of-process using the default `SocketServer`,
@@ -137,7 +137,7 @@ returning non-OK ABCI response to either of the following queries will
 cause CometBFT to not connect to the corresponding peer:
 
 - `p2p/filter/addr/<ip addr>`, where `<ip addr>` is an IP address.
-- `p2p/filter/id/<id>`, where `<is>` is the hex-encoded node ID (the hash of
+- `p2p/filter/id/<id>`, where `<id>` is the hex-encoded node ID (the hash of
   the node's p2p pubkey).
 
 Note: these query formats are subject to change!
@@ -166,7 +166,7 @@ the difference credited back. CometBFT adopts a similar abstraction,
 though uses it only optionally and weakly, allowing applications to define
 their own sense of the cost of execution.
 
-In CometBFT, the [ConsensusParams.Block.MaxGas](../proto/types/params.proto) limits the amount of `gas` that can be used in a block.
+In CometBFT, the [ConsensusParams.Block.MaxGas](https://github.com/celestiaorg/celestia-core/blob/v0.34.x-celestia/proto/tendermint/types/params.proto) limits the amount of `gas` that can be used in a block.
 The default value is `-1`, meaning no limit, or that the concept of gas is
 meaningless.
 
@@ -413,7 +413,7 @@ verification of the transactions included in the block, etc.
 The `AppHash` is unique in that it is application specific, and allows for
 application-specific Merkle proofs about the state of the application.
 While some applications keep all relevant state in the transactions themselves
-(like Bitcoin and its UTXOs), others maintain a separated state that is
+(like Bitcoin and its UTXOs), others maintain a separate state that is
 computed deterministically *from* transactions, but is not contained directly in
 the transactions themselves (like Ethereum contracts and accounts).
 For such applications, the `AppHash` provides a much more efficient way to verify light-client proofs.
@@ -480,9 +480,9 @@ implementation of
 
 On startup, CometBFT calls the `Info` method on the Info Connection to get the latest
 committed state of the app. The app MUST return information consistent with the
-last block it succesfully completed Commit for.
+last block it successfully completed Commit for.
 
-If the app succesfully committed block H, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
+If the app successfully committed block H, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
 failed during the Commit of block H, then `last_block_height = H-1` and
 `last_block_app_hash = <hash returned by Commit for block H-1, which is the hash in the header of block H>`.
 
@@ -493,7 +493,7 @@ the app.
 storeBlockHeight = height of the last block CometBFT saw a commit for
 stateBlockHeight = height of the last block for which CometBFT completed all
     block processing and saved all ABCI results to disk
-appBlockHeight = height of the last block for which ABCI app succesfully
+appBlockHeight = height of the last block for which ABCI app successfully
     completed Commit
 
 ```
@@ -537,7 +537,7 @@ If `appBlockHeight == stateBlockHeight`,
 This happens if we crashed before the app finished Commit
 
 If `appBlockHeight == storeBlockHeight`
-    update the state using the saved ABCI responses but dont run the block against the real app.
+    update the state using the saved ABCI responses but don't run the block against the real app.
 This happens if we crashed after the app finished Commit but before CometBFT saved the state.
 
 ## State Sync

--- a/spec/consensus/bft-time.md
+++ b/spec/consensus/bft-time.md
@@ -18,12 +18,12 @@ a faulty process cannot arbitrarily increase the Time value.
 In the context of CometBFT, time is of type int64 and denotes UNIX time in milliseconds, i.e.,
 corresponds to the number of milliseconds since January 1, 1970.
 Before defining rules that need to be enforced by Tendermint, the consensus algorithm adopted in CometBFT,
-so the properties above holds, we introduce the following definition:
+so the properties above hold, we introduce the following definition:
 
 - median of a Commit is equal to the median of `Vote.Time` fields of the `Vote` messages,
 where the value of `Vote.Time` is counted number of times proportional to the process voting power. As
 the voting power is not uniform (one process one vote), a vote message is actually an aggregator of the same votes whose
-number is equal to the voting power of the process that has casted the corresponding votes message.
+number is equal to the voting power of the process that has cast the corresponding votes message.
 
 Let's consider the following example:
 
@@ -39,7 +39,7 @@ Furthermore, we have the following vote messages in some LastCommit field (we ig
 
 We ensure Time Monotonicity and Time Validity properties by the following rules:
   
-- let rs denotes `RoundState` (consensus internal state) of some process. Then
+- let rs denote `RoundState` (consensus internal state) of some process. Then
 `rs.ProposalBlock.Header.Time == median(rs.LastCommit) &&
 rs.Proposal.Timestamp == rs.ProposalBlock.Header.Time`.
 
@@ -50,7 +50,7 @@ rs.Proposal.Timestamp == rs.ProposalBlock.Header.Time`.
         denotes local Unix time in milliseconds
 
     - else if `rs.Proposal` is defined then
-    `vote.Time = max(rs.Proposal.Timestamp + time.Millisecond,, time.Now())`,
+    `vote.Time = max(rs.Proposal.Timestamp + time.Millisecond, time.Now())`,
 
-    - otherwise, `vote.Time = time.Now())`. In this case vote is for `nil` so it is not taken into account for
+    - otherwise, `vote.Time = time.Now()`. In this case vote is for `nil` so it is not taken into account for
     the timestamp of the next block.

--- a/spec/consensus/consensus.md
+++ b/spec/consensus/consensus.md
@@ -62,7 +62,7 @@ parameters over each successive round.
 
 ```md
                          +-------------------------------------+
-                         v                                     |(Wait til `CommmitTime+timeoutCommit`)
+                         v                                     |(Wait til `CommitTime+timeoutCommit`)
                    +-----------+                         +-----+-----+
       +----------> |  Propose  +--------------+          | NewHeight |
       |            +-----------+              |          +-----------+
@@ -315,7 +315,7 @@ adversary.
 For these types of attacks, a subset of the validators through external
 means should coordinate to sign a reorg-proposal that chooses a fork
 (and any evidence thereof) and the initial subset of validators with
-their signatures. Validators who sign such a reorg-proposal forego its
+their signatures. Validators who sign such a reorg-proposal forgo its
 collateral on all other forks. Clients should verify the signatures on
 the reorg-proposal, verify any evidence, and make a judgement or prompt
 the end-user for a decision. For example, a phone wallet app may prompt

--- a/spec/consensus/evidence.md
+++ b/spec/consensus/evidence.md
@@ -4,9 +4,9 @@
 # Evidence
 
 Evidence is an important component of CometBFT's security model. Whilst the core
-consensus protocol provides correctness gaurantees for state machine replication
+consensus protocol provides correctness guarantees for state machine replication
 that can tolerate less than 1/3 failures, the evidence system looks to detect and
-gossip byzantine faults whose combined power is greater than  or equal to 1/3. It is worth noting that
+gossip byzantine faults whose combined power is greater than or equal to 1/3. It is worth noting that
 the evidence system is designed purely to detect possible attacks, gossip them,
 commit them on chain and inform the application running on top of CometBFT.
 Evidence in itself does not punish "bad actors", this is left to the discretion
@@ -74,14 +74,14 @@ type LightClientAttackEvidence struct {
 If a node receives evidence, it will first try to verify it, then persist it.
 Evidence of byzantine behavior should only be committed once (uniqueness) and
 should be committed within a certain period from the point that it occurred
-(timely). Timelines is defined by the `EvidenceParams`: `MaxAgeNumBlocks` and
+(timely). Timeline is defined by the `EvidenceParams`: `MaxAgeNumBlocks` and
 `MaxAgeDuration`. In Proof of Stake chains where validators are bonded, evidence
 age should be less than the unbonding period so validators still can be
-punished. Given these two propoerties the following initial checks are made.
+punished. Given these two properties the following initial checks are made.
 
 1. Has the evidence expired? This is done by taking the height of the `Vote`
    within `DuplicateVoteEvidence` or `CommonHeight` within
-   `LightClientAttakEvidence`. The evidence height is then used to retrieve the
+   `LightClientAttackEvidence`. The evidence height is then used to retrieve the
    header and thus the time of the block that corresponds to the evidence. If
    `CurrentHeight - MaxAgeNumBlocks > EvidenceHeight` && `CurrentTime -
    MaxAgeDuration > EvidenceTime`, the evidence is considered expired and
@@ -126,11 +126,11 @@ Valid Light Client Attack Evidence must adhere to the following rules:
 
 ## Gossiping
 
-If a node verifies evidence it then broadcasts it to all peers, continously sending
+If a node verifies evidence it then broadcasts it to all peers, continuously sending
 the same evidence once every 10 seconds until the evidence is seen on chain or
 expires.
 
-## Commiting on Chain
+## Committing on Chain
 
 Evidence takes strict priority over regular transactions, thus a block is filled
 with evidence first and transactions take up the remainder of the space. To

--- a/spec/consensus/signing.md
+++ b/spec/consensus/signing.md
@@ -151,7 +151,7 @@ these basic validation rules.
 
 Signers must be careful not to sign conflicting messages, also known as "double signing" or "equivocating".
 CometBFT has mechanisms to publish evidence of validators that signed conflicting votes, so they can be punished
-by the application. Note CometBFT does not currently handle evidence of conflciting proposals, though it may in the future.
+by the application. Note CometBFT does not currently handle evidence of conflicting proposals, though it may in the future.
 
 ### State
 


### PR DESCRIPTION
1. Header and Link Corrections:
Changed the section title from "Validator Set Updates" to "Updating the Validator Set"

2.Typo Corrections:
Corrected "it's own" to "its own".
Corrected "succesfully" to "successfully".
Corrected "dont" to "don't".
Corrected "forego" to "forgo".
Corrected "gaurantees" to "guarantees".
Corrected "propoerties" to "properties".
Corrected "continously" to "continuously".
Corrected "Committing" to "Committing".
Corrected "conflciting" to "conflicting".

3. Link Updates:
Updated repository file links from version v0.34.4 to main.(because the links didn't work)

4.Format and Syntax Updates:
Fixed syntax and formatting errors, such as extra commas and brackets.
