### PR TITLE
chore: deprecate timeout_commit and timeout_propose config

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -480,7 +480,7 @@ only_internal_wal = "{{ .Consensus.OnlyInternalWal }}"
 wal_file = "{{ js .Consensus.WalPath }}"
 
 # How long we wait for a proposal block before prevoting nil
-# Deprecated: timeout_commit is overriden by the state machine in app version >= 3.
+# Deprecated: timeout_commit is overridden by the state machine in app version >= 3.
 # Therefore, the value set in this config will be ignored.
 timeout_propose = "{{ .Consensus.TimeoutPropose }}"
 # How much timeout_propose increases with each round

--- a/config/toml.go
+++ b/config/toml.go
@@ -480,6 +480,8 @@ only_internal_wal = "{{ .Consensus.OnlyInternalWal }}"
 wal_file = "{{ js .Consensus.WalPath }}"
 
 # How long we wait for a proposal block before prevoting nil
+# Deprecated: timeout_commit is overriden by the state machine in app version >= 3.
+# Therefore, the value set in this config will be ignored.
 timeout_propose = "{{ .Consensus.TimeoutPropose }}"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "{{ .Consensus.TimeoutProposeDelta }}"
@@ -494,6 +496,8 @@ timeout_precommit_delta = "{{ .Consensus.TimeoutPrecommitDelta }}"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
+# Deprecated: timeout_commit is overriden by the state machine in app version >= 3.
+# Therefore, the value set in this config will be ignored.
 timeout_commit = "{{ .Consensus.TimeoutCommit }}"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus

--- a/config/toml.go
+++ b/config/toml.go
@@ -496,7 +496,7 @@ timeout_precommit_delta = "{{ .Consensus.TimeoutPrecommitDelta }}"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-# Deprecated: timeout_commit is overriden by the state machine in app version >= 3.
+# Deprecated: timeout_commit is overridden by the state machine in app version >= 3.
 # Therefore, the value set in this config will be ignored.
 timeout_commit = "{{ .Consensus.TimeoutCommit }}"
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/1550

## Testing

In celestia-app I replaced celestia-core with this repo. Then created a new config file and observed:

```toml
# How long we wait for a proposal block before prevoting nil
# Deprecated: timeout_commit is overridden by the state machine in app version >= 3.
# Therefore, the value set in this config will be ignored.
timeout_propose = "3.5s"

# How long we wait after committing a block, before starting on the new
# height (this gives us a chance to receive some more precommits, even
# though we already have +2/3).
# Deprecated: timeout_commit is overridden by the state machine in app version >= 3.
# Therefore, the value set in this config will be ignored.
timeout_commit = "4.2s"
```