### PR TITLE
fix typo in ADR 007

### DIFF
--- a/docs/celestia-architecture/adr-007-minimal-changes-to-tendermint.md
+++ b/docs/celestia-architecture/adr-007-minimal-changes-to-tendermint.md
@@ -123,7 +123,7 @@ describe how to hash the block data here:
 - Add PreprocessTxs method to ABCI (https://github.com/celestiaorg/celestia-core/pull/110)
 - Add method to ABCI interface
 - Create sync and async versions
-- Add sync version the CreateProposalBlock method of BlockExecutor
+- Add sync version to the CreateProposalBlock method of BlockExecutor
 
 #### Fill the DAH while making the block
 


### PR DESCRIPTION
**Changes:**
- Fixed a typo in the [ADR 007: Minimal Changes to Tendermint](https://github.com/celestiaorg/celestia-core/blob/v0.34.x-celestia/docs/celestia-architecture/adr-007-minimal-changes-to-tendermint.md)
