### PR TITLE
Refined text by fixing typos and improving clarity

### DIFF
--- a/mempool/v0/doc.go
+++ b/mempool/v0/doc.go
@@ -15,7 +15,7 @@
 // 2. Mutations to the linked-list elements are atomic
 // 3. CheckTx() and/or ReapMaxBytesMaxGas() calls can be paused upon Update(), protected by .updateMtx
 
-// Garbage collection of old elements from mempool.txs is handlde via the
+// Garbage collection of old elements from mempool.txs is handled via the
 // DetachPrev() call, which makes old elements not reachable by peer
 // broadcastTxRoutine().
 

--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -72,7 +72,7 @@ it is already included.
 ### DeliverTx
 
 The `DeliverTx` ABCI method delivers transactions from CometBFT to the application.
-When CometBFT recieves a `ResponseDeliverTx` with a non-zero `Code`, the response code is logged.
+When CometBFT receives a `ResponseDeliverTx` with a non-zero `Code`, the response code is logged.
 The transaction was already included in a block, so the `Code` does not influence
 CometBFT consensus.
 
@@ -411,7 +411,7 @@ the blockchain's `AppHash` which is verified via [light client verification](../
     | Name | Type        | Description                                                                                                                                                                                                                                         | Field Number |
     |------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
     | tx   | bytes       | The request transaction bytes                                                                                                                                                                                                                       | 1            |
-    | type | CheckTxType | One of `CheckTx_New` or `CheckTx_Recheck`. `CheckTx_New` is the default and means that a full check of the tranasaction is required. `CheckTx_Recheck` types are used when the mempool is initiating a normal recheck of a transaction.             | 2            |
+    | type | CheckTxType | One of `CheckTx_New` or `CheckTx_Recheck`. `CheckTx_New` is the default and means that a full check of the transaction is required. `CheckTx_Recheck` types are used when the mempool is initiating a normal recheck of a transaction.             | 2            |
 
 * **Response**:
 


### PR DESCRIPTION
This pull request fixes the following spelling errors:

"handlde" corrected to "handled"
"recieves" corrected to "receives"
"tranasaction" corrected to "transaction"

I hope my correction will contribute to the project's development. Thank you for the time you gave me.