### PR TITLE
fix: typos in documentation files

### DIFF
--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -562,7 +562,7 @@ the blockchain's `AppHash` which is verified via [light client verification](../
 
     | Name  | Type  | Description                                                                                                                                           | Field Number |
     |-------|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
-    | chunk | bytes | The binary chunk contents, in an arbitray format. Chunk messages cannot be larger than 16 MB _including metadata_, so 10 MB is a good starting point. | 1            |
+    | chunk | bytes | The binary chunk contents, in an arbitrary format. Chunk messages cannot be larger than 16 MB _including metadata_, so 10 MB is a good starting point. | 1            |
 
 * **Usage**:
     * Used during state sync to retrieve snapshot chunks from peers.

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -379,7 +379,7 @@ blockchain.
 #### EndBlock
 
 ResponseEndBlock includes a ConsensusParams.
-If ConsensusParams nil, CometBFT will do nothing.
+If ConsensusParams is nil, CometBFT will do nothing.
 If ConsensusParam is not nil, CometBFT will use it.
 This way the application can update the consensus params over time.
 

--- a/spec/consensus/evidence.md
+++ b/spec/consensus/evidence.md
@@ -4,7 +4,7 @@
 # Evidence
 
 Evidence is an important component of CometBFT's security model. Whilst the core
-consensus protocol provides correctness gaurantees for state machine replication
+consensus protocol provides correctness guarantees for state machine replication
 that can tolerate less than 1/3 failures, the evidence system looks to detect and
 gossip byzantine faults whose combined power is greater than  or equal to 1/3. It is worth noting that
 the evidence system is designed purely to detect possible attacks, gossip them,
@@ -77,7 +77,7 @@ should be committed within a certain period from the point that it occurred
 (timely). Timelines is defined by the `EvidenceParams`: `MaxAgeNumBlocks` and
 `MaxAgeDuration`. In Proof of Stake chains where validators are bonded, evidence
 age should be less than the unbonding period so validators still can be
-punished. Given these two propoerties the following initial checks are made.
+punished. Given these two properties the following initial checks are made.
 
 1. Has the evidence expired? This is done by taking the height of the `Vote`
    within `DuplicateVoteEvidence` or `CommonHeight` within
@@ -126,7 +126,7 @@ Valid Light Client Attack Evidence must adhere to the following rules:
 
 ## Gossiping
 
-If a node verifies evidence it then broadcasts it to all peers, continously sending
+If a node verifies evidence it then broadcasts it to all peers, continuously sending
 the same evidence once every 10 seconds until the evidence is seen on chain or
 expires.
 

--- a/spec/consensus/proposer-based-timestamp/pbts-algorithm_001_draft.md
+++ b/spec/consensus/proposer-based-timestamp/pbts-algorithm_001_draft.md
@@ -148,7 +148,7 @@ upon ⟨PROPOSAL, h_p, r, (v,t), ∗⟩ from proposer(h_p, r) AND 2f + 1 ⟨PREC
 }
 ```
 
-**All other rules remains unchanged.**
+**All other rules remain unchanged.**
 
 Back to [main document][main].
 

--- a/spec/consensus/proposer-based-timestamp/pbts_001_draft.md
+++ b/spec/consensus/proposer-based-timestamp/pbts_001_draft.md
@@ -21,7 +21,7 @@ In CometBFT, the first version of how time is computed and stored in a block wor
 1. **Liveness.** The liveness of the protocol:
    1. does not depend on clock synchronization,
    1. depends on bounded message delays.
-1. **Relation to real time.** There is no clock synchronizaton, which implies that there is **no relation** between the computed block `time` and real time.
+1. **Relation to real time.** There is no clock synchronization, which implies that there is **no relation** between the computed block `time` and real time.
 1. **Aggregate signatures.** As the `precommit` messages contain the local times, all these `precommit` messages typically differ in the time field, which **prevents** the use of aggregate signatures.
 
 ## Suggested Proposer-Based Time


### PR DESCRIPTION
This PR fixes several typos in documentation files.
