### PR TITLE
fix(mempool/cat): TestReactorEventuallyRemovesExpiredTransaction flaky test

### DIFF
--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -239,8 +239,11 @@ func TestReactorEventuallyRemovesExpiredTransaction(t *testing.T) {
 	require.True(t, reactor.mempool.Has(key))
 
 	// wait for the transaction to expire
-	time.Sleep(reactor.mempool.config.TTLDuration * 2)
-	require.False(t, reactor.mempool.Has(key))
+	require.Eventually(t,
+		func() bool { return !reactor.mempool.Has(key) },
+		4*reactor.mempool.config.TTLDuration,
+		50*time.Millisecond,
+		"transaction was not removed after TTL expired")
 }
 
 func TestLegacyReactorReceiveBasic(t *testing.T) {


### PR DESCRIPTION
## Description

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

Closes #1131 

Relax the time constrain for testing the eventual expiring of transactions. 


#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

