### PR TITLE
docs: fix typos

### DIFF
--- a/mempool/cat/spec.md
+++ b/mempool/cat/spec.md
@@ -36,7 +36,7 @@ message WantTx {
 }
 ```
 
-Both `SeenTx` and `WantTx` contain the sha256 hash of the raw transaction bytes. `SeenTx` also contains an optional `p2p.ID` that corresponds to the peer that the node recieved the tx from. The only validation for both is that the byte slice of the `tx_key` MUST have a length of 32.
+Both `SeenTx` and `WantTx` contain the sha256 hash of the raw transaction bytes. `SeenTx` also contains an optional `p2p.ID` that corresponds to the peer that the node received the tx from. The only validation for both is that the byte slice of the `tx_key` MUST have a length of 32.
 
 Both messages are sent across a new channel with the ID: `byte(0x31)`. This enables cross compatibility as discussed in greater detail below.
 
@@ -75,7 +75,7 @@ Transaction pools are solely run in-memory; thus when a node stops, all transact
 
 Upon receiving a `Txs` message:
 
-- Check whether it is in reponse to a request or simply an unsolicited broadcast
+- Check whether it is in response to a request or simply an unsolicited broadcast
 - Validate the tx against current resources and the applications `CheckTx`
 - If rejected or evicted, mark accordingly
 - If successful, send a `SeenTx` message to all connected peers excluding the original sender. If it was from an initial broadcast, the `SeenTx` should populate the `From` field with the `p2p.ID` of the recipient else if it is in response to a request `From` should remain empty.

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -54,7 +54,7 @@ type Call struct {
 	Error    error
 }
 
-// GetResponse will generate the apporiate response for us, when
+// GetResponse will generate the appropriate response for us, when
 // using the Call struct to configure a Mock handler.
 //
 // When configuring a response, if only one of Response or Error is


### PR DESCRIPTION
# Fix: Corrected typos in source and documentation files

## Changes
1. **Corrected typo in `mempool/cat/spec.md:78`**:
   - "reponse" corrected to "response".

2. **Corrected typo in `mempool/cat/spec.md:39`**:
   - "recieved" corrected to "received".

3. **Corrected typo in `rpc/client/mock/client.go:57`**:
   - "apporiate" corrected to "appropriate".

## Purpose
- Improved code and documentation accuracy by fixing typos.

