### PR TITLE
docs: fix typos

### DIFF
--- a/crypto/merkle/README.md
+++ b/crypto/merkle/README.md
@@ -1,4 +1,5 @@
 # Merkle Tree
 
-For smaller static data structures that don't require immutable snapshots or mutability; 
-for instance the transactions and validation signatures of a block can be hashed using this simple merkle tree logic.
+For smaller static data structures that don't require immutable snapshots or mutability.
+
+For instance, the transactions and validation signatures of a block can be hashed using this simple merkle tree logic.

--- a/mempool/cat/spec.md
+++ b/mempool/cat/spec.md
@@ -36,7 +36,7 @@ message WantTx {
 }
 ```
 
-Both `SeenTx` and `WantTx` contain the sha256 hash of the raw transaction bytes. `SeenTx` also contains an optional `p2p.ID` that corresponds to the peer that the node recieved the tx from. The only validation for both is that the byte slice of the `tx_key` MUST have a length of 32.
+Both `SeenTx` and `WantTx` contain the sha256 hash of the raw transaction bytes. `SeenTx` also contains an optional `p2p.ID` that corresponds to the peer that the node received the tx from. The only validation for both is that the byte slice of the `tx_key` MUST have a length of 32.
 
 Both messages are sent across a new channel with the ID: `byte(0x31)`. This enables cross compatibility as discussed in greater detail below.
 

--- a/pkg/trace/schema/misc.go
+++ b/pkg/trace/schema/misc.go
@@ -26,7 +26,7 @@ type ABCI struct {
 	Round     int32  `json:"round"`
 }
 
-// Table returns the table name for the ABCI struct and fullfills the
+// Table returns the table name for the ABCI struct and fulfills the
 // trace.Entry interface.
 func (m ABCI) Table() string {
 	return ABCITable

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -480,9 +480,9 @@ implementation of
 
 On startup, CometBFT calls the `Info` method on the Info Connection to get the latest
 committed state of the app. The app MUST return information consistent with the
-last block it succesfully completed Commit for.
+last block it successfully completed Commit for.
 
-If the app succesfully committed block H, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
+If the app successfully committed block H, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
 failed during the Commit of block H, then `last_block_height = H-1` and
 `last_block_app_hash = <hash returned by Commit for block H-1, which is the hash in the header of block H>`.
 
@@ -493,7 +493,7 @@ the app.
 storeBlockHeight = height of the last block CometBFT saw a commit for
 stateBlockHeight = height of the last block for which CometBFT completed all
     block processing and saved all ABCI results to disk
-appBlockHeight = height of the last block for which ABCI app succesfully
+appBlockHeight = height of the last block for which ABCI app successfully
     completed Commit
 
 ```

--- a/spec/consensus/consensus-paper/IEEEtran.cls
+++ b/spec/consensus/consensus-paper/IEEEtran.cls
@@ -268,7 +268,7 @@
 \newtoks\@IEEEtrantmptoksA
 
 % we use \CLASSOPTIONpt so that we can ID the point size (even for 9pt docs)
-% as well as LaTeX's \@ptsize to retain some compatability with some
+% as well as LaTeX's \@ptsize to retain some compatibility with some
 % external packages
 \def\@ptsize{0}
 % LaTeX does not support 9pt, so we set \@ptsize to 0 - same as that of 10pt

--- a/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_001_draft.tla
+++ b/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_001_draft.tla
@@ -499,7 +499,7 @@ MessageProcessing(p) ==
     \/ OnRoundCatchup(p)
 
 (*
- * A system transition. In this specificatiom, the system may eventually deadlock,
+ * A system transition. In this specification, the system may eventually deadlock,
  * e.g., when all processes decide. This is expected behavior, as we focus on safety.
  *)
 Next ==

--- a/spec/p2p/messages/state-sync.md
+++ b/spec/p2p/messages/state-sync.md
@@ -108,7 +108,7 @@ In order to build the state, the state provider will request the params at the h
 
 ### ParamsResponse
 
-A reciever to the request will use the state store to fetch the consensus params at that height and return it to the sender.
+A receiver to the request will use the state store to fetch the consensus params at that height and return it to the sender.
 
 | Name     | Type   | Description                     | Field Number |
 |----------|--------|---------------------------------|--------------|


### PR DESCRIPTION
Fix typos, such as:
- Recieved -> Received
- Fullfils -> Fulfills