### PR TITLE
test: fix `TestTxPool_ExpiredTxs_Timestamp` flake

### DIFF
--- a/mempool/cat/pool_test.go
+++ b/mempool/cat/pool_test.go
@@ -553,16 +553,11 @@ func TestTxPool_ExpiredTxs_Timestamp(t *testing.T) {
 
 	// Wait a while, then add some more transactions that should not be expired
 	// when the first batch TTLs out.
-	//
-	// ms: 0   1   2   3   4   5   6
-	//     ^           ^       ^   ^
-	//     |           |       |   +-- Update (triggers pruning)
-	//     |           |       +------ first batch expires
-	//     |           +-------------- second batch added
-	//     +-------------------------- first batch added
-	//
-	// The exact intervals are not important except that the delta should be
-	// large relative to the cost of CheckTx (ms vs. ns is fine here).
+	// Because the TTL is 5ms which is very short, we need to have a more precise
+	// pruning interval to ensure that the transactions are expired
+	// so that the expired event is caught quickly enough
+	// that the second batch of transactions are not expired.
+
 	time.Sleep(2500 * time.Microsecond)
 	added2 := checkTxs(t, txmp, 10, 1)
 

--- a/mempool/cat/pool_test.go
+++ b/mempool/cat/pool_test.go
@@ -563,30 +563,35 @@ func TestTxPool_ExpiredTxs_Timestamp(t *testing.T) {
 	//
 	// The exact intervals are not important except that the delta should be
 	// large relative to the cost of CheckTx (ms vs. ns is fine here).
-	time.Sleep(3 * time.Millisecond)
+	time.Sleep(2500 * time.Microsecond)
 	added2 := checkTxs(t, txmp, 10, 1)
 
-	// Wait a while longer, so that the first batch will expire.
-	time.Sleep(3 * time.Millisecond)
+	// use require.Eventually to wait for the TTL to expire
+	require.Eventually(t, func() bool {
+		// Trigger an update so that pruning will occur.
+		txmp.Lock()
+		defer txmp.Unlock()
+		require.NoError(t, txmp.Update(txmp.height+1, nil, nil, nil, nil))
 
-	// Trigger an update so that pruning will occur.
-	txmp.Lock()
-	defer txmp.Unlock()
-	require.NoError(t, txmp.Update(txmp.height+1, nil, nil, nil, nil))
+		// All the transactions in the original set should have been purged.
+		for _, tx := range added1 {
+			// Check that it was added to the evictedTxCache
+			evicted := txmp.WasRecentlyEvicted(tx.tx.Key())
+			if !evicted {
+				return false
+			}
 
-	// All the transactions in the original set should have been purged.
-	for _, tx := range added1 {
-		// Check that it was added to the evictedTxCache
-		evicted := txmp.WasRecentlyEvicted(tx.tx.Key())
-		require.True(t, evicted)
-
-		if txmp.store.has(tx.tx.Key()) {
-			t.Errorf("Transaction %X should have been purged for TTL", tx.tx.Key())
+			if txmp.store.has(tx.tx.Key()) {
+				t.Errorf("Transaction %X should have been purged for TTL", tx.tx.Key())
+				return false
+			}
+			if txmp.rejectedTxCache.Has(tx.tx.Key()) {
+				t.Errorf("Transaction %X should have been removed from the cache", tx.tx.Key())
+				return false
+			}
 		}
-		if txmp.rejectedTxCache.Has(tx.tx.Key()) {
-			t.Errorf("Transaction %X should have been removed from the cache", tx.tx.Key())
-		}
-	}
+		return true
+	}, 10*time.Millisecond, 50*time.Microsecond)
 
 	// All the transactions added later should still be around.
 	for _, tx := range added2 {


### PR DESCRIPTION
## Description

Closes #1207  

## Rationale
After a lot of trial and errors and some research, the rationale behind this change of flaky test is: 

Because the TTL is 5ms which is very short, we need to have a more precise pruning interval to ensure that the transactions are expired, so that the expired event is caught quickly enough, while the second batch of transactions are not expired to prevent flaky behaviors.


## Testing method 
```go test -run TestTxPool_ExpiredTxs_Timestamp github.com/tendermint/tendermint/mempool/cat -mod=readonly -race -count 100```

I run this command 200 times and see no failing one, which is kind of reliable compare to failing rate of 15-20% of old implemetation 


---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

