### PR TITLE
chore: fix typos

### DIFF
--- a/mempool/cat/spec.md
+++ b/mempool/cat/spec.md
@@ -36,7 +36,7 @@ message WantTx {
 }
 ```
 
-Both `SeenTx` and `WantTx` contain the sha256 hash of the raw transaction bytes. `SeenTx` also contains an optional `p2p.ID` that corresponds to the peer that the node recieved the tx from. The only validation for both is that the byte slice of the `tx_key` MUST have a length of 32.
+Both `SeenTx` and `WantTx` contain the sha256 hash of the raw transaction bytes. `SeenTx` also contains an optional `p2p.ID` that corresponds to the peer that the node received the tx from. The only validation for both is that the byte slice of the `tx_key` MUST have a length of 32.
 
 Both messages are sent across a new channel with the ID: `byte(0x31)`. This enables cross compatibility as discussed in greater detail below.
 
@@ -75,7 +75,7 @@ Transaction pools are solely run in-memory; thus when a node stops, all transact
 
 Upon receiving a `Txs` message:
 
-- Check whether it is in reponse to a request or simply an unsolicited broadcast
+- Check whether it is in response to a request or simply an unsolicited broadcast
 - Validate the tx against current resources and the applications `CheckTx`
 - If rejected or evicted, mark accordingly
 - If successful, send a `SeenTx` message to all connected peers excluding the original sender. If it was from an initial broadcast, the `SeenTx` should populate the `From` field with the `p2p.ID` of the recipient else if it is in response to a request `From` should remain empty.

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -480,9 +480,9 @@ implementation of
 
 On startup, CometBFT calls the `Info` method on the Info Connection to get the latest
 committed state of the app. The app MUST return information consistent with the
-last block it succesfully completed Commit for.
+last block it successfully completed Commit for.
 
-If the app succesfully committed block H, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
+If the app successfully committed block H, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
 failed during the Commit of block H, then `last_block_height = H-1` and
 `last_block_app_hash = <hash returned by Commit for block H-1, which is the hash in the header of block H>`.
 
@@ -493,7 +493,7 @@ the app.
 storeBlockHeight = height of the last block CometBFT saw a commit for
 stateBlockHeight = height of the last block for which CometBFT completed all
     block processing and saved all ABCI results to disk
-appBlockHeight = height of the last block for which ABCI app succesfully
+appBlockHeight = height of the last block for which ABCI app successfully
     completed Commit
 
 ```

--- a/spec/p2p/messages/state-sync.md
+++ b/spec/p2p/messages/state-sync.md
@@ -108,7 +108,7 @@ In order to build the state, the state provider will request the params at the h
 
 ### ParamsResponse
 
-A reciever to the request will use the state store to fetch the consensus params at that height and return it to the sender.
+A receiver to the request will use the state store to fetch the consensus params at that height and return it to the sender.
 
 | Name     | Type   | Description                     | Field Number |
 |----------|--------|---------------------------------|--------------|


### PR DESCRIPTION
Corrected `recieved` to `received`
Corrected `reponse` to `response`
Corrected `succesfully` to `successfully` x3.
Corrected `reciever` to `receiver` 