### PR TITLE
test(abci): Expand test coverage for WriteMessage and ReadMessage

### DIFF
--- a/abci/types/messages_test.go
+++ b/abci/types/messages_test.go
@@ -65,19 +65,95 @@ func TestWriteReadMessage(t *testing.T) {
 			Height:  4,
 			ChainID: "test",
 		},
-		// TODO: add the rest
+		// Expanded test cases covering various ABCI message types
+		&RequestCheckTx{
+			Tx:   []byte("transaction data"),
+			Type: CheckTxType_New,
+		},
+		&ResponseCheckTx{
+			Code:      1,
+			Data:      []byte("response data"),
+			GasWanted: 1000,
+			GasUsed:   500,
+			Events: []Event{
+				{
+					Type: "test_event",
+					Attributes: []EventAttribute{
+						{Key: []byte("key1"), Value: []byte("value1")},
+						{Key: []byte("key2"), Value: []byte("value2")},
+					},
+				},
+			},
+		},
+		&RequestDeliverTx{
+			Tx: []byte("deliver transaction"),
+		},
+		&ResponseDeliverTx{
+			Code:      0,
+			Data:      []byte("delivery successful"),
+			GasWanted: 2000,
+			GasUsed:   1500,
+		},
+		&RequestBeginBlock{
+			Hash: []byte("block hash"),
+			Header: cmtproto.Header{
+				Height:  100,
+				ChainID: "test-chain",
+			},
+			LastCommitInfo: LastCommitInfo{
+				Round: 0,
+				Votes: []VoteInfo{
+					{
+						Validator: Validator{
+							Address: []byte("validator address"),
+							Power:   1000,
+						},
+						SignedLastBlock: true,
+					},
+				},
+			},
+		},
+		&ResponseBeginBlock{
+			Events: []Event{
+				{
+					Type: "block_begin",
+					Attributes: []EventAttribute{
+						{Key: []byte("block"), Value: []byte("started")},
+					},
+				},
+			},
+		},
+		&RequestEndBlock{
+			Height: 150,
+		},
+		&ResponseEndBlock{
+			ValidatorUpdates: []ValidatorUpdate{
+				{
+					Power: 500,
+				},
+			},
+			Events: []Event{
+				{
+					Type: "block_end",
+					Attributes: []EventAttribute{
+						{Key: []byte("block"), Value: []byte("completed")},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
 		buf := new(bytes.Buffer)
 		err := WriteMessage(c, buf)
-		assert.Nil(t, err)
+		assert.Nil(t, err, "Failed to write message of type %T", c)
 
-		msg := new(cmtproto.Header)
+		// Create a new message of the same type to read into
+		msg := proto.Clone(c)
 		err = ReadMessage(buf, msg)
-		assert.Nil(t, err)
+		assert.Nil(t, err, "Failed to read message of type %T", c)
 
-		assert.True(t, proto.Equal(c, msg))
+		assert.True(t, proto.Equal(c, msg), "Message of type %T not equal after write and read", c)
 	}
 }
 
@@ -97,18 +173,93 @@ func TestWriteReadMessage2(t *testing.T) {
 				},
 			},
 		},
-		// TODO: add the rest
+		&RequestDeliverTx{
+			Tx: []byte("transaction payload"),
+		},
+		&ResponseDeliverTx{
+			Code:      0,
+			Data:      []byte("delivery successful"),
+			Log:       "Transaction processed",
+			GasWanted: 100,
+			GasUsed:   50,
+			Events: []Event{
+				{
+					Type: "transfer",
+					Attributes: []EventAttribute{
+						{Key: []byte("recipient"), Value: []byte("address1")},
+						{Key: []byte("amount"), Value: []byte("1000")},
+					},
+				},
+			},
+		},
+		&RequestBeginBlock{
+			Hash: []byte("block-hash"),
+			Header: cmtproto.Header{
+				Height:  1000,
+				ChainID: "celestia-testnet",
+			},
+			LastCommitInfo: LastCommitInfo{
+				Round: 0,
+				Votes: []VoteInfo{
+					{
+						Validator: Validator{
+							Address: []byte("validator-address"),
+							Power:   1000,
+						},
+						SignedLastBlock: true,
+					},
+				},
+			},
+		},
+		&ResponseBeginBlock{
+			Events: []Event{
+				{
+					Type: "block_begin",
+					Attributes: []EventAttribute{
+						{Key: []byte("block_height"), Value: []byte("1000")},
+						{Key: []byte("proposer"), Value: []byte("validator-address")},
+					},
+				},
+			},
+		},
+		&RequestEndBlock{
+			Height: 1001,
+		},
+		&ResponseEndBlock{
+			ValidatorUpdates: []ValidatorUpdate{
+				{
+					Power: 1200,
+				},
+			},
+			ConsensusParamUpdates: nil,
+			Events: []Event{
+				{
+					Type: "block_end",
+					Attributes: []EventAttribute{
+						{Key: []byte("block_height"), Value: []byte("1001")},
+						{Key: []byte("status"), Value: []byte("completed")},
+					},
+				},
+			},
+		},
+		&RequestEcho{
+			Message: "ping",
+		},
+		&ResponseEcho{
+			Message: "pong",
+		},
 	}
 
 	for _, c := range cases {
 		buf := new(bytes.Buffer)
 		err := WriteMessage(c, buf)
-		assert.Nil(t, err)
+		assert.Nil(t, err, "Failed to write message of type %T", c)
 
-		msg := new(ResponseCheckTx)
+		// Create a new message of the same type to read into
+		msg := proto.Clone(c)
 		err = ReadMessage(buf, msg)
-		assert.Nil(t, err)
+		assert.Nil(t, err, "Failed to read message of type %T", c)
 
-		assert.True(t, proto.Equal(c, msg))
+		assert.True(t, proto.Equal(c, msg), "Message of type %T not equal after write and read", c)
 	}
 }


### PR DESCRIPTION
## Description

feat(abci): Expand test coverage for WriteMessage and ReadMessage

- Add comprehensive test cases for ABCI message types in TestWriteReadMessage
- Include more diverse scenarios for message serialization and deserialization
- Improve error messaging in test assertions
- Cover `RequestCheckTx`, `ResponseCheckTx`, `RequestDeliverTx`, `ResponseDeliverTx`,
  `RequestBeginBlock`, `ResponseBeginBlock`, `RequestEndBlock`, `ResponseEndBlock`,
  and `RequestEcho`, `ResponseEcho` message types

Closes // TODO:

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

