### PR TITLE
fix: mempool locking mechanism in v1 and cat

### DIFF
--- a/mempool/cat/pool.go
+++ b/mempool/cat/pool.go
@@ -127,12 +127,12 @@ func WithMetrics(metrics *mempool.Metrics) TxPoolOption {
 	return func(txmp *TxPool) { txmp.metrics = metrics }
 }
 
-// Lock is a noop as ABCI calls are serialized
+// Lock locks the mempool, no new transactions can be processed
 func (txmp *TxPool) Lock() {
 	txmp.mtx.Lock()
 }
 
-// Unlock is a noop as ABCI calls are serialized
+// Unlock unlocks the mempool
 func (txmp *TxPool) Unlock() {
 	txmp.mtx.Unlock()
 }

--- a/mempool/cat/store.go
+++ b/mempool/cat/store.go
@@ -1,6 +1,8 @@
 package cat
 
 import (
+	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 type store struct {
 	mtx         sync.RWMutex
 	bytes       int64
+	orderedTxs  []*wrappedTx
 	txs         map[types.TxKey]*wrappedTx
 	reservedTxs map[types.TxKey]struct{}
 }
@@ -18,6 +21,7 @@ type store struct {
 func newStore() *store {
 	return &store{
 		bytes:       0,
+		orderedTxs:  make([]*wrappedTx, 0),
 		txs:         make(map[types.TxKey]*wrappedTx),
 		reservedTxs: make(map[types.TxKey]struct{}),
 	}
@@ -31,6 +35,7 @@ func (s *store) set(wtx *wrappedTx) bool {
 	defer s.mtx.Unlock()
 	if _, exists := s.txs[wtx.key]; !exists {
 		s.txs[wtx.key] = wtx
+		s.orderTx(wtx)
 		s.bytes += wtx.size()
 		return true
 	}
@@ -58,6 +63,9 @@ func (s *store) remove(txKey types.TxKey) bool {
 		return false
 	}
 	s.bytes -= tx.size()
+	if err := s.deleteOrderedTx(tx); err != nil {
+		panic(err)
+	}
 	delete(s.txs, txKey)
 	return true
 }
@@ -131,10 +139,13 @@ func (s *store) getTxsBelowPriority(priority int64) ([]*wrappedTx, int64) {
 	defer s.mtx.RUnlock()
 	txs := make([]*wrappedTx, 0, len(s.txs))
 	bytes := int64(0)
-	for _, tx := range s.txs {
+	for i := len(s.orderedTxs) - 1; i >= 0; i-- {
+		tx := s.orderedTxs[i]
 		if tx.priority < priority {
 			txs = append(txs, tx)
 			bytes += tx.size()
+		} else {
+			break
 		}
 	}
 	return txs, bytes
@@ -165,4 +176,41 @@ func (s *store) reset() {
 	defer s.mtx.Unlock()
 	s.bytes = 0
 	s.txs = make(map[types.TxKey]*wrappedTx)
+	s.orderedTxs = make([]*wrappedTx, 0)
+}
+
+func (s *store) orderTx(tx *wrappedTx) {
+	idx := s.getTxOrder(tx)
+	s.orderedTxs = append(s.orderedTxs[:idx], append([]*wrappedTx{tx}, s.orderedTxs[idx:]...)...)
+}
+
+func (s *store) deleteOrderedTx(tx *wrappedTx) error {
+	if len(s.orderedTxs) == 0 {
+		return fmt.Errorf("ordered transactions list is empty")
+	}
+	idx := s.getTxOrder(tx) - 1
+	if idx >= len(s.orderedTxs) || s.orderedTxs[idx] != tx {
+		return fmt.Errorf("transaction %X not found in ordered list", tx.key)
+	}
+	s.orderedTxs = append(s.orderedTxs[:idx], s.orderedTxs[idx+1:]...)
+	return nil
+}
+
+func (s *store) getTxOrder(tx *wrappedTx) int {
+	return sort.Search(len(s.orderedTxs), func(i int) bool {
+		if s.orderedTxs[i].priority == tx.priority {
+			return tx.timestamp.Before(s.orderedTxs[i].timestamp)
+		}
+		return s.orderedTxs[i].priority < tx.priority
+	})
+}
+
+func (s *store) iterateOrderedTxs(fn func(tx *wrappedTx) bool) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	for _, tx := range s.orderedTxs {
+		if !fn(tx) {
+			break
+		}
+	}
 }

--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -74,6 +74,50 @@ func TestStoreOrdering(t *testing.T) {
 	require.Equal(t, wtx1, orderedTxs[2])
 }
 
+func TestStore(t *testing.T) {
+	t.Run("deleteOrderedTx", func(*testing.T) {
+		store := newStore()
+
+		tx1 := types.Tx("tx1")
+		tx2 := types.Tx("tx2")
+		tx3 := types.Tx("tx3")
+
+		// Create wrapped txs with different priorities
+		wtx1 := newWrappedTx(tx1, tx1.Key(), 1, 1, 1, "")
+		wtx2 := newWrappedTx(tx2, tx2.Key(), 2, 2, 2, "")
+		wtx3 := newWrappedTx(tx3, tx3.Key(), 3, 3, 3, "")
+
+		// Add txs in reverse priority order
+		store.set(wtx1)
+		store.set(wtx2)
+		store.set(wtx3)
+
+		orderedTxs := getOrderedTxs(store)
+		require.Equal(t, []*wrappedTx{wtx3, wtx2, wtx1}, orderedTxs)
+
+		store.deleteOrderedTx(wtx2)
+		require.Equal(t, []*wrappedTx{wtx3, wtx1}, getOrderedTxs(store))
+
+		store.deleteOrderedTx(wtx3)
+		require.Equal(t, []*wrappedTx{wtx1}, getOrderedTxs(store))
+
+		store.deleteOrderedTx(wtx1)
+		require.Equal(t, []*wrappedTx{}, getOrderedTxs(store))
+
+		err := store.deleteOrderedTx(wtx1)
+		require.ErrorContains(t, err, "ordered transactions list is empty")
+	})
+}
+
+func getOrderedTxs(store *store) []*wrappedTx {
+	orderedTxs := []*wrappedTx{}
+	store.iterateOrderedTxs(func(tx *wrappedTx) bool {
+		orderedTxs = append(orderedTxs, tx)
+		return true
+	})
+	return orderedTxs
+}
+
 func TestStoreReservingTxs(t *testing.T) {
 	store := newStore()
 

--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -70,7 +70,7 @@ func TestStoreOrdering(t *testing.T) {
 
 	require.Equal(t, 3, len(orderedTxs))
 	require.Equal(t, wtx3, orderedTxs[0])
-	require.Equal(t, wtx2, orderedTxs[1]) 
+	require.Equal(t, wtx2, orderedTxs[1])
 	require.Equal(t, wtx1, orderedTxs[2])
 }
 

--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -95,16 +95,19 @@ func TestStore(t *testing.T) {
 		orderedTxs := getOrderedTxs(store)
 		require.Equal(t, []*wrappedTx{wtx3, wtx2, wtx1}, orderedTxs)
 
-		store.deleteOrderedTx(wtx2)
+		err := store.deleteOrderedTx(wtx2)
+		require.NoError(t, err)
 		require.Equal(t, []*wrappedTx{wtx3, wtx1}, getOrderedTxs(store))
 
-		store.deleteOrderedTx(wtx3)
+		err = store.deleteOrderedTx(wtx3)
+		require.NoError(t, err)
 		require.Equal(t, []*wrappedTx{wtx1}, getOrderedTxs(store))
 
-		store.deleteOrderedTx(wtx1)
+		err = store.deleteOrderedTx(wtx1)
+		require.NoError(t, err)
 		require.Equal(t, []*wrappedTx{}, getOrderedTxs(store))
 
-		err := store.deleteOrderedTx(wtx1)
+		err = store.deleteOrderedTx(wtx1)
 		require.ErrorContains(t, err, "ordered transactions list is empty")
 	})
 }

--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -40,6 +40,38 @@ func TestStoreSimple(t *testing.T) {
 	require.Nil(t, store.get(key))
 	require.Zero(t, store.size())
 	require.Zero(t, store.totalBytes())
+	require.Empty(t, store.orderedTxs)
+	require.Empty(t, store.txs)
+}
+
+func TestStoreOrdering(t *testing.T) {
+	store := newStore()
+
+	tx1 := types.Tx("tx1")
+	tx2 := types.Tx("tx2")
+	tx3 := types.Tx("tx3")
+
+	// Create wrapped txs with different priorities
+	wtx1 := newWrappedTx(tx1, tx1.Key(), 1, 1, 1, "")
+	wtx2 := newWrappedTx(tx2, tx2.Key(), 2, 2, 2, "")
+	wtx3 := newWrappedTx(tx3, tx3.Key(), 3, 3, 3, "")
+
+	// Add txs in reverse priority order
+	store.set(wtx1)
+	store.set(wtx2)
+	store.set(wtx3)
+
+	// Check that iteration returns txs in correct priority order
+	var orderedTxs []*wrappedTx
+	store.iterateOrderedTxs(func(tx *wrappedTx) bool {
+		orderedTxs = append(orderedTxs, tx)
+		return true
+	})
+
+	require.Equal(t, 3, len(orderedTxs))
+	require.Equal(t, wtx3, orderedTxs[0])
+	require.Equal(t, wtx2, orderedTxs[1]) 
+	require.Equal(t, wtx1, orderedTxs[2])
 }
 
 func TestStoreReservingTxs(t *testing.T) {

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -185,49 +185,43 @@ func (txmp *TxMempool) TxsAvailable() <-chan struct{} { return txmp.txsAvailable
 // the size of tx, and adds tx instead. If no such transactions exist, tx is
 // discarded.
 func (txmp *TxMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo mempool.TxInfo) error {
-
 	// During the initial phase of CheckTx, we do not need to modify any state.
-	// A transaction will not actually be added to the mempool until it survives
-	// a call to the ABCI CheckTx method and size constraint checks.
-	height, err := func() (int64, error) {
-		txmp.mtx.RLock()
-		defer txmp.mtx.RUnlock()
 
-		// Reject transactions in excess of the configured maximum transaction size.
-		if len(tx) > txmp.config.MaxTxBytes {
-			return 0, mempool.ErrTxTooLarge{Max: txmp.config.MaxTxBytes, Actual: len(tx)}
+	// Reject transactions in excess of the configured maximum transaction size.
+	if len(tx) > txmp.config.MaxTxBytes {
+		return mempool.ErrTxTooLarge{Max: txmp.config.MaxTxBytes, Actual: len(tx)}
+	}
+
+	// If a precheck hook is defined, call it before invoking the application.
+	if txmp.preCheck != nil {
+		if err := txmp.preCheck(tx); err != nil {
+			txmp.metrics.FailedTxs.Add(1)
+			return mempool.ErrPreCheck{Reason: err}
 		}
+	}
 
-		// If a precheck hook is defined, call it before invoking the application.
-		if txmp.preCheck != nil {
-			if err := txmp.preCheck(tx); err != nil {
-				txmp.metrics.FailedTxs.Add(1)
-				return 0, mempool.ErrPreCheck{Reason: err}
-			}
-		}
-
-		// Early exit if the proxy connection has an error.
-		if err := txmp.proxyAppConn.Error(); err != nil {
-			return 0, err
-		}
-
-		txKey := tx.Key()
-
-		// Check for the transaction in the cache.
-		if !txmp.cache.Push(tx) {
-			// If the cached transaction is also in the pool, record its sender.
-			if elt, ok := txmp.txByKey[txKey]; ok {
-				txmp.metrics.AlreadySeenTxs.Add(1)
-				w := elt.Value.(*WrappedTx)
-				w.SetPeer(txInfo.SenderID)
-			}
-			return 0, mempool.ErrTxInCache
-		}
-		return txmp.height, nil
-	}()
-	if err != nil {
+	// Early exit if the proxy connection has an error.
+	if err := txmp.proxyAppConn.Error(); err != nil {
 		return err
 	}
+
+	txKey := tx.Key()
+
+	// Check for the transaction in the cache.
+	if !txmp.cache.Push(tx) {
+		// If the cached transaction is also in the pool, record its sender.
+		if elt, ok := txmp.txByKey[txKey]; ok {
+			txmp.metrics.AlreadySeenTxs.Add(1)
+			w := elt.Value.(*WrappedTx)
+			w.SetPeer(txInfo.SenderID)
+		}
+		return mempool.ErrTxInCache
+	}
+
+	// At this point, we need to ensure that passing CheckTx and adding to
+	// the mempool is atomic.
+	txmp.Lock()
+	defer txmp.Unlock()
 
 	// Invoke an ABCI CheckTx for this transaction.
 	rsp, err := txmp.proxyAppConn.CheckTxSync(abci.RequestCheckTx{Tx: tx})
@@ -239,9 +233,10 @@ func (txmp *TxMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo memp
 		tx:        tx,
 		hash:      tx.Key(),
 		timestamp: time.Now().UTC(),
-		height:    height,
+		height:    txmp.height,
 	}
 	wtx.SetPeer(txInfo.SenderID)
+	// This won't add the transaction if the response code is non zero (i.e. there was an error)
 	txmp.addNewTransaction(wtx, rsp)
 	if cb != nil {
 		cb(&abci.Response{Value: &abci.Response_CheckTx{CheckTx: rsp}})
@@ -479,9 +474,6 @@ func (txmp *TxMempool) Update(
 //
 // Finally, the new transaction is added and size stats updated.
 func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, checkTxRes *abci.ResponseCheckTx) {
-	txmp.mtx.Lock()
-	defer txmp.mtx.Unlock()
-
 	var err error
 	if txmp.postCheck != nil {
 		err = txmp.postCheck(wtx.tx, checkTxRes)


### PR DESCRIPTION
This is residual of https://github.com/celestiaorg/celestia-core/pull/1553

The problem is now even more subtle. Because the mempool mutexes weren't over both CheckTx and the actual adding of the transaction to the mempool we occasionally hit a situation as follows:

- CheckTx a tx with nonce 2
- Before saving it to the store, collect all transactions and recheck tx. This excludes the last tx with nonce 2, thus the nonce in the state machine is still  1
- Save the tx to the pool
- New tx comes in with nonce 3. The application is at 1 so rejects it expecting the next to be 2.

This PR fixes this pattern, however this won't be watertight for the CAT pool until we can order both on gas fee (priority) and nonce.