### PR TITLE
fix: typos in documentation files

### DIFF
--- a/spec/light-client/accountability/Synopsis.md
+++ b/spec/light-client/accountability/Synopsis.md
@@ -4,7 +4,7 @@
  A TLA+ specification of a simplified Tendermint consensus algorithm, tuned for
  fork accountability. The simplifications are as follows:
 
-- the procotol runs for one height, that is, one-shot consensus
+- the protocol runs for one height, that is, one-shot consensus
 
 - this specification focuses on safety, so timeouts are modelled with
    with non-determinism

--- a/spec/rpc/README.md
+++ b/spec/rpc/README.md
@@ -802,7 +802,7 @@ curl -X POST https://localhost:26657 -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\
 
 ### GenesisChunked
 
-Get the genesis document in a chunks to support easily transfering larger documents.
+Get the genesis document in a chunks to support easily transferring larger documents.
 
 #### Parameters
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `procotol` to`protocol`
Corrected `transfering` to `transferring`

Please review the changes and let me know if any additional changes are needed.



