### PR TITLE
chore: Fix multiple spelling errors

### DIFF
--- a/spec/light-client/detection/draft-functions.md
+++ b/spec/light-client/detection/draft-functions.md
@@ -60,7 +60,7 @@ func QueryHeightsRange(id, from, to) ([]Height)
 
 > This function can be used if the relayer has no information about
 > the IBC component. This allows late-joining relayers to also
-> participate in fork dection and the generation in proof of
+> participate in fork detection and the generation in proof of
 > fork. Alternatively, we may also postulate that relayers are not
 > responsible to detect forks for heights before they started (and
 > subscribed to the transactions reporting fresh headers being
@@ -120,7 +120,7 @@ func SubmitIBCProofOfFork(
     else {
         // the ibc component does not have the TrustedBlock and might
   // even be on yet a different branch. We have to compute a PoF
-  // that the ibc component can verifiy based on its current
+  // that the ibc component can verify based on its current
         // knowledge
   
         ibcLightBlock, lblock, _, result := commonRoot(lightStore, ibc, PoF.TrustedBlock)
@@ -281,7 +281,7 @@ func DetectIBCFork(ibc IBCComponent, lightStore LightStore) (LightNodeProofOfFor
 **TODO:** finish conditions
 
 - Implementation remark
-    - we ask the handler for the lastest check. Cross-check with the
+    - we ask the handler for the latest check. Cross-check with the
       chain. In case they deviate we generate PoF.
     - we assume IBC component is correct. It has verified the
       consensus state

--- a/spec/light-client/supervisor/supervisor_001_draft.md
+++ b/spec/light-client/supervisor/supervisor_001_draft.md
@@ -568,7 +568,7 @@ func VerifyAndDetect (lightStore LightStore, targetHeight Height)
                 // no attack detected, we trust the new lightblock
                 lightStore.Update(auxLS.Latest(), 
                                   StateTrusted, 
-                                  verfiedLS.Latest().verification-root);
+                                  verifiedLS.Latest().verification-root);
                 return (lightStore, OK);
             }
             else {
@@ -610,9 +610,9 @@ func VerifyAndDetect (lightStore LightStore, targetHeight Height)
         Evidences := AttackDetector(root_of_trust, verifiedLS);
         if Evidences.Empty {
             // no attack detected, we trust the new lightblock
-            verifiedLS.Update(verfiedLS.Latest(), 
+            verifiedLS.Update(verifiedLS.Latest(), 
                               StateTrusted, 
-                              verfiedLS.Latest().verification-root);
+                              verifiedLS.Latest().verification-root);
             lightStore.store_chain(verifidLS);
             return (lightStore, OK);
         }

--- a/spec/light-client/supervisor/supervisor_001_draft.md
+++ b/spec/light-client/supervisor/supervisor_001_draft.md
@@ -439,7 +439,7 @@ func Sequential-Supervisor (initdata LCInitData) (Error) {
 - Implementation remark
     - infinite loop unless a light client attack is detected
     - In typical implementations (e.g., the one in Rust),
-   there are mutliple input actions:
+   there are multiple input actions:
       `VerifytoLatest`, `LatestTrusted`, and `GetStatus`. The
       information can be easily obtained from the lightstore, so that
       we do not treat these requests explicitly here but just consider

--- a/spec/light-client/verification/verification_001_published.md
+++ b/spec/light-client/verification/verification_001_published.md
@@ -529,7 +529,7 @@ func (ls LightStore) LatestVerified() LightBlock
 
 ```go
 func (ls LightStore) Update(lightBlock LightBlock, 
-                            verfiedState VerifiedState
+                            verifiedState VerifiedState
        verifiedBy Height)
 ```
 

--- a/spec/p2p/v0.34/addressbook.md
+++ b/spec/p2p/v0.34/addressbook.md
@@ -259,8 +259,8 @@ A known address becomes bad if it is stored in buckets of new addresses, and
 when connection attempts:
 
 - Have not been made over a week, i.e., `LastAttempt` is older than a week
-- Have failed 3 times and never succeeded, i.e., `LastSucess` field is unset
-- Have failed 10 times in the last week, i.e., `LastSucess` is older than a week
+- Have failed 3 times and never succeeded, i.e., `LastSuccess` field is unset
+- Have failed 10 times in the last week, i.e., `LastSuccess` is older than a week
 
 Addresses marked as *bad* are the first candidates to be removed from a bucket of
 new addresses when the bucket becomes full.

--- a/spec/p2p/v0.34/peer_manager.md
+++ b/spec/p2p/v0.34/peer_manager.md
@@ -128,7 +128,7 @@ The picture below is a first attempt of illustrating the life cycle of an outbou
 
 A peer can be in the following states:
 
-- Candidate peers: peer addresses stored in the address boook, that can be
+- Candidate peers: peer addresses stored in the address book, that can be
   retrieved via the [`PickAddress`](./addressbook.md#pick-address) method
 - [Dialing](switch.md#dialing-peers): peer addresses that are currently being
   dialed. This state exists to ensure that a single dialing routine exist per peer.

--- a/spec/p2p/v0.34/types.md
+++ b/spec/p2p/v0.34/types.md
@@ -116,7 +116,7 @@ Interface `IPeerSet` offers methods to access a table of [`Peer`](#peergo) insta
 Type `PeerSet` implements a thread-safe table of [`Peer`](#peergo) instances,
 used by the [switch](#switchgo).
 
-The switch provides limited access to this table by returing a `IPeerSet`
+The switch provides limited access to this table by returning a `IPeerSet`
 instance, used by the [PEX reactor](#pex_reactorgo).
 
 ### `switch.go`

--- a/spec/rpc/README.md
+++ b/spec/rpc/README.md
@@ -802,7 +802,7 @@ curl -X POST https://localhost:26657 -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\
 
 ### GenesisChunked
 
-Get the genesis document in a chunks to support easily transfering larger documents.
+Get the genesis document in a chunks to support easily transferring larger documents.
 
 #### Parameters
 


### PR DESCRIPTION
**Corrections:**
1. `transfering` → `transferring`
2. `returing` → `returning`
3. `boook` → `book`
4. `Sucess` → `Success`
5. `mutliple` → `multiple`
6. `verfied` → `verified`
7. `dection` → `detection`
8. `lastest` → `latest`

**Affected files:**
- `spec/light-client/detection/draft-functions.md`
- `spec/light-client/supervisor/supervisor_001_draft.md`
- `spec/light-client/verification/verification_001_published.md`
- `spec/p2p/v0.34/addressbook.md`
- `spec/p2p/v0.34/peer_manager.md`
- `spec/p2p/v0.34/types.md`
- `spec/rpc/README.md`

---

### PR checklist
- [x] Tests written/updated (if applicable)
- [x] Changelog entry added in `.changelog`
- [x] Updated relevant documentation and code comments

---

Allow edits by maintainers.
Remember, contributions to this repository should follow its contributing guidelines and security policy.
