### PR TITLE
refactor(types): Add ToProto method for RowProof struct

### DIFF
--- a/types/row_proof.go
+++ b/types/row_proof.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tendermint/tendermint/crypto/merkle"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/proto/tendermint/crypto"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
@@ -82,5 +83,22 @@ func RowProofFromProto(p *tmproto.RowProof) RowProof {
 		Proofs:   rowProofs,
 		StartRow: p.StartRow,
 		EndRow:   p.EndRow,
+	}
+}
+
+// ToProto converts RowProof to its protobuf representation
+func (rp RowProof) ToProto() *tmproto.RowProof {
+	rowRoots := make([][]byte, len(rp.RowRoots))
+	proofs := make([]*crypto.Proof, len(rp.Proofs))
+	for i := range rp.Proofs {
+		rowRoots[i] = rp.RowRoots[i].Bytes()
+		proofs[i] = rp.Proofs[i].ToProto()
+	}
+
+	return &tmproto.RowProof{
+		RowRoots: rowRoots,
+		Proofs:   proofs,
+		StartRow: rp.StartRow,
+		EndRow:   rp.EndRow,
 	}
 }

--- a/types/row_proof.go
+++ b/types/row_proof.go
@@ -86,8 +86,16 @@ func RowProofFromProto(p *tmproto.RowProof) RowProof {
 	}
 }
 
-// ToProto converts RowProof to its protobuf representation
+// ToProto converts RowProof to its protobuf representation.
+// It converts all the fields to their protobuf counterparts and returns a new RowProof message.
 func (rp RowProof) ToProto() *tmproto.RowProof {
+	if len(rp.RowRoots) == 0 && len(rp.Proofs) == 0 {
+		return &tmproto.RowProof{
+			StartRow: rp.StartRow,
+			EndRow:   rp.EndRow,
+		}
+	}
+
 	rowRoots := make([][]byte, len(rp.RowRoots))
 	proofs := make([]*crypto.Proof, len(rp.Proofs))
 	for i := range rp.Proofs {

--- a/types/share_proof.go
+++ b/types/share_proof.go
@@ -3,102 +3,119 @@ package types
 import (
 	"errors"
 	"fmt"
+	"math"
 
-	"github.com/tendermint/tendermint/crypto/merkle"
-	tmbytes "github.com/tendermint/tendermint/libs/bytes"
-	"github.com/tendermint/tendermint/proto/tendermint/crypto"
+	"github.com/celestiaorg/nmt"
+	"github.com/tendermint/tendermint/pkg/consts"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
-// RowProof is a Merkle proof that a set of rows exist in a Merkle tree with a
-// given data root.
-type RowProof struct {
-	// RowRoots are the roots of the rows being proven.
-	RowRoots []tmbytes.HexBytes `json:"row_roots"`
-	// Proofs is a list of Merkle proofs where each proof proves that a row
-	// exists in a Merkle tree with a given data root.
-	Proofs []*merkle.Proof `json:"proofs"`
-	// StartRow the index of the start row.
-	// Note: currently, StartRow is not validated as part of the proof verification.
-	// If this field is used downstream, Validate(root) should be called along with
-	// extra validation depending on how it's used.
-	StartRow uint32 `json:"start_row"`
-	// EndRow the index of the end row.
-	// Note: currently, EndRow is not validated as part of the proof verification.
-	// If this field is used downstream, Validate(root) should be called along with
-	// extra validation depending on how it's used.
-	EndRow uint32 `json:"end_row"`
+// ShareProof is an NMT proof that a set of shares exist in a set of rows and a
+// Merkle proof that those rows exist in a Merkle tree with a given data root.
+type ShareProof struct {
+	// Data are the raw shares that are being proven.
+	Data [][]byte `json:"data"`
+	// ShareProofs are NMT proofs that the shares in Data exist in a set of
+	// rows. There will be one ShareProof per row that the shares occupy.
+	ShareProofs []*tmproto.NMTProof `json:"share_proofs"`
+	// NamespaceID is the namespace id of the shares being proven. This
+	// namespace id is used when verifying the proof. If the namespace id doesn't
+	// match the namespace of the shares, the proof will fail verification.
+	NamespaceID      []byte   `json:"namespace_id"`
+	RowProof         RowProof `json:"row_proof"`
+	NamespaceVersion uint32   `json:"namespace_version"`
 }
 
-// Validate performs checks on the fields of this RowProof. Returns an error if
-// the proof fails validation. If the proof passes validation, this function
-// attempts to verify the proof. It returns nil if the proof is valid.
-func (rp RowProof) Validate(root []byte) error {
-	if rp.EndRow < rp.StartRow {
-		return fmt.Errorf("end row %d cannot be less than start row %d", rp.EndRow, rp.StartRow)
+func (sp ShareProof) ToProto() tmproto.ShareProof {
+	pbtp := tmproto.ShareProof{
+		Data:             sp.Data,
+		ShareProofs:      sp.ShareProofs,
+		NamespaceId:      sp.NamespaceID,
+		RowProof:         sp.RowProof.ToProto(),
+		NamespaceVersion: sp.NamespaceVersion,
 	}
-	if int(rp.EndRow-rp.StartRow+1) != len(rp.RowRoots) {
-		return fmt.Errorf("the number of rows %d must equal the number of row roots %d", int(rp.EndRow-rp.StartRow+1), len(rp.RowRoots))
+
+	return pbtp
+}
+
+// ShareProofFromProto creates a ShareProof from a proto message.
+// Expects the proof to be pre-validated.
+func ShareProofFromProto(pb tmproto.ShareProof) (ShareProof, error) {
+	return ShareProof{
+		RowProof:         RowProofFromProto(pb.RowProof),
+		Data:             pb.Data,
+		ShareProofs:      pb.ShareProofs,
+		NamespaceID:      pb.NamespaceId,
+		NamespaceVersion: pb.NamespaceVersion,
+	}, nil
+}
+
+// Validate runs basic validations on the proof then verifies if it is consistent.
+// It returns nil if the proof is valid. Otherwise, it returns a sensible error.
+// The `root` is the block data root that the shares to be proven belong to.
+// Note: these proofs are tested on the app side.
+func (sp ShareProof) Validate(root []byte) error {
+	numberOfSharesInProofs := int32(0)
+	for _, proof := range sp.ShareProofs {
+		// the range is not inclusive from the left.
+		numberOfSharesInProofs += proof.End - proof.Start
 	}
-	if len(rp.Proofs) != len(rp.RowRoots) {
-		return fmt.Errorf("the number of proofs %d must equal the number of row roots %d", len(rp.Proofs), len(rp.RowRoots))
+
+	if len(sp.ShareProofs) != len(sp.RowProof.RowRoots) {
+		return fmt.Errorf("the number of share proofs %d must equal the number of row roots %d", len(sp.ShareProofs), len(sp.RowProof.RowRoots))
+
 	}
-	if !rp.VerifyProof(root) {
-		return errors.New("row proof failed to verify")
+	if len(sp.Data) != int(numberOfSharesInProofs) {
+		return fmt.Errorf("the number of shares %d must equal the number of shares in share proofs %d", len(sp.Data), numberOfSharesInProofs)
+	}
+
+	for _, proof := range sp.ShareProofs {
+		if proof.Start < 0 {
+			return errors.New("proof index cannot be negative")
+		}
+		if (proof.End - proof.Start) <= 0 {
+			return errors.New("proof total must be positive")
+		}
+	}
+
+	if err := sp.RowProof.Validate(root); err != nil {
+		return err
+	}
+
+	if ok := sp.VerifyProof(); !ok {
+		return errors.New("share proof failed to verify")
 	}
 
 	return nil
 }
 
-// VerifyProof verifies that all the row roots in this RowProof exist in a
-// Merkle tree with the given root. Returns true if all proofs are valid.
-func (rp RowProof) VerifyProof(root []byte) bool {
-	for i, proof := range rp.Proofs {
-		err := proof.Verify(root, rp.RowRoots[i])
-		if err != nil {
+func (sp ShareProof) VerifyProof() bool {
+	cursor := int32(0)
+	for i, proof := range sp.ShareProofs {
+		nmtProof := nmt.NewInclusionProof(
+			int(proof.Start),
+			int(proof.End),
+			proof.Nodes,
+			true,
+		)
+		sharesUsed := proof.End - proof.Start
+		if sp.NamespaceVersion > math.MaxUint8 {
 			return false
 		}
+		// Consider extracting celestia-app's namespace package. We can't use it
+		// here because that would introduce a circulcar import.
+		//nolint:gosec
+		namespace := append([]byte{uint8(sp.NamespaceVersion)}, sp.NamespaceID...)
+		valid := nmtProof.VerifyInclusion(
+			consts.NewBaseHashFunc(),
+			namespace,
+			sp.Data[cursor:sharesUsed+cursor],
+			sp.RowProof.RowRoots[i],
+		)
+		if !valid {
+			return false
+		}
+		cursor += sharesUsed
 	}
 	return true
-}
-
-func RowProofFromProto(p *tmproto.RowProof) RowProof {
-	if p == nil {
-		return RowProof{}
-	}
-	rowRoots := make([]tmbytes.HexBytes, len(p.RowRoots))
-	rowProofs := make([]*merkle.Proof, len(p.Proofs))
-	for i := range p.Proofs {
-		rowRoots[i] = p.RowRoots[i]
-		rowProofs[i] = &merkle.Proof{
-			Total:    p.Proofs[i].Total,
-			Index:    p.Proofs[i].Index,
-			LeafHash: p.Proofs[i].LeafHash,
-			Aunts:    p.Proofs[i].Aunts,
-		}
-	}
-
-	return RowProof{
-		RowRoots: rowRoots,
-		Proofs:   rowProofs,
-		StartRow: p.StartRow,
-		EndRow:   p.EndRow,
-	}
-}
-
-// ToProto converts RowProof to its protobuf representation
-func (rp RowProof) ToProto() *tmproto.RowProof {
-	rowRoots := make([][]byte, len(rp.RowRoots))
-	proofs := make([]*crypto.Proof, len(rp.Proofs))
-	for i := range rp.Proofs {
-		rowRoots[i] = rp.RowRoots[i].Bytes()
-		proofs[i] = rp.Proofs[i].ToProto()
-	}
-
-	return &tmproto.RowProof{
-		RowRoots: rowRoots,
-		Proofs:   proofs,
-		StartRow: rp.StartRow,
-		EndRow:   rp.EndRow,
-	}
 }

--- a/types/share_proof.go
+++ b/types/share_proof.go
@@ -3,120 +3,102 @@ package types
 import (
 	"errors"
 	"fmt"
-	"math"
 
-	"github.com/celestiaorg/nmt"
-	"github.com/tendermint/tendermint/pkg/consts"
+	"github.com/tendermint/tendermint/crypto/merkle"
+	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/proto/tendermint/crypto"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
-// ShareProof is an NMT proof that a set of shares exist in a set of rows and a
-// Merkle proof that those rows exist in a Merkle tree with a given data root.
-type ShareProof struct {
-	// Data are the raw shares that are being proven.
-	Data [][]byte `json:"data"`
-	// ShareProofs are NMT proofs that the shares in Data exist in a set of
-	// rows. There will be one ShareProof per row that the shares occupy.
-	ShareProofs []*tmproto.NMTProof `json:"share_proofs"`
-	// NamespaceID is the namespace id of the shares being proven. This
-	// namespace id is used when verifying the proof. If the namespace id doesn't
-	// match the namespace of the shares, the proof will fail verification.
-	NamespaceID      []byte   `json:"namespace_id"`
-	RowProof         RowProof `json:"row_proof"`
-	NamespaceVersion uint32   `json:"namespace_version"`
+// RowProof is a Merkle proof that a set of rows exist in a Merkle tree with a
+// given data root.
+type RowProof struct {
+	// RowRoots are the roots of the rows being proven.
+	RowRoots []tmbytes.HexBytes `json:"row_roots"`
+	// Proofs is a list of Merkle proofs where each proof proves that a row
+	// exists in a Merkle tree with a given data root.
+	Proofs []*merkle.Proof `json:"proofs"`
+	// StartRow the index of the start row.
+	// Note: currently, StartRow is not validated as part of the proof verification.
+	// If this field is used downstream, Validate(root) should be called along with
+	// extra validation depending on how it's used.
+	StartRow uint32 `json:"start_row"`
+	// EndRow the index of the end row.
+	// Note: currently, EndRow is not validated as part of the proof verification.
+	// If this field is used downstream, Validate(root) should be called along with
+	// extra validation depending on how it's used.
+	EndRow uint32 `json:"end_row"`
 }
 
-func (sp ShareProof) ToProto() tmproto.ShareProof {
-	pbtp := tmproto.ShareProof{
-		Data:             sp.Data,
-		ShareProofs:      sp.ShareProofs,
-		NamespaceId:      sp.NamespaceID,
-		RowProof:         sp.RowProof.ToProto(),
-		NamespaceVersion: sp.NamespaceVersion,
+// Validate performs checks on the fields of this RowProof. Returns an error if
+// the proof fails validation. If the proof passes validation, this function
+// attempts to verify the proof. It returns nil if the proof is valid.
+func (rp RowProof) Validate(root []byte) error {
+	if rp.EndRow < rp.StartRow {
+		return fmt.Errorf("end row %d cannot be less than start row %d", rp.EndRow, rp.StartRow)
 	}
-
-	return pbtp
-}
-
-// ShareProofFromProto creates a ShareProof from a proto message.
-// Expects the proof to be pre-validated.
-func ShareProofFromProto(pb tmproto.ShareProof) (ShareProof, error) {
-	return ShareProof{
-		RowProof:         RowProofFromProto(pb.RowProof),
-		Data:             pb.Data,
-		ShareProofs:      pb.ShareProofs,
-		NamespaceID:      pb.NamespaceId,
-		NamespaceVersion: pb.NamespaceVersion,
-	}, nil
-}
-
-// Validate runs basic validations on the proof then verifies if it is consistent.
-// It returns nil if the proof is valid. Otherwise, it returns a sensible error.
-// The `root` is the block data root that the shares to be proven belong to.
-// Note: these proofs are tested on the app side.
-func (sp ShareProof) Validate(root []byte) error {
-	numberOfSharesInProofs := int32(0)
-	for _, proof := range sp.ShareProofs {
-		// the range is not inclusive from the left.
-		numberOfSharesInProofs += proof.End - proof.Start
+	if int(rp.EndRow-rp.StartRow+1) != len(rp.RowRoots) {
+		return fmt.Errorf("the number of rows %d must equal the number of row roots %d", int(rp.EndRow-rp.StartRow+1), len(rp.RowRoots))
 	}
-
-	if len(sp.ShareProofs) != len(sp.RowProof.RowRoots) {
-		return fmt.Errorf("the number of share proofs %d must equal the number of row roots %d", len(sp.ShareProofs), len(sp.RowProof.RowRoots))
-
+	if len(rp.Proofs) != len(rp.RowRoots) {
+		return fmt.Errorf("the number of proofs %d must equal the number of row roots %d", len(rp.Proofs), len(rp.RowRoots))
 	}
-	if len(sp.Data) != int(numberOfSharesInProofs) {
-		return fmt.Errorf("the number of shares %d must equal the number of shares in share proofs %d", len(sp.Data), numberOfSharesInProofs)
-	}
-
-	for _, proof := range sp.ShareProofs {
-		if proof.Start < 0 {
-			return errors.New("proof index cannot be negative")
-		}
-		if (proof.End - proof.Start) <= 0 {
-			return errors.New("proof total must be positive")
-		}
-	}
-
-	if err := sp.RowProof.Validate(root); err != nil {
-		return err
-	}
-
-	if ok := sp.VerifyProof(); !ok {
-		return errors.New("share proof failed to verify")
+	if !rp.VerifyProof(root) {
+		return errors.New("row proof failed to verify")
 	}
 
 	return nil
 }
 
-func (sp ShareProof) VerifyProof() bool {
-	cursor := int32(0)
-	for i, proof := range sp.ShareProofs {
-		nmtProof := nmt.NewInclusionProof(
-			int(proof.Start),
-			int(proof.End),
-			proof.Nodes,
-			true,
-		)
-		sharesUsed := proof.End - proof.Start
-		if sp.NamespaceVersion > math.MaxUint8 {
+// VerifyProof verifies that all the row roots in this RowProof exist in a
+// Merkle tree with the given root. Returns true if all proofs are valid.
+func (rp RowProof) VerifyProof(root []byte) bool {
+	for i, proof := range rp.Proofs {
+		err := proof.Verify(root, rp.RowRoots[i])
+		if err != nil {
 			return false
 		}
-		// Consider extracting celestia-app's namespace package. We can't use it
-		// here because that would introduce a circulcar import.
-		//nolint:gosec
-		namespace := append([]byte{uint8(sp.NamespaceVersion)}, sp.NamespaceID...)
-		valid := nmtProof.VerifyInclusion(
-			consts.NewBaseHashFunc(),
-			namespace,
-			sp.Data[cursor:sharesUsed+cursor],
-			sp.RowProof.RowRoots[i],
-		)
-		if !valid {
-			return false
-		}
-		cursor += sharesUsed
 	}
 	return true
+}
+
+func RowProofFromProto(p *tmproto.RowProof) RowProof {
+	if p == nil {
+		return RowProof{}
+	}
+	rowRoots := make([]tmbytes.HexBytes, len(p.RowRoots))
+	rowProofs := make([]*merkle.Proof, len(p.Proofs))
+	for i := range p.Proofs {
+		rowRoots[i] = p.RowRoots[i]
+		rowProofs[i] = &merkle.Proof{
+			Total:    p.Proofs[i].Total,
+			Index:    p.Proofs[i].Index,
+			LeafHash: p.Proofs[i].LeafHash,
+			Aunts:    p.Proofs[i].Aunts,
+		}
+	}
+
+	return RowProof{
+		RowRoots: rowRoots,
+		Proofs:   rowProofs,
+		StartRow: p.StartRow,
+		EndRow:   p.EndRow,
+	}
+}
+
+// ToProto converts RowProof to its protobuf representation
+func (rp RowProof) ToProto() *tmproto.RowProof {
+	rowRoots := make([][]byte, len(rp.RowRoots))
+	proofs := make([]*crypto.Proof, len(rp.Proofs))
+	for i := range rp.Proofs {
+		rowRoots[i] = rp.RowRoots[i].Bytes()
+		proofs[i] = rp.Proofs[i].ToProto()
+	}
+
+	return &tmproto.RowProof{
+		RowRoots: rowRoots,
+		Proofs:   proofs,
+		StartRow: rp.StartRow,
+		EndRow:   rp.EndRow,
+	}
 }

--- a/types/share_proof.go
+++ b/types/share_proof.go
@@ -28,23 +28,11 @@ type ShareProof struct {
 }
 
 func (sp ShareProof) ToProto() tmproto.ShareProof {
-	// TODO consider extracting a ToProto function for RowProof
-	rowRoots := make([][]byte, len(sp.RowProof.RowRoots))
-	rowProofs := make([]*crypto.Proof, len(sp.RowProof.Proofs))
-	for i := range sp.RowProof.RowRoots {
-		rowRoots[i] = sp.RowProof.RowRoots[i].Bytes()
-		rowProofs[i] = sp.RowProof.Proofs[i].ToProto()
-	}
 	pbtp := tmproto.ShareProof{
-		Data:        sp.Data,
-		ShareProofs: sp.ShareProofs,
-		NamespaceId: sp.NamespaceID,
-		RowProof: &tmproto.RowProof{
-			RowRoots: rowRoots,
-			Proofs:   rowProofs,
-			StartRow: sp.RowProof.StartRow,
-			EndRow:   sp.RowProof.EndRow,
-		},
+		Data:             sp.Data,
+		ShareProofs:      sp.ShareProofs,
+		NamespaceId:      sp.NamespaceID,
+		RowProof:         sp.RowProof.ToProto(),
 		NamespaceVersion: sp.NamespaceVersion,
 	}
 


### PR DESCRIPTION
### Description
This PR introduces a dedicated ToProto() method for the RowProof struct, addressing a TODO comment in the codebase. The change improves code modularity and maintainability by extracting the protobuf conversion logic from ShareProof.ToProto() into a separate method.
### Key Changes:
- Added new ToProto() method to RowProof struct
- Updated ShareProof.ToProto() to use the new method
- Removed duplicated conversion logic from ShareProof
### Files Modified:
types/row_proof.go: Added new ToProto() method
types/share_proof.go: Updated to use new RowProof.ToProto()
This is a small, focused change that improves code organization without changing any functionality. The conversion logic remains the same but is now properly encapsulated in the RowProof struct.
PR checklist
- [ ] Tests written/updated (existing tests cover the protobuf conversion functionality)
- [ ] Changelog entry added in .changelog:
- [x] Updated relevant documentation and code comments
