### PR TITLE
fix: typos in API docs and test files

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -149,7 +149,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}, upgradeVersion st
 		return manifest, fmt.Errorf("unknown topology %q", opt["topology"])
 	}
 
-	if opt["typologoy"].(string) == "large_partially_connected" {
+	if opt["topology"].(string) == "large_partially_connected" {
 		// currently this is at max 11 and minimum 4
 		totalPossibleConnections := numSeeds + numValidators + numFulls - 1
 		// this value should be between 3 and 2

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -22,7 +22,7 @@ Inputs:
 |  |- <testname>.go
 ```
 
-`/corpus` directory contains corpus data. The idea is to help the fuzzier to
+`/corpus` directory contains corpus data. The idea is to help the fuzzer to
 understand what bytes sequences are semantically valid (e.g. if we're testing
 PNG decoder, then we would put black-white PNG into corpus directory; with
 blockchain reactor - we would put blockchain messages into corpus).
@@ -31,7 +31,7 @@ blockchain reactor - we would put blockchain messages into corpus).
 
 `/testdata` directory may contain an additional data (like `addrbook.json`).
 
-Upon running the fuzzier, `/crashers` and `/suppressions` dirs will be created,
+Upon running the fuzzer, `/crashers` and `/suppressions` dirs will be created,
 along with <testname>.zip archive. `/crashers` will show any inputs, which have
 lead to panics (plus a trace). `/suppressions` will show any suppressed inputs.
 


### PR DESCRIPTION
- Fix "fuzzier" to "fuzzer" in test/fuzz/README.md 
- Fix "typologoy" to "topology" in test/e2e/generator/generate.go