### PR TITLE
consensus: add block recovery messages with ValidateBasic methods. Fixes #1605

### DIFF
--- a/proto/tendermint/consensus/types.proto
+++ b/proto/tendermint/consensus/types.proto
@@ -77,6 +77,22 @@ message VoteSetBits {
   tendermint.libs.bits.BitArray  votes    = 5 [(gogoproto.nullable) = false];
 }
 
+// RecoveryRequest is sent when a node needs to recover blocks
+message RecoveryRequest {
+  int64 height = 1;
+  int32 round = 2;
+  int64 from_height = 3;
+  int64 to_height = 4;
+}
+
+// RecoveryResponse is sent in response to a RecoveryRequest
+message RecoveryResponse {
+  int64 height = 1;
+  int32 round = 2;
+  repeated tendermint.types.Block blocks = 3;
+  repeated tendermint.types.Commit commits = 4;
+}
+
 message Message {
   oneof sum {
     NewRoundStep  new_round_step  = 1;
@@ -88,5 +104,7 @@ message Message {
     HasVote       has_vote        = 7;
     VoteSetMaj23  vote_set_maj23  = 8;
     VoteSetBits   vote_set_bits   = 9;
+    RecoveryRequest recovery_request = 10;
+    RecoveryResponse recovery_response = 11;
   }
 }


### PR DESCRIPTION
This pull request adds support for block recovery messages in the consensus protocol. 
It introduces two new message types:

- RecoveryRequest: Used to request blocks from a specific height range
- RecoveryResponse: Used to respond with the requested blocks and their commits

The changes include:
- Added new protobuf message definitions
- Added corresponding Go types with ValidateBasic methods
- Updated MsgToProto and MsgFromProto functions to handle new message types
- Added comprehensive validation for blocks and commits in responses
- Added string representations for debugging purposes

The ValidateBasic methods perform the following checks:
- Validate height and round are non-negative
- Validate from/to heights are non-negative and properly ordered
- Validate blocks and commits arrays match in length
- Validate individual blocks and commits are non-nil and valid

Fixes #1605