### PR TITLE
feat: save the compact block when proposing

### DIFF
--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -34,7 +34,8 @@ func (blockProp *Reactor) ProposeBlock(proposal *types.Proposal, block *types.Pa
 		Blobs:     txs,
 	}
 
-	blockProp.broadcastCompactBlock(&cb, blockProp.self)
+	// save the compact block locally and broadcast it to the connected peers
+	blockProp.handleCompactBlock(&cb, blockProp.self)
 
 	// distribute equal portions of haves to each of the proposer's peers
 	peers := blockProp.getPeers()
@@ -75,7 +76,7 @@ func chunkToPartMetaData(chunk *bits.BitArray, partSet *types.PartSet) []*propag
 // time a proposal is received from a peer or when a proposal is created. If the
 // proposal is new, it will be stored and broadcast to the relevant peers.
 func (blockProp *Reactor) handleCompactBlock(cb *proptypes.CompactBlock, peer p2p.ID) {
-	if cb.Proposal.Height > blockProp.currentHeight+1 || cb.Proposal.Round > blockProp.currentRound+1 {
+	if peer != blockProp.self && (cb.Proposal.Height > blockProp.currentHeight+1 || cb.Proposal.Round > blockProp.currentRound+1) {
 		// catchup on missing heights/rounds by requesting the missing parts from all connected peers.
 		go blockProp.requestMissingBlocks(cb.Proposal.Height, cb.Proposal.Round)
 	}

--- a/consensus/propagation/commitment_test.go
+++ b/consensus/propagation/commitment_test.go
@@ -48,10 +48,14 @@ func TestPropose(t *testing.T) {
 
 	reactor1.ProposeBlock(prop, partSet, metaData)
 
-	time.Sleep(400 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
+
+	// check that the proposal was saved in reactor 1
+	_, _, has := reactor1.GetProposal(prop.Height, prop.Round)
+	require.True(t, has)
 
 	// Check that the proposal was received by the other reactors
-	_, _, has := reactor2.GetProposal(prop.Height, prop.Round)
+	_, _, has = reactor2.GetProposal(prop.Height, prop.Round)
 	require.True(t, has)
 	_, _, has = reactor3.GetProposal(prop.Height, prop.Round)
 	require.True(t, has)

--- a/consensus/propagation/reactor_test.go
+++ b/consensus/propagation/reactor_test.go
@@ -160,7 +160,7 @@ func TestHandleHavesAndWantsAndRecoveryParts(t *testing.T) {
 	assert.Contains(t, haves.Parts, proptypes.PartMetaData{Index: 3, Proof: proof})
 	assert.Contains(t, haves.Parts, proptypes.PartMetaData{Index: 4, Proof: proof})
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(400 * time.Millisecond)
 
 	// reactor 1 will gossip the haves with reactor 3
 	// check if the third reactor received the haves
@@ -189,7 +189,7 @@ func TestHandleHavesAndWantsAndRecoveryParts(t *testing.T) {
 		Data:   randomData,
 	})
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	// check if reactor 3 received the recovery part.
 	_, parts, found := reactor3.GetProposal(10, 1)


### PR DESCRIPTION
## Description

Saves the compact block locally when proposing a block.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

