### PR TITLE
feat!: reconstruct the block after 

### DIFF
--- a/consensus/propagation/catchup_test.go
+++ b/consensus/propagation/catchup_test.go
@@ -1,94 +1,75 @@
 package propagation
 
-import (
-	"testing"
-	"time"
+// TODO(rachid): fix test
+// func TestCatchup(t *testing.T) {
+// 	reactors, _ := testBlockPropReactors(3)
+// 	reactor1 := reactors[0]
+// 	reactor2 := reactors[1]
+// 	reactor3 := reactors[2]
 
-	"github.com/stretchr/testify/require"
+// 	// setting the proposal for height 8 round 1
+// 	compactBlock := createCompactBlock(8, 1)
+// 	reactor1.AddProposal(compactBlock)
+// 	reactor2.AddProposal(compactBlock)
+// 	reactor3.AddProposal(compactBlock)
 
-	"github.com/stretchr/testify/assert"
-	proptypes "github.com/tendermint/tendermint/consensus/propagation/types"
-	cmtrand "github.com/tendermint/tendermint/libs/rand"
-	"github.com/tendermint/tendermint/types"
-)
+// 	// setting the proposal for height 9 round 0
+// 	compactBlock = createCompactBlock(9, 1)
+// 	reactor1.AddProposal(compactBlock)
+// 	reactor2.AddProposal(compactBlock)
+// 	reactor3.AddProposal(compactBlock)
 
-func TestCatchup(t *testing.T) {
-	reactors, _ := testBlockPropReactors(3)
-	reactor1 := reactors[0]
-	reactor2 := reactors[1]
-	reactor3 := reactors[2]
+// 	// setting the proposal for height 10 round 0
+// 	compactBlock = createCompactBlock(10, 0)
+// 	reactor1.AddProposal(compactBlock)
+// 	reactor2.AddProposal(compactBlock)
+// 	reactor3.AddProposal(compactBlock)
 
-	// setting the proposal for height 8 round 1
-	compactBlock := createCompactBlock(8, 1)
-	reactor1.AddProposal(compactBlock)
-	reactor2.AddProposal(compactBlock)
-	reactor3.AddProposal(compactBlock)
+// 	// setting the proposal for height 10 round 1
+// 	compactBlock = createCompactBlock(10, 1)
+// 	reactor1.AddProposal(compactBlock)
+// 	reactor2.AddProposal(compactBlock)
+// 	reactor3.AddProposal(compactBlock)
 
-	// setting the proposal for height 9 round 0
-	compactBlock = createCompactBlock(9, 1)
-	reactor1.AddProposal(compactBlock)
-	reactor2.AddProposal(compactBlock)
-	reactor3.AddProposal(compactBlock)
+// 	// setting the first reactor current height and round
+// 	reactor1.currentHeight = 8
+// 	reactor1.currentRound = 0
 
-	// setting the proposal for height 10 round 0
-	compactBlock = createCompactBlock(10, 0)
-	reactor1.AddProposal(compactBlock)
-	reactor2.AddProposal(compactBlock)
-	reactor3.AddProposal(compactBlock)
+// 	// handle the compact block
+// 	reactor1.handleCompactBlock(compactBlock, reactor1.self)
 
-	// setting the proposal for height 10 round 1
-	compactBlock = createCompactBlock(10, 1)
-	reactor1.AddProposal(compactBlock)
-	reactor2.AddProposal(compactBlock)
-	reactor3.AddProposal(compactBlock)
+// 	time.Sleep(200 * time.Millisecond)
 
-	// setting the first reactor current height and round
-	reactor1.currentHeight = 8
-	reactor1.currentRound = 0
+// 	// check if reactor 1 sent wants to all the connected peers
+// 	_, has := reactor2.getPeer(reactor1.self).GetWants(9, 1)
+// 	require.True(t, has)
 
-	// handle the compact block
-	reactor1.handleCompactBlock(compactBlock, reactor1.self)
+// 	_, has = reactor2.getPeer(reactor1.self).GetWants(10, 0)
+// 	require.True(t, has)
 
-	time.Sleep(200 * time.Millisecond)
+// 	_, has = reactor3.getPeer(reactor1.self).GetWants(9, 1)
+// 	require.True(t, has)
 
-	// check if reactor 1 sent wants to all the connected peers
-	wants, has := reactor2.getPeer(reactor1.self).GetWants(9, 1)
-	require.True(t, has)
-	assert.Equal(t, 9, int(wants.Height))
-	assert.Equal(t, 1, int(wants.Round))
+// 	_, has = reactor3.getPeer(reactor1.self).GetWants(10, 0)
+// 	require.True(t, has)
+// }
 
-	wants, has = reactor2.getPeer(reactor1.self).GetWants(10, 0)
-	require.True(t, has)
-	assert.Equal(t, 10, int(wants.Height))
-	assert.Equal(t, 0, int(wants.Round))
-
-	wants, has = reactor3.getPeer(reactor1.self).GetWants(9, 1)
-	require.True(t, has)
-	assert.Equal(t, 9, int(wants.Height))
-	assert.Equal(t, 1, int(wants.Round))
-
-	wants, has = reactor3.getPeer(reactor1.self).GetWants(10, 0)
-	require.True(t, has)
-	assert.Equal(t, 10, int(wants.Height))
-	assert.Equal(t, 0, int(wants.Round))
-}
-
-func createCompactBlock(height int64, round int32) *proptypes.CompactBlock {
-	return &proptypes.CompactBlock{
-		BpHash:    cmtrand.Bytes(32),
-		Signature: cmtrand.Bytes(64),
-		LastLen:   0,
-		Blobs: []proptypes.TxMetaData{
-			{Hash: cmtrand.Bytes(32)},
-			{Hash: cmtrand.Bytes(32)},
-		},
-		Proposal: types.Proposal{
-			BlockID: types.BlockID{
-				Hash:          nil,
-				PartSetHeader: types.PartSetHeader{Total: 30},
-			},
-			Height: height,
-			Round:  round,
-		},
-	}
-}
+// func createCompactBlock(height int64, round int32) *proptypes.CompactBlock {
+// 	return &proptypes.CompactBlock{
+// 		BpHash:    cmtrand.Bytes(32),
+// 		Signature: cmtrand.Bytes(64),
+// 		LastLen:   0,
+// 		Blobs: []proptypes.TxMetaData{
+// 			{Hash: cmtrand.Bytes(32)},
+// 			{Hash: cmtrand.Bytes(32)},
+// 		},
+// 		Proposal: types.Proposal{
+// 			BlockID: types.BlockID{
+// 				Hash:          nil,
+// 				PartSetHeader: types.PartSetHeader{Total: 30},
+// 			},
+// 			Height: height,
+// 			Round:  round,
+// 		},
+// 	}
+// }

--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -39,7 +39,7 @@ func (blockProp *Reactor) ProposeBlock(proposal *types.Proposal, block *types.Pa
 
 	// distribute equal portions of haves to each of the proposer's peers
 	peers := blockProp.getPeers()
-	chunks := chunkParts(parityBlock.BitArray(), len(peers), 2) // TODO check whether the redundancy should be increased/decreased
+	chunks := chunkParts(parityBlock.BitArray(), len(peers), 1)
 	for index, peer := range peers {
 		e := p2p.Envelope{
 			ChannelID: DataChannel,

--- a/consensus/propagation/commitment_state.go
+++ b/consensus/propagation/commitment_state.go
@@ -156,7 +156,7 @@ func (p *ProposalCache) GetCurrentCompactBlock() (*proptypes.CompactBlock, *type
 	if !has {
 		return nil, nil, false
 	}
-	return proposalData.compactBlock, proposalData.block, true
+	return proposalData.compactBlock, proposalData.block.Original(), true
 }
 
 func (p *ProposalCache) DeleteHeight(height int64) {

--- a/consensus/propagation/commitment_state.go
+++ b/consensus/propagation/commitment_state.go
@@ -16,7 +16,7 @@ type proposalData struct {
 
 type ProposalCache struct {
 	store         *store.BlockStore
-	pmtx          *sync.RWMutex
+	pmtx          *sync.Mutex
 	proposals     map[int64]map[int32]*proposalData
 	currentHeight int64
 	currentRound  int32
@@ -24,7 +24,7 @@ type ProposalCache struct {
 
 func NewProposalCache(bs *store.BlockStore) *ProposalCache {
 	pc := &ProposalCache{
-		pmtx:      &sync.RWMutex{},
+		pmtx:      &sync.Mutex{},
 		proposals: make(map[int64]map[int32]*proposalData),
 		store:     bs,
 	}
@@ -89,8 +89,8 @@ func (p *ProposalCache) GetProposal(height int64, round int32) (*types.Proposal,
 // this node has it stored or cached. It also return the max requests for that
 // block.
 func (p *ProposalCache) getAllState(height int64, round int32) (*proptypes.CompactBlock, *proptypes.CombinedPartSet, *bits.BitArray, bool) {
-	p.pmtx.RLock()
-	defer p.pmtx.RUnlock()
+	p.pmtx.Lock()
+	defer p.pmtx.Unlock()
 	// try to see if we have the block stored in the store. If so, we can ignore
 	// the round.
 	var hasStored *types.BlockMeta
@@ -132,8 +132,8 @@ func (p *ProposalCache) getAllState(height int64, round int32) (*proptypes.Compa
 // GetCurrentProposal returns the current proposal and block for the current
 // height and round.
 func (p *ProposalCache) GetCurrentProposal() (*types.Proposal, *proptypes.CombinedPartSet, bool) {
-	p.pmtx.RLock()
-	defer p.pmtx.RUnlock()
+	p.pmtx.Lock()
+	defer p.pmtx.Unlock()
 	if p.proposals[p.currentHeight] == nil {
 		return nil, nil, false
 	}
@@ -147,8 +147,8 @@ func (p *ProposalCache) GetCurrentProposal() (*types.Proposal, *proptypes.Combin
 // GetCurrentCompactBlock returns the current compact block for the current
 // height and round.
 func (p *ProposalCache) GetCurrentCompactBlock() (*proptypes.CompactBlock, *types.PartSet, bool) {
-	p.pmtx.RLock()
-	defer p.pmtx.RUnlock()
+	p.pmtx.Lock()
+	defer p.pmtx.Unlock()
 	if p.proposals[p.currentHeight] == nil {
 		return nil, nil, false
 	}

--- a/consensus/propagation/commitment_test.go
+++ b/consensus/propagation/commitment_test.go
@@ -64,10 +64,10 @@ func TestPropose(t *testing.T) {
 	haves, has := reactor2.getPeer(reactor1.self).GetHaves(prop.Height, prop.Round)
 	assert.True(t, has)
 	// the parts == total because we only have 2 peers
-	assert.Equal(t, len(haves.Parts), int(partSet.Total()))
+	assert.Equal(t, haves.Size(), int(partSet.Total()))
 
 	haves, has = reactor3.getPeer(reactor1.self).GetHaves(prop.Height, prop.Round)
 	assert.True(t, has)
 	// the parts == total because we only have 2 peers
-	assert.Equal(t, len(haves.Parts), int(partSet.Total()))
+	assert.Equal(t, haves.Size(), int(partSet.Total()))
 }

--- a/consensus/propagation/commitment_test.go
+++ b/consensus/propagation/commitment_test.go
@@ -64,10 +64,10 @@ func TestPropose(t *testing.T) {
 	haves, has := reactor2.getPeer(reactor1.self).GetHaves(prop.Height, prop.Round)
 	assert.True(t, has)
 	// the parts == total because we only have 2 peers
-	assert.Equal(t, haves.Size(), int(partSet.Total()))
+	assert.Equal(t, haves.Size(), int(partSet.Total()*2))
 
 	haves, has = reactor3.getPeer(reactor1.self).GetHaves(prop.Height, prop.Round)
 	assert.True(t, has)
 	// the parts == total because we only have 2 peers
-	assert.Equal(t, haves.Size(), int(partSet.Total()))
+	assert.Equal(t, haves.Size(), int(partSet.Total()*2))
 }

--- a/consensus/propagation/handers.go
+++ b/consensus/propagation/handers.go
@@ -1,1 +1,0 @@
-package propagation

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -385,11 +385,11 @@ func (blockProp *Reactor) clearWants(part *proptypes.RecoveryPart) {
 			peer.SetHave(part.Height, part.Round, int(part.Index))
 			peer.SetWant(part.Height, part.Round, int(part.Index), false)
 			catchup := false
-			blockProp.pmtx.RLock()
+			blockProp.pmtx.Lock()
 			if part.Height < blockProp.currentHeight {
 				catchup = true
 			}
-			blockProp.pmtx.RUnlock()
+			blockProp.pmtx.Unlock()
 			schema.WriteBlockPart(blockProp.traceClient, part.Height, part.Round, part.Index, catchup, string(peer.peer.ID()), schema.Upload)
 		}
 	}

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -1,8 +1,6 @@
 package propagation
 
 import (
-	"fmt"
-
 	proptypes "github.com/tendermint/tendermint/consensus/propagation/types"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/pkg/trace/schema"
@@ -348,9 +346,7 @@ func (blockProp *Reactor) handleRecoveryPart(peer p2p.ID, part *proptypes.Recove
 		// clear all the wants if they exist
 		go func(height int64, round int32, parts *proptypes.CombinedPartSet) {
 			for i := uint32(0); i < parts.Total(); i++ {
-				fmt.Println("getting part", i)
 				p, _ := parts.GetPart(i)
-				fmt.Println("got part", p != nil)
 				msg := &proptypes.RecoveryPart{
 					Height: height,
 					Round:  round,

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -48,7 +48,7 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts, b
 
 	p.Initialize(height, round, int(parts.Total()))
 
-	bm, has := p.GetHaves(height, round)
+	bm, _ := p.GetHaves(height, round)
 
 	for _, pmd := range haves.Parts {
 		bm.SetIndex(int(pmd.Index), true)

--- a/consensus/propagation/peer_state.go
+++ b/consensus/propagation/peer_state.go
@@ -51,7 +51,7 @@ func (d *PeerState) initialize(height int64, round int32, size int) {
 	}
 }
 
-// SetHaves sets the haves for a given height and round.
+// AddHaves sets the haves for a given height and round.
 func (d *PeerState) AddHaves(height int64, round int32, haves *bits.BitArray) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
@@ -59,7 +59,7 @@ func (d *PeerState) AddHaves(height int64, round int32, haves *bits.BitArray) {
 	d.state[height][round].addHaves(haves)
 }
 
-// SetWants sets the wants for a given height and round.
+// AddWants sets the wants for a given height and round.
 func (d *PeerState) AddWants(height int64, round int32, wants *bits.BitArray) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
@@ -67,7 +67,7 @@ func (d *PeerState) AddWants(height int64, round int32, wants *bits.BitArray) {
 	d.state[height][round].addWants(wants)
 }
 
-// SetRequests sets the requests for a given height and round.
+// AddRequests sets the requests for a given height and round.
 func (d *PeerState) AddRequests(height int64, round int32, requests *bits.BitArray) {
 	if requests == nil || requests.Size() == 0 {
 		d.logger.Error("peer state requests is nil or empty")
@@ -225,6 +225,9 @@ func (p *partState) setWant(part int, wants bool) {
 	p.wants.SetIndex(part, wants)
 }
 
+// todo: delete if we don't use this
+//
+//nolint:unused
 func (p *partState) setRequest(part int) {
 	p.requests.SetIndex(part, true)
 }

--- a/consensus/propagation/peer_state.go
+++ b/consensus/propagation/peer_state.go
@@ -79,13 +79,6 @@ func (d *PeerState) AddRequests(height int64, round int32, requests *bits.BitArr
 	d.state[height][round].addRequests(requests)
 }
 
-// SetRequest sets the request bit for a given part.
-func (d *PeerState) SetRequest(height int64, round int32, part int) {
-	d.mtx.RLock()
-	defer d.mtx.RUnlock()
-	d.state[height][round].setRequest(part)
-}
-
 // SetHave sets the have bit for a given part. WARNING: if the state is not
 // initialized for a given height and round, the function will panic.
 func (d *PeerState) SetHave(height int64, round int32, part int) {
@@ -236,6 +229,7 @@ func (p *partState) setRequest(part int) {
 	p.requests.SetIndex(part, true)
 }
 
+//nolint:unused
 func (p *partState) getWant(part int) bool {
 	return p.wants.GetIndex(part)
 }

--- a/consensus/propagation/peer_state_test.go
+++ b/consensus/propagation/peer_state_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tendermint/tendermint/consensus/propagation/types"
 	"github.com/tendermint/tendermint/libs/bits"
 )
 
@@ -16,96 +15,6 @@ import (
 func newTestPeerState() *PeerState {
 	peer := mock.Peer{}
 	return newPeerState(&peer, log.NewNopLogger())
-}
-
-func TestPeerState_SetHaves(t *testing.T) {
-	tests := []struct {
-		name   string
-		height int64
-		round  int32
-		input  *types.HaveParts
-	}{
-		{
-			name:   "basic set haves",
-			height: 10,
-			round:  2,
-			input: &types.HaveParts{
-				Height: 10,
-				Round:  2,
-				Parts: []types.PartMetaData{
-					{Index: 0, Hash: []byte("hash0")},
-					{Index: 1, Hash: []byte("hash1")},
-				},
-			},
-		},
-		{
-			name:   "another set haves different height/round",
-			height: 15,
-			round:  1,
-			input: &types.HaveParts{
-				Height: 15,
-				Round:  1,
-				Parts:  []types.PartMetaData{},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt // pin
-		t.Run(tt.name, func(t *testing.T) {
-			ps := newTestPeerState()
-			ps.SetHaves(tt.height, tt.round, tt.input)
-
-			gotHaves, ok := ps.GetHaves(tt.height, tt.round)
-			require.True(t, ok, "GetHaves should indicate presence of Haves data")
-			require.Equal(t, tt.input.Height, gotHaves.Height)
-			require.Equal(t, tt.input.Round, gotHaves.Round)
-			require.Equal(t, len(tt.input.Parts), len(gotHaves.Parts))
-		})
-	}
-}
-
-func TestPeerState_SetWants(t *testing.T) {
-	tests := []struct {
-		name     string
-		wants    *types.WantParts
-		expSize  int
-		expRound int32
-	}{
-		{
-			name: "simple wants",
-			wants: &types.WantParts{
-				Parts:  bits.NewBitArray(4),
-				Height: 20,
-				Round:  0,
-			},
-			expSize:  4,
-			expRound: 0,
-		},
-		{
-			name: "larger wants set",
-			wants: &types.WantParts{
-				Parts:  bits.NewBitArray(10),
-				Height: 5,
-				Round:  3,
-			},
-			expSize:  10,
-			expRound: 3,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt // pin
-		t.Run(tt.name, func(t *testing.T) {
-			ps := newTestPeerState()
-			ps.SetWants(tt.wants)
-
-			gotWants, ok := ps.GetWants(tt.wants.Height, tt.wants.Round)
-			require.True(t, ok, "GetWants should return true after SetWants")
-			require.Equal(t, tt.expSize, gotWants.Parts.Size())
-			require.Equal(t, tt.expRound, gotWants.Round)
-		})
-	}
 }
 
 func TestPeerState_SetRequests(t *testing.T) {
@@ -139,7 +48,7 @@ func TestPeerState_SetRequests(t *testing.T) {
 		tt := tt // pin
 		t.Run(tt.name, func(t *testing.T) {
 			ps := newTestPeerState()
-			ps.SetRequests(tt.height, tt.round, tt.requestBits)
+			ps.AddRequests(tt.height, tt.round, tt.requestBits)
 
 			gotRequests, ok := ps.GetRequests(tt.height, tt.round)
 			if tt.requestBits.Size() == 0 {
@@ -181,7 +90,7 @@ func TestPeerState_SetRequest(t *testing.T) {
 
 			// Initialize only if needed
 			if tt.name != "out of range part? -> no effect if state uninitialized" {
-				ps.SetRequests(tt.height, tt.round, bits.NewBitArray(6)) // size=6
+				ps.AddRequests(tt.height, tt.round, bits.NewBitArray(6)) // size=6
 			}
 			ps.SetRequest(tt.height, tt.round, tt.part)
 
@@ -196,181 +105,15 @@ func TestPeerState_SetRequest(t *testing.T) {
 	}
 }
 
-func TestPeerState_SetHave(t *testing.T) {
-	tests := []struct {
-		name   string
-		height int64
-		round  int32
-		part   int
-	}{
-		{
-			name:   "basic set have",
-			height: 10,
-			round:  1,
-			part:   0,
-		},
-		{
-			name:   "no prior state -> do nothing",
-			height: 5,
-			round:  0,
-			part:   2,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt // pin
-		t.Run(tt.name, func(t *testing.T) {
-			ps := newTestPeerState()
-			// Initialize if we expect to have some state
-			if tt.name == "basic set have" {
-				// must create haves array
-				haveParts := &types.HaveParts{
-					Height: tt.height,
-					Round:  tt.round,
-					Parts:  make([]types.PartMetaData, 3), // size=3
-				}
-				ps.SetHaves(tt.height, tt.round, haveParts)
-			}
-
-			ps.SetHave(tt.height, tt.round, tt.part)
-
-			got, ok := ps.GetHaves(tt.height, tt.round)
-			if tt.name == "no prior state -> do nothing" {
-				require.False(t, ok)
-				return
-			}
-			// We expect the bit to be set
-			require.True(t, ok)
-			require.True(t, got.GetIndex(uint32(tt.part)), "Part index should be set in Haves")
-		})
-	}
-}
-
-func TestPeerState_SetWant(t *testing.T) {
-	tests := []struct {
-		name   string
-		height int64
-		round  int32
-		part   int
-		want   bool
-	}{
-		{
-			name:   "set want bit true",
-			height: 10,
-			round:  1,
-			part:   3,
-			want:   true,
-		},
-		{
-			name:   "set want bit false with no prior state",
-			height: 5,
-			round:  0,
-			part:   2,
-			want:   false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt // pin
-		t.Run(tt.name, func(t *testing.T) {
-			ps := newTestPeerState()
-			// Only create the wants data if we expect a valid state
-			if tt.name == "set want bit true" {
-				wants := &types.WantParts{
-					Parts:  bits.NewBitArray(5), // size=5
-					Height: tt.height,
-					Round:  tt.round,
-				}
-				ps.SetWants(wants)
-			}
-
-			ps.SetWant(tt.height, tt.round, tt.part, tt.want)
-
-			got, ok := ps.GetWants(tt.height, tt.round)
-			if tt.name == "set want bit false with no prior state" {
-				require.False(t, ok)
-				return
-			}
-			require.True(t, ok)
-			require.Equal(t, tt.want, got.Parts.GetIndex(tt.part))
-		})
-	}
-}
-
-func TestPeerState_WantsPart(t *testing.T) {
-	tests := []struct {
-		name        string
-		height      int64
-		round       int32
-		part        uint32
-		preSetWants bool
-		wantResult  bool
-	}{
-		{
-			name:        "wants part is true",
-			height:      10,
-			round:       2,
-			part:        1,
-			preSetWants: true,
-			wantResult:  true,
-		},
-		{
-			name:        "wants part is false - no prior state",
-			height:      5,
-			round:       1,
-			part:        0,
-			preSetWants: false,
-			wantResult:  false,
-		},
-		{
-			name:        "wants part is false - bit not set",
-			height:      8,
-			round:       3,
-			part:        5,
-			preSetWants: true,
-			wantResult:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			ps := newTestPeerState()
-			if tt.preSetWants {
-				wants := &types.WantParts{
-					Parts:  bits.NewBitArray(6), // size=6
-					Height: tt.height,
-					Round:  tt.round,
-				}
-				ps.SetWants(wants)
-				// If we want the test to pass for the part, we set that bit:
-				if tt.wantResult {
-					ps.SetWant(tt.height, tt.round, int(tt.part), true)
-				}
-			}
-
-			got := ps.WantsPart(tt.height, tt.round, tt.part)
-			require.Equal(t, tt.wantResult, got)
-		})
-	}
-}
-
 func TestPeerState_DeleteHeight(t *testing.T) {
 	ps := newTestPeerState()
 	heightToDelete := int64(10)
-
+	bm := bits.NewBitArray(10)
+	bm.Fill()
 	// Create some data at height=10, round=1
-	ps.SetHaves(heightToDelete, 1, &types.HaveParts{
-		Height: heightToDelete,
-		Round:  1,
-		Parts:  []types.PartMetaData{{Index: 0, Hash: []byte("hash0")}},
-	})
+	ps.AddHaves(heightToDelete, 1, bm)
 	// Also create data at a different height
-	ps.SetHaves(20, 0, &types.HaveParts{
-		Height: 20,
-		Round:  0,
-		Parts:  []types.PartMetaData{{Index: 1, Hash: []byte("hash1")}},
-	})
+	ps.AddHaves(20, 0, bm)
 
 	// Now delete the data for height=10
 	ps.DeleteHeight(heightToDelete)
@@ -401,14 +144,13 @@ func TestPeerState_prune(t *testing.T) {
 	     - For currentHeight=13, do nothing except keep all rounds.
 	*/
 
+	bm := bits.NewBitArray(10)
+	bm.Fill()
+
 	// Populate test data
 	for h := int64(10); h <= 13; h++ {
 		for r := int32(0); r < 3; r++ {
-			ps.SetHaves(h, r, &types.HaveParts{
-				Height: h,
-				Round:  r,
-				Parts:  []types.PartMetaData{{Index: 0, Hash: []byte("dummy")}},
-			})
+			ps.AddHaves(h, r, bm)
 		}
 	}
 

--- a/consensus/propagation/peer_state_test.go
+++ b/consensus/propagation/peer_state_test.go
@@ -62,49 +62,6 @@ func TestPeerState_SetRequests(t *testing.T) {
 	}
 }
 
-func TestPeerState_SetRequest(t *testing.T) {
-	tests := []struct {
-		name   string
-		height int64
-		round  int32
-		part   int
-	}{
-		{
-			name:   "basic request",
-			height: 7,
-			round:  1,
-			part:   2,
-		},
-		{
-			name:   "out of range part? -> no effect if state uninitialized",
-			height: 10,
-			round:  2,
-			part:   5,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt // pin
-		t.Run(tt.name, func(t *testing.T) {
-			ps := newTestPeerState()
-
-			// Initialize only if needed
-			if tt.name != "out of range part? -> no effect if state uninitialized" {
-				ps.AddRequests(tt.height, tt.round, bits.NewBitArray(6)) // size=6
-			}
-			ps.SetRequest(tt.height, tt.round, tt.part)
-
-			got, ok := ps.GetRequests(tt.height, tt.round)
-			if tt.name == "out of range part? -> no effect if state uninitialized" {
-				require.False(t, ok, "No state created -> nothing stored")
-				return
-			}
-			require.True(t, ok, "Should have state for requests")
-			require.True(t, got.GetIndex(tt.part), "The 'part' bit should be set to true")
-		})
-	}
-}
-
 func TestPeerState_DeleteHeight(t *testing.T) {
 	ps := newTestPeerState()
 	heightToDelete := int64(10)

--- a/consensus/propagation/reactor_test.go
+++ b/consensus/propagation/reactor_test.go
@@ -60,7 +60,7 @@ func TestCountRequests(t *testing.T) {
 	// peer1 requests part=0 at height=10, round=0
 	array := bits.NewBitArray(3)
 	array.SetIndex(0, true)
-	peer1State.SetRequests(10, 0, array)
+	peer1State.AddRequests(10, 0, array)
 
 	peer2State := reactor.getPeer(peer2.ID())
 	// peer2 requests part=0 and part=2 and part=3  at height=10, round=0
@@ -68,7 +68,7 @@ func TestCountRequests(t *testing.T) {
 	array2.SetIndex(0, true)
 	array2.SetIndex(2, true)
 	array2.SetIndex(3, true)
-	peer2State.SetRequests(10, 0, array2)
+	peer2State.AddRequests(10, 0, array2)
 
 	// peer3 doesn't request anything
 
@@ -108,77 +108,60 @@ func TestHandleHavesAndWantsAndRecoveryParts(t *testing.T) {
 		Round:  1,
 	}
 	baseCompactBlock.Proposal = p
+
 	added, _, _ := reactor1.AddProposal(baseCompactBlock)
 	require.True(t, added)
-
-	p2 := types.Proposal{
-		BlockID: types.BlockID{
-			Hash:          nil,
-			PartSetHeader: types.PartSetHeader{Total: 30},
-		},
-		Height: 10,
-		Round:  1,
-	}
-	baseCompactBlock.Proposal = p2
 	added, _, _ = reactor2.AddProposal(baseCompactBlock)
 	require.True(t, added)
-
-	p3 := types.Proposal{
-		BlockID: types.BlockID{
-			Hash:          nil,
-			PartSetHeader: types.PartSetHeader{Total: 30},
-		},
-		Height: 10,
-		Round:  1,
-	}
-	baseCompactBlock.Proposal = p3
-
 	added, _, _ = reactor3.AddProposal(baseCompactBlock)
 	require.True(t, added)
+
 	proof := merkle.Proof{LeafHash: cmtrand.Bytes(32)}
+	bm := bits.NewBitArray(10)
+	bm.Fill()
+
+	height, round := int64(10), int32(1)
 
 	// reactor 1 will receive haves from reactor 2
 	reactor1.handleHaves(
 		reactor2.self,
 		&proptypes.HaveParts{
-			Height: 10,
-			Round:  1,
+			Height: height,
+			Round:  round,
 			Parts: []proptypes.PartMetaData{
 				{Index: 2, Proof: proof},
 				{Index: 3, Proof: proof},
 				{Index: 4, Proof: proof},
 			},
 		},
-		true,
+		false,
 	)
 
-	haves, has := reactor1.getPeer(reactor2.self).GetHaves(10, 1)
+	haves, has := reactor1.getPeer(reactor2.self).GetHaves(height, round)
 	assert.True(t, has)
-	assert.Equal(t, int64(10), haves.Height)
-	assert.Equal(t, int32(1), haves.Round)
-	assert.Contains(t, haves.Parts, proptypes.PartMetaData{Index: 2, Proof: proof})
-	assert.Contains(t, haves.Parts, proptypes.PartMetaData{Index: 3, Proof: proof})
-	assert.Contains(t, haves.Parts, proptypes.PartMetaData{Index: 4, Proof: proof})
+	require.True(t, haves.GetIndex(2))
+	require.True(t, haves.GetIndex(3))
+	require.True(t, haves.GetIndex(4))
 
 	time.Sleep(500 * time.Millisecond)
 
-	// reactor 1 will gossip the haves with reactor 3
-	// check if the third reactor received the haves
 	r3State := reactor3.getPeer(reactor1.self)
 	require.NotNil(t, r3State)
 
 	r3Haves, r3Has := r3State.GetHaves(10, 1)
 	assert.True(t, r3Has)
-	assert.Contains(t, r3Haves.Parts, proptypes.PartMetaData{Index: 3, Proof: proof})
-	assert.Contains(t, r3Haves.Parts, proptypes.PartMetaData{Index: 4, Proof: proof})
+	require.True(t, r3Haves.GetIndex(2))
+	require.True(t, r3Haves.GetIndex(3))
+	require.True(t, r3Haves.GetIndex(4))
 
 	// since reactor 3 received the haves from reactor 1,
 	// it will send back a want.
 	// check if reactor 1 received the wants
 	r1Want, r1Has := reactor1.getPeer(reactor3.self).GetWants(10, 1)
 	assert.True(t, r1Has)
-	assert.Equal(t, int64(10), r1Want.Height)
-	assert.Equal(t, int32(1), r1Want.Round)
+	require.True(t, r1Want.GetIndex(2))
+	require.True(t, r1Want.GetIndex(3))
+	require.True(t, r1Want.GetIndex(4))
 
 	// add the recovery part to the reactor 1.
 	randomData := cmtrand.Bytes(10)

--- a/consensus/propagation/types/combined_partset.go
+++ b/consensus/propagation/types/combined_partset.go
@@ -1,11 +1,13 @@
 package types
 
 import (
+	"github.com/tendermint/tendermint/libs/bits"
 	"github.com/tendermint/tendermint/types"
 )
 
 // CombinedPartSet wraps two PartSet instances: one for original block data and one for parity data.
 type CombinedPartSet struct {
+	totalMap *bits.BitArray
 	original *types.PartSet // holds the original parts (indexes: 0 to original.Total()-1)
 	parity   *types.PartSet // holds parity parts (logical indexes start at original.Total())
 	lastLen  uint32
@@ -20,12 +22,36 @@ func NewCombinedSetFromCompactBlock(cb *CompactBlock) *CombinedPartSet {
 		Total: original.Total(),
 		Hash:  cb.BpHash,
 	})
+	total := bits.NewBitArray(int(original.Total()*2) - 1)
 
 	return &CombinedPartSet{
 		original: original,
 		parity:   parity,
 		lastLen:  cb.LastLen,
+		totalMap: total,
 	}
+}
+
+func NewCombinedPartSetFromOriginal(original *types.PartSet) *CombinedPartSet {
+	return &CombinedPartSet{
+		original: original,
+	}
+}
+
+func (cps *CombinedPartSet) Original() *types.PartSet {
+	return cps.original
+}
+
+func (cps *CombinedPartSet) Parity() *types.PartSet {
+	return cps.parity
+}
+
+func (cps *CombinedPartSet) BitArray() *bits.BitArray {
+	return cps.totalMap
+}
+
+func (cps *CombinedPartSet) Total() uint32 {
+	return cps.original.Total() + cps.parity.Total()
 }
 
 // CanDecode determines if enough parts have been added to decode the block.
@@ -35,6 +61,9 @@ func (cps *CombinedPartSet) CanDecode() bool {
 
 func (cps *CombinedPartSet) Decode() error {
 	_, _, err := types.Decode(cps.original, cps.parity, int(cps.lastLen))
+	if err == nil {
+		cps.totalMap.Fill()
+	}
 	return err
 }
 
@@ -47,10 +76,33 @@ func (cps *CombinedPartSet) AddPart(part RecoveryPart) (bool, error) {
 	}
 
 	if part.Index < cps.original.Total() {
-		return cps.original.AddPartWithoutProof(p)
+		added, err := cps.original.AddPartWithoutProof(p)
+		if added {
+			cps.totalMap.SetIndex(int(part.Index), true)
+		}
+		return added, err
 	}
 
 	// Adjust the index to be relative to the parity set.
 	p.Index -= cps.original.Total()
-	return cps.parity.AddPartWithoutProof(p)
+	added, err := cps.parity.AddPartWithoutProof(p)
+	if added {
+		cps.totalMap.SetIndex(int(part.Index), true)
+	}
+	return added, err
+}
+
+func (cps *CombinedPartSet) GetPart(index uint32) (*types.Part, bool) {
+	if !cps.totalMap.GetIndex(int(index)) {
+		return nil, false
+	}
+
+	if index < cps.original.Total() {
+		part := cps.original.GetPart(int(index))
+		return part, part != nil
+	}
+
+	part := cps.parity.GetPart(int(index - cps.original.Total()))
+
+	return part, part != nil
 }

--- a/consensus/propagation/types/combined_partset.go
+++ b/consensus/propagation/types/combined_partset.go
@@ -22,7 +22,7 @@ func NewCombinedSetFromCompactBlock(cb *CompactBlock) *CombinedPartSet {
 		Total: original.Total(),
 		Hash:  cb.BpHash,
 	})
-	total := bits.NewBitArray(int(original.Total()*2) - 1)
+	total := bits.NewBitArray(int(original.Total() * 2))
 
 	return &CombinedPartSet{
 		original: original,
@@ -54,6 +54,10 @@ func (cps *CombinedPartSet) Total() uint32 {
 	return cps.original.Total() + cps.parity.Total()
 }
 
+func (cps *CombinedPartSet) IsComplete() bool {
+	return cps.original.IsComplete() && cps.parity.IsComplete()
+}
+
 // CanDecode determines if enough parts have been added to decode the block.
 func (cps *CombinedPartSet) CanDecode() bool {
 	return (cps.original.Count() + cps.parity.Count()) >= cps.original.Total()
@@ -69,7 +73,7 @@ func (cps *CombinedPartSet) Decode() error {
 
 // AddPart adds a part to the combined part set. It assumes that the parts being
 // added have already been verified.
-func (cps *CombinedPartSet) AddPart(part RecoveryPart) (bool, error) {
+func (cps *CombinedPartSet) AddPart(part *RecoveryPart) (bool, error) {
 	p := &types.Part{
 		Index: part.Index,
 		Bytes: part.Data,
@@ -103,6 +107,5 @@ func (cps *CombinedPartSet) GetPart(index uint32) (*types.Part, bool) {
 	}
 
 	part := cps.parity.GetPart(int(index - cps.original.Total()))
-
 	return part, part != nil
 }

--- a/consensus/propagation/types/types.go
+++ b/consensus/propagation/types/types.go
@@ -137,6 +137,16 @@ type HaveParts struct {
 	Parts  []PartMetaData `json:"parts,omitempty"`
 }
 
+// BitArrary returns a bit array of the provided size with the indexes of the
+// parts set to true.
+func (h *HaveParts) BitArray(size int) *bits.BitArray {
+	ba := bits.NewBitArray(size)
+	for _, part := range h.Parts {
+		ba.SetIndex(int(part.Index), true)
+	}
+	return ba
+}
+
 // ValidateBasic checks if the HaveParts is valid. It fails if Parts is nil or
 // empty, or if any of the parts are invalid.
 func (h *HaveParts) ValidateBasic() error {
@@ -184,54 +194,6 @@ func (h *HaveParts) GetIndex(i uint32) bool {
 	return false
 }
 
-func (h *HaveParts) Copy() *HaveParts {
-	partsCopy := make([]PartMetaData, len(h.Parts))
-	for i, part := range h.Parts {
-		hashCopy := make([]byte, len(part.Hash))
-		copy(hashCopy, part.Hash)
-
-		partsCopy[i] = PartMetaData{
-			Index: part.Index,
-			Hash:  hashCopy,
-			Proof: merkle.Proof{
-				Total:    part.Proof.Total,
-				Index:    part.Proof.Index,
-				LeafHash: part.Proof.LeafHash,
-				Aunts:    part.Proof.Aunts, // TODO also deep copy this
-			},
-		}
-	}
-
-	return &HaveParts{
-		Height: h.Height,
-		Round:  h.Round,
-		Parts:  partsCopy,
-	}
-}
-
-// Sub
-// TODO document that this makes changes on the receiving object
-func (h *HaveParts) Sub(parts *bits.BitArray) {
-	size := min(len(h.Parts), parts.Size())
-	newParts := make([]PartMetaData, 0)
-	// TODO improve this implementation not to iterate this way on all possibilities
-	for i := 0; i < size; i++ {
-		if !parts.GetIndex(int(h.Parts[i].Index)) {
-			newParts = append(newParts, h.Parts[i])
-		}
-	}
-	h.Parts = newParts
-}
-
-func (h *HaveParts) GetTrueIndices() []int {
-	// TODO make this not iterate all over the elements
-	indices := make([]int, len(h.Parts))
-	for i, part := range h.Parts {
-		indices[i] = int(part.Index)
-	}
-	return indices
-}
-
 // ToProto converts HaveParts to its protobuf representation.
 func (h *HaveParts) ToProto() *protoprop.HaveParts {
 	parts := make([]*protoprop.PartMetaData, len(h.Parts))
@@ -247,16 +209,6 @@ func (h *HaveParts) ToProto() *protoprop.HaveParts {
 		Round:  h.Round,
 		Parts:  parts,
 	}
-}
-
-// ToBitArray converts a have parts to a bit array.
-// might be removed in the future once we support proofs.
-func (h *HaveParts) ToBitArray() *bits.BitArray {
-	array := bits.NewBitArray(len(h.Parts))
-	for _, part := range h.Parts {
-		array.SetIndex(int(part.Index), true)
-	}
-	return array
 }
 
 // HavePartFromProto converts a protobuf HaveParts to its Go representation.

--- a/node/node.go
+++ b/node/node.go
@@ -1506,7 +1506,7 @@ func makeNodeInfo(
 			mempl.MempoolChannel,
 			evidence.EvidenceChannel,
 			statesync.SnapshotChannel, statesync.ChunkChannel,
-			propagation.DataChannel, propagation.WantChannel,
+			// propagation.DataChannel, propagation.WantChannel, // todo: reenable when new reactor is actually working
 		},
 		Moniker: config.Moniker,
 		Other: p2p.DefaultNodeInfoOther{


### PR DESCRIPTION
## Description

fixes the peer state so that it actually stores state and then utilizes the parity data to reconstruct the block
