### PR TITLE
docs: fix typos on multiple files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 # allow users to pass additional flags via the conventional LDFLAGS variable
 LD_FLAGS += $(LDFLAGS)
 
-# Process Docker environment varible TARGETPLATFORM
+# Process Docker environment variable TARGETPLATFORM
 # in order to build binary with correspondent ARCH
 # by default will always build for linux/amd64
 TARGETPLATFORM ?=
@@ -336,7 +336,7 @@ endif
 
 # Run a nodejs tool to test endpoints against a localnet
 # The command takes care of starting and stopping the network
-# prerequisits: build-contract-tests-hooks build-linux
+# prerequisites: build-contract-tests-hooks build-linux
 # the two build commands were not added to let this command run from generic containers or machines.
 # The binaries should be built beforehand
 contract-tests:

--- a/consensus/ticker.go
+++ b/consensus/ticker.go
@@ -89,7 +89,7 @@ func (t *timeoutTicker) stopTimer() {
 }
 
 // send on tickChan to start a new timer.
-// timers are interupted and replaced by new ticks from later steps
+// timers are interrupted and replaced by new ticks from later steps
 // timeouts of 0 on the tickChan will be immediately relayed to the tockChan
 func (t *timeoutTicker) timeoutRoutine() {
 	t.Logger.Debug("Starting timeout routine")

--- a/crypto/merkle/proof_op.go
+++ b/crypto/merkle/proof_op.go
@@ -149,7 +149,7 @@ func (prt *ProofRuntime) VerifyValueFromKeys(proof *cmtcrypto.ProofOps, root []b
 	return prt.VerifyFromKeys(proof, root, keys, [][]byte{value})
 }
 
-// TODO In the long run we'll need a method of classifcation of ops,
+// TODO In the long run we'll need a method of classification of ops,
 // whether existence or absence or perhaps a third?
 func (prt *ProofRuntime) VerifyAbsence(proof *cmtcrypto.ProofOps, root []byte, keypath string) (err error) {
 	return prt.Verify(proof, root, keypath, nil)

--- a/libs/tempfile/tempfile.go
+++ b/libs/tempfile/tempfile.go
@@ -67,7 +67,7 @@ func randWriteFileSuffix() string {
 	suffix := strconv.Itoa(int(r))
 	if string(suffix[0]) == "-" {
 		// Replace first "-" with "0". This is purely for UI clarity,
-		// as otherwhise there would be two `-` in a row.
+		// as otherwise there would be two `-` in a row.
 		suffix = strings.Replace(suffix, "-", "0", 1)
 	}
 	return suffix

--- a/light/detector.go
+++ b/light/detector.go
@@ -287,7 +287,7 @@ func (c *Client) handleConflictingHeaders(
 }
 
 // examineConflictingHeaderAgainstTrace takes a trace from one provider and a divergent header that
-// it has received from another and preforms verifySkipping at the heights of each of the intermediate
+// it has received from another and performs verifySkipping at the heights of each of the intermediate
 // headers in the trace until it reaches the divergentHeader. 1 of 2 things can happen.
 //
 //  1. The light client verifies a header that is different to the intermediate header in the trace. This

--- a/light/detector.go
+++ b/light/detector.go
@@ -251,7 +251,7 @@ func (c *Client) handleConflictingHeaders(
 	// and generate evidence against the primary that we can send to the witness
 	commonBlock, trustedBlock := witnessTrace[0], witnessTrace[len(witnessTrace)-1]
 	evidenceAgainstPrimary := newLightClientAttackEvidence(primaryBlock, trustedBlock, commonBlock)
-	c.logger.Error("ATTEMPTED ATTACK DETECTED. Sending evidence againt primary by witness", "ev", evidenceAgainstPrimary,
+	c.logger.Error("ATTEMPTED ATTACK DETECTED. Sending evidence against primary by witness", "ev", evidenceAgainstPrimary,
 		"primary", c.primary, "witness", supportingWitness)
 	c.sendEvidence(ctx, evidenceAgainstPrimary, supportingWitness)
 

--- a/light/detector.go
+++ b/light/detector.go
@@ -407,7 +407,7 @@ func (c *Client) getTargetBlockOrLatest(
 
 	if lightBlock.Height > height {
 		// the witness has caught up. We recursively call the function again. However in order
-		// to avoud a wild goose chase where the witness sends us one header below and one header
+		// to avoid a wild goose chase where the witness sends us one header below and one header
 		// above the height we set a timeout to the context
 		lightBlock, err := witness.LightBlock(ctx, height)
 		return true, lightBlock, err

--- a/mempool/cat/cache.go
+++ b/mempool/cat/cache.go
@@ -10,7 +10,7 @@ import (
 
 // LRUTxCache maintains a thread-safe LRU cache of raw transactions. The cache
 // only stores the hash of the raw transaction.
-// NOTE: This has been copied from mempool/cache with the main diffence of using
+// NOTE: This has been copied from mempool/cache with the main difference of using
 // tx keys instead of raw transactions.
 type LRUTxCache struct {
 	staticSize int

--- a/mempool/cat/pool.go
+++ b/mempool/cat/pool.go
@@ -26,7 +26,7 @@ var (
 // TxPoolOption sets an optional parameter on the TxPool.
 type TxPoolOption func(*TxPool)
 
-// TxPool implemements the Mempool interface and allows the application to
+// TxPool implements the Mempool interface and allows the application to
 // set priority values on transactions in the CheckTx response. When selecting
 // transactions to include in a block, higher-priority transactions are chosen
 // first.  When evicting transactions from the mempool for size constraints,

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -250,7 +250,7 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 				// If we didn't request the transaction we simply mark the peer as having the
 				// tx (we'd have already done it if we were requesting the tx).
 				memR.mempool.PeerHasTx(peerID, key)
-				memR.Logger.Debug("received new trasaction", "peerID", peerID, "txKey", key)
+				memR.Logger.Debug("received new transaction", "peerID", peerID, "txKey", key)
 			}
 			_, err = memR.mempool.TryAddNewTx(ntx, key, txInfo)
 			if err != nil && err != ErrTxInMempool {

--- a/mempool/v0/clist_mempool_test.go
+++ b/mempool/v0/clist_mempool_test.go
@@ -500,7 +500,7 @@ func TestSerialReap(t *testing.T) {
 	// Reap again.  We should get the same amount
 	reapCheck(1000)
 
-	// Commit from the conensus AppConn
+	// Commit from the consensus AppConn
 	commitRange(0, 500)
 	updateRange(0, 500)
 

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -22,7 +22,7 @@ var _ mempool.Mempool = (*TxMempool)(nil)
 // TxMempoolOption sets an optional parameter on the TxMempool.
 type TxMempoolOption func(*TxMempool)
 
-// TxMempool implemements the Mempool interface and allows the application to
+// TxMempool implements the Mempool interface and allows the application to
 // set priority values on transactions in the CheckTx response. When selecting
 // transactions to include in a block, higher-priority transactions are chosen
 // first.  When evicting transactions from the mempool for size constraints,

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -590,7 +590,7 @@ FOR_LOOP:
 		c.recvMonitor.Update(_n)
 		if err != nil {
 			// stopServices was invoked and we are shutting down
-			// receiving is excpected to fail since we will close the connection
+			// receiving is expected to fail since we will close the connection
 			select {
 			case <-c.quitRecvRoutine:
 				break FOR_LOOP

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -19,7 +19,7 @@ import (
 
 var waitForEventTimeout = 8 * time.Second
 
-// MakeTxKV returns a text transaction, allong with expected key, value pair
+// MakeTxKV returns a text transaction, along with expected key, value pair
 func MakeTxKV() ([]byte, []byte, []byte) {
 	k := []byte(cmtrand.Str(8))
 	v := []byte(cmtrand.Str(8))

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -3039,7 +3039,7 @@ components:
           type: string
           example: "Dialing seeds in progress. See /net_info for details"
 
-    ###### Reuseable types ######
+    ###### Reusable types ######
 
     # Validator type with proposer prioirty
     ValidatorPriority:

--- a/state/execution.go
+++ b/state/execution.go
@@ -99,7 +99,7 @@ func (blockExec *BlockExecutor) SetEventBus(eventBus types.BlockEventPublisher) 
 
 // CreateProposalBlock calls state.MakeBlock with evidence from the evpool
 // and txs from the mempool. The max bytes must be big enough to fit the commit.
-// Up to 1/10th of the block space is allcoated for maximum sized evidence.
+// Up to 1/10th of the block space is allocated for maximum sized evidence.
 // The rest is given to txs, up to the max gas.
 //
 // Contract: application will not return more bytes than are sent over the wire.

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -264,7 +264,7 @@ func TestLastABCIResponses(t *testing.T) {
 		require.NoError(t, err)
 		// check to see if the saved response height is the same as the loaded height.
 		assert.Equal(t, lastResponse, response1)
-		// use an incorret height to make sure the state store errors.
+		// use an incorrect height to make sure the state store errors.
 		_, err = stateStore.LoadLastABCIResponse(height + 1)
 		assert.Error(t, err)
 		// check if the abci response didnt save in the abciresponses.

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -278,7 +278,7 @@ func (l *LightClientAttackEvidence) GetByzantineValidators(commonVals *Validator
 	return validators
 }
 
-// ConflictingHeaderIsInvalid takes a trusted header and matches it againt a conflicting header
+// ConflictingHeaderIsInvalid takes a trusted header and matches it against a conflicting header
 // to determine whether the conflicting header was the product of a valid state transition
 // or not. If it is then all the deterministic fields of the header should be the same.
 // If not, it is an invalid header and constitutes a lunatic attack.

--- a/types/validator.go
+++ b/types/validator.go
@@ -133,7 +133,7 @@ func (v *Validator) Bytes() []byte {
 	return bz
 }
 
-// ToProto converts Valiator to protobuf
+// ToProto converts Validator to protobuf
 func (v *Validator) ToProto() (*cmtproto.Validator, error) {
 	if v == nil {
 		return nil, errors.New("nil validator")


### PR DESCRIPTION
The errors in these codes were checked against [https://github.com/cometbft/cometbft](https://github.com/cometbft/cometbft). I also reviewed the errors there. These should be fixed directly in this repo.

Valiator to Validator
varible to variable
prerequisits to prerequisites
interupted to interrupted
trasaction to transaction
classifcation to classification
otherwhise to otherwise
againt to against 
preforms to performs
avoud to avoid
diffence to  difference
implemements to implements
conensus to consensus
excpected to expected
Reuseable to reusable
allong to along
allcoated to allocated
incorret to incorrect


