### PR TITLE
feat: purpose -1 to return all unconfirmed transactions in UnconfirmedTxs RPC

### DIFF
--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -154,7 +154,7 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 // UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
 // including their number.
 // More: https://docs.cometbft.com/v0.34/rpc/#/Info/unconfirmed_txs
-// If limit == -1, it will return all the unconfirmed transactions in the mempool.
+// If limitPtr == -1, it will return all the unconfirmed transactions in the mempool.
 func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
 	limit := *limitPtr
 	if limit != -1 {

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -154,9 +154,13 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 // UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
 // including their number.
 // More: https://docs.cometbft.com/v0.34/rpc/#/Info/unconfirmed_txs
+// If limit == -1, it will return all the unconfirmed transactions in the mempool.
 func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
-	// reuse per_page validator
-	limit := validatePerPage(limitPtr)
+	limit := *limitPtr
+	if limit != -1 {
+		// reuse per_page validator
+		limit = validatePerPage(limitPtr)
+	}
 	env := GetEnvironment()
 
 	txs := env.Mempool.ReapMaxTxs(limit)

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -824,7 +824,7 @@ paths:
       parameters:
         - in: query
           name: limit
-          description: Maximum number of unconfirmed transactions to return (max 100)
+          description: Maximum number of unconfirmed transactions to return (max 100). If set to -1, it will return all the unconfirmed mempool transactions.
           required: false
           schema:
             type: integer


### PR DESCRIPTION
## Description

Instead of creating a new RPC method that returns all the unconfirmed mempool transactions, I used -1 as a special flag to do that. I think it's fine to do so. If it's not, can always define a new endpoint.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

