### PR TITLE
docs: fix default indexer in config.toml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1199,13 +1199,7 @@ func TestStorageConfig() *StorageConfig {
 // TxIndexConfig defines the configuration for the transaction indexer,
 // including composite keys to index.
 type TxIndexConfig struct {
-	// What indexer to use for transactions
-	//
-	// Options:
-	//   1) "null"
-	//   2) "kv" (default) - the simplest possible indexer,
-	//      backed by key-value storage (defaults to levelDB; see DBBackend).
-	//   3) "psql" - the indexer services backed by PostgreSQL.
+	// Indexer is the indexer to use for transactions
 	Indexer string `mapstructure:"indexer"`
 
 	// The PostgreSQL connection configuration, the connection format:

--- a/config/toml.go
+++ b/config/toml.go
@@ -539,7 +539,7 @@ discard_abci_responses = {{ .Storage.DiscardABCIResponses}}
 # to decide which txs to index based on configuration set in the application.
 #
 # Options:
-#   1) "null" (default) - disable indexer
+#   1) "null" (default) - index transaction status only
 #   2) "kv" - index transactions using key-value storage based on DBBackend. "tx.height" and "tx.hash" will always be indexed.
 #   3) "psql" - index transactions using PostgreSQL. "tx.height" and "tx.hash" will always be indexed.
 indexer = "{{ .TxIndex.Indexer }}"

--- a/config/toml.go
+++ b/config/toml.go
@@ -539,11 +539,9 @@ discard_abci_responses = {{ .Storage.DiscardABCIResponses}}
 # to decide which txs to index based on configuration set in the application.
 #
 # Options:
-#   1) "null"
-#   2) "kv" (default) - the simplest possible indexer, backed by key-value storage (defaults to levelDB; see DBBackend).
-# 		- When "kv" is chosen "tx.height" and "tx.hash" will always be indexed.
-#   3) "psql" - the indexer services backed by PostgreSQL.
-# When "kv" or "psql" is chosen "tx.height" and "tx.hash" will always be indexed.
+#   1) "null" (default) - disable indexer
+#   2) "kv" - index transactions using key-value storage based on DBBackend. "tx.height" and "tx.hash" will always be indexed.
+#   3) "psql" - index transactions using PostgreSQL. "tx.height" and "tx.hash" will always be indexed.
 indexer = "{{ .TxIndex.Indexer }}"
 
 # The PostgreSQL connection configuration, the connection format:


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/1720

## Testing

Used this in celestia-app

```
./scripts/single-node.sh
cat ~/.celestia-app/config/config.toml
``` 


```
# What indexer to use for transactions
#
# The application will set which txs to index. In some cases a node operator will be able
# to decide which txs to index based on configuration set in the application.
#
# Options:
#   1) "null" (default) - index transaction status only
#   2) "kv" - index transactions using key-value storage based on DBBackend. "tx.height" and "tx.hash" will always be indexed.
#   3) "psql" - index transactions using PostgreSQL. "tx.height" and "tx.hash" will always be indexed.
indexer = "null"
```