### PR TITLE
feat: retry heights when adding proposal

### DIFF
--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -124,7 +124,7 @@ func chunkToPartMetaData(chunk *bits.BitArray, partSet *proptypes.CombinedPartSe
 func (blockProp *Reactor) handleCompactBlock(cb *proptypes.CompactBlock, peer p2p.ID, proposer bool) {
 	err := blockProp.validateCompactBlock(cb)
 	if !proposer && err != nil {
-		blockProp.Logger.Info("failed to validate proposal. ignoring", "err", err, "height", cb.Proposal.Height, "round", cb.Proposal.Round)
+		blockProp.Logger.Debug("failed to validate proposal. ignoring", "err", err, "height", cb.Proposal.Height, "round", cb.Proposal.Round)
 		return
 	}
 

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -32,7 +32,7 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts) {
 
 	_, parts, fullReqs, has := blockProp.getAllState(height, round, false)
 	if !has {
-		blockProp.Logger.Error("received have part for unknown proposal", "peer", peer, "height", height, "round", round)
+		//blockProp.Logger.Error("received have part for unknown proposal", "peer", peer, "height", height, "round", round)
 		// blockProp.Switch.StopPeerForError(blockProp.getPeer(peer).peer, errors.New("received part for unknown proposal"))
 		return
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -930,6 +930,7 @@ func NewNodeWithContext(ctx context.Context,
 	if !stateSync && !fastSync {
 		propagationReactor.StartProcessing()
 	}
+	propagationReactor.SetLogger(logger.With("module", "propagation"))
 
 	// Make ConsensusReactor. Don't enable fully if doing a state sync and/or fast sync first.
 	// FIXME We need to update metrics here, since other reactors don't have access to them.


### PR DESCRIPTION
## Description

Retries heights when adding a proposal while having a longer catchup frequency of 30s.

Also, retries heights the moment the propagation reactor starts processing in case it received any commitment during block/state sync.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

