### PR TITLE
docs: fix broken internal and external links in markdown files

### DIFF
--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -22,7 +22,7 @@ CometBFT is Byzantine Fault Tolerant (BFT) middleware that takes a state transit
 
 For more background, see the [the docs](https://docs.cometbft.com/v0.34/introduction/#quick-start).
 
-To get started developing applications, see the [application developers guide](https://docs.cometbft.com/v0.34/introduction/quick-start.html).
+To get started developing applications, see the [application developers guide](https://docs.cometbft.com/v0.34/guides/quick-start).
 
 ## How to use this image
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,7 +18,7 @@ oldest release is predominantly just security patches).
 As non-breaking changes land on `main`, they should also be backported to
 these backport branches.
 
-We use Mergify's [backport feature](https://mergify.io/features/backports) to
+We use Mergify's [backport feature](https://docs.mergify.com/workflow/actions/backport/) to
 automatically backport to the needed branch. There should be a label for any
 backport branch that you'll be targeting. To notify the bot to backport a pull
 request, mark the pull request with the label corresponding to the correct

--- a/abci/README.md
+++ b/abci/README.md
@@ -12,14 +12,16 @@ Previously, the ABCI was referred to as TMSP.
 
 ## Installation & Usage
 
-To get up and running quickly, see the [getting started guide](../docs/app-dev/getting-started.md) along with the [abci-cli documentation](../docs/app-dev/abci-cli.md) which will go through the examples found in the [examples](./example/) directory.
+To get up and running quickly, see the [getting started guide](https://github.com/cometbft/cometbft/blob/main/docs/guides/app-dev/getting-started.md)
+along with the [abci-cli documentation](https://github.com/cometbft/cometbft/blob/main/docs/guides/app-dev/abci-cli.md)
+which will go through the examples found in the [examples](./example/) directory.
 
 ## Specification
 
 A detailed description of the ABCI methods and message types is contained in:
 
-- [The main spec](https://github.com/cometbft/cometbft/blob/v0.34.x/spec/abci/README.md)
-- [A protobuf file](../proto/abci/types.proto)
+- [The main spec](https://github.com/cometbft/cometbft/blob/main/spec/abci/README.md)
+- [A protobuf file](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/types/v1/types.proto)
 - [A Go interface](./types/application.go)
 
 ## Protocol Buffers

--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -14,7 +14,7 @@ _methods_, each with a corresponding `Request` and `Response`message type.
 To perform state-machine replication, CometBFT calls the ABCI methods on the
 ABCI application by sending the `Request*` messages and receiving the `Response*` messages in return.
 
-All ABCI messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/v0.34.x/proto/abci/types.proto).
+All ABCI messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/v0.34.x/proto/tendermint/abci/types.proto).
 This allows CometBFT to run with applications written in many programming languages.
 
 This specification is split as follows:

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -32,10 +32,10 @@ be synchronized during `Commit`.
 In principle, each of the four ABCI connections operate concurrently with one
 another. This means applications need to ensure access to state is
 thread safe. In practice, both the
-[default in-process ABCI client](https://github.com/cometbft/cometbft/blob/v0.34.4/abci/client/local_client.go#L18)
+[default in-process ABCI client](https://github.com/cometbft/cometbft/blob/v0.34.x/abci/client/local_client.go#L18)
 and the
 [default Go ABCI
-server](https://github.com/cometbft/cometbft/blob/v0.34.4/abci/server/socket_server.go#L32)
+server](https://github.com/cometbft/cometbft/blob/v0.34.x/abci/server/socket_server.go#L32)
 use global locks across all connections, so they are not
 concurrent at all. This means if your app is written in Go, and compiled in-process with CometBFT
 using the default `NewLocalClient`, or run out-of-process using the default `SocketServer`,


### PR DESCRIPTION
## Description

This pull request fixes several broken or outdated links across the documentation and spec files in the repository. 

The following files were affected:
- `DOCKER/README.md`
- `RELEASES.md`
- `abci/README.md`
- `spec/abci/README.md`
- `spec/abci/apps.md`

Most of the fixes involve:
- Updating links pointing to old paths (e.g., `docs/app-dev/`) to their new locations in the CometBFT repo (`docs/guides/app-dev/`).
- Replacing local or missing `.proto` and `.go` file references with stable links pointing to files on GitHub.
- Updating outdated external links, such as Mergify's backport feature documentation.

### Example error output

![Pasted Graphic 9](https://github.com/user-attachments/assets/57e787a1-7d45-4d1b-b051-ab1c9ffcec50)


