### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/spec/consensus/consensus-paper/IEEEtran.cls
+++ b/spec/consensus/consensus-paper/IEEEtran.cls
@@ -125,7 +125,7 @@
 %    margins will be the same and the text will be horizontally centered. 
 %    For final submission to IEEE, authors should use US letter (8.5 X 11in)
 %    paper. Note that authors should ensure that all post-processing 
-%    (ps, pdf, etc.) uses the same paper specificiation as the .tex document.
+%    (ps, pdf, etc.) uses the same paper specification as the .tex document.
 %    Problems here are by far the number one reason for incorrect margins.
 %    IEEEtran will automatically set the default paper size under pdflatex 
 %    (without requiring a change to pdftex.cfg), so this issue is more

--- a/spec/consensus/signing.md
+++ b/spec/consensus/signing.md
@@ -151,7 +151,7 @@ these basic validation rules.
 
 Signers must be careful not to sign conflicting messages, also known as "double signing" or "equivocating".
 CometBFT has mechanisms to publish evidence of validators that signed conflicting votes, so they can be punished
-by the application. Note CometBFT does not currently handle evidence of conflciting proposals, though it may in the future.
+by the application. Note CometBFT does not currently handle evidence of conflicting proposals, though it may in the future.
 
 ### State
 

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -72,7 +72,7 @@ set (TODO). Execute is defined as:
 
 ```go
 func Execute(state State, app ABCIApp, block Block) State {
- // Fuction ApplyBlock executes block of transactions against the app and returns the new root hash of the app state,
+ // Function ApplyBlock executes block of transactions against the app and returns the new root hash of the app state,
  // modifications to the validator set and the changes of the consensus parameters.
  AppHash, ValidatorChanges, ConsensusParamChanges := app.ApplyBlock(block)
 


### PR DESCRIPTION
This PR fixes several typos across documentation files:

- spec/consensus/consensus-paper/IEEEtran.cls: Fix typo "specificiation" -> "specification"
- spec/consensus/signing.md: Fix typo "conflciting" -> "conflicting" 
- spec/core/data_structures.md: Fix typo "Fuction" -> "Function"

These are minor text corrections that improve readability of the documentation.
#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

