### PR TITLE
chore: set default RPC GRPC listen address

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -443,7 +443,7 @@ func DefaultRPCConfig() *RPCConfig {
 		CORSAllowedOrigins:     []string{},
 		CORSAllowedMethods:     []string{http.MethodHead, http.MethodGet, http.MethodPost},
 		CORSAllowedHeaders:     []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time"},
-		GRPCListenAddress:      "",
+		GRPCListenAddress:      "localhost:9090",
 		GRPCMaxOpenConnections: 900,
 
 		Unsafe:             false,


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/4629

celestia-app v4 can't start up without a RPC GRPC listen address so IMO we should update the default config to populate it.

@julienrbrt is this the correct address to default to?