### PR TITLE
test(evidence): fix flaky TestReactorsGossipNoCommittedEvidence by comparing hashes instead of objects

### DIFF
--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -185,7 +185,9 @@ func TestReactorsGossipNoCommittedEvidence(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 
 	peerEv, _ = pools[1].PendingEvidence(1000)
-	assert.EqualValues(t, []types.Evidence{evList[0], evList[1]}, peerEv)
+	require.Len(t, peerEv, 2)
+    assert.Equal(t, evList[0].Hash(), peerEv[0].Hash())
+    assert.Equal(t, evList[1].Hash(), peerEv[1].Hash())
 }
 
 func TestReactorBroadcastEvidenceMemoryLeak(t *testing.T) {


### PR DESCRIPTION
### Summary
Closes #1739 
 
This PR fixes a flakiness issue in the `TestReactorsGossipNoCommittedEvidence` test under the `evidence` package.

The test would occasionally fail due to `assert.Equal` comparing evidence objects by pointer, even though their content was identical. This caused non-deterministic failures during CI runs.

### Test

`go test ./evidence -run TestReactorsGossipNoCommittedEvidence -count=10`

![image](https://github.com/user-attachments/assets/1992c4e3-e492-4a56-b977-2849596f5fb7)

#### PR checklist

- [X] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

