### PR TITLE
chore: return if compact block is nil in handle have

### DIFF
--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -37,6 +37,10 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts) {
 		return
 	}
 
+	if cb == nil {
+		// we can't process haves for a compact block we don't have
+		return
+	}
 	err := haves.ValidatePartHashes(cb.PartsHashes)
 	if err != nil {
 		blockProp.Logger.Error("received invalid have part", "height", haves.Height, "round", haves.Round, "parts", haves.Parts, "err", err)


### PR DESCRIPTION
Fixes a nil pointer that can happen if the compact block is nil

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

