### PR TITLE
fix: increment the current height when adding a commitment

### DIFF
--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -108,6 +108,8 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 		maxRequests: bits.NewBitArray(int(psh.Total * 2)), // this assumes that the parity parts are the same size
 	}
 
+	blockProp.currentHeight = height + 1
+
 	go blockProp.retryWants(height)
 }
 

--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -116,6 +116,12 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 	}
 	blockProp.Logger.Info("added commitment", "height", height, "round", round)
 
+	// increment the local copies of the height and round
+	blockProp.currentHeight = height + 1
+	blockProp.currentRound = 0
+	blockProp.consensusHeight = height
+	blockProp.consensusRound = 0
+
 	go blockProp.retryWants(height + 1)
 }
 

--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -116,9 +116,7 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 	}
 	blockProp.Logger.Info("added commitment", "height", height, "round", round)
 
-	blockProp.currentHeight = height + 1
-
-	go blockProp.retryWants(height)
+	go blockProp.retryWants(height + 1)
 }
 
 func shuffle[T any](slice []T) []T {


### PR DESCRIPTION
@rach-id found that removing the current height fixed the issues we were seeing in the e2e test. Intuitively, this fix makes sense since we started verifying the proposal we won't increment the current height, which means we wouldn't retry. I'm not sure how it was working before tbh.