### PR TITLE
fix: replace deprecated grpc.Dial with grpc.NewClient 

### DIFF
--- a/abci/client/grpc_client_test.go
+++ b/abci/client/grpc_client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cometbft/cometbft/libs/log"
 	cmtnet "github.com/cometbft/cometbft/libs/net"
@@ -41,7 +42,10 @@ func TestGRPC(t *testing.T) {
 
 	// Connect to the socket
 	//nolint:staticcheck // SA1019 Existing use of deprecated but supported dial option.
-	conn, err := grpc.Dial(socket, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc))
+	conn, err := grpc.NewClient(socket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialerFunc),
+	)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/abci/client/grpc_client_test.go
+++ b/abci/client/grpc_client_test.go
@@ -41,10 +41,8 @@ func TestGRPC(t *testing.T) {
 	})
 
 	// Connect to the socket
-	//nolint:staticcheck // SA1019 Existing use of deprecated but supported dial option.
 	conn, err := grpc.NewClient(socket,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialerFunc),
 	)
 	require.NoError(t, err)
 
@@ -76,8 +74,4 @@ func TestGRPC(t *testing.T) {
 		}
 
 	}
-}
-
-func dialerFunc(_ context.Context, addr string) (net.Conn, error) {
-	return cmtnet.Connect(addr)
 }

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -86,10 +86,6 @@ func StartGRPCClient(protoAddr string) BroadcastAPIClient {
 	return NewBroadcastAPIClient(conn)
 }
 
-func dialerFunc(_ context.Context, addr string) (net.Conn, error) {
-	return cmtnet.Connect(addr)
-}
-
 // StartBlockAPIGRPCClient dials the gRPC server using protoAddr and returns a new
 // BlockAPIClient.
 func StartBlockAPIGRPCClient(protoAddr string, opts ...grpc.DialOption) (BlockAPIClient, error) {


### PR DESCRIPTION
Closes #1587

Key changes:
- Updated gRPC client initializations to use `grpc.NewClient`.
- Normalized address parsing using `NormalizeGRPCAddress` where applicable.
- Adjusted test client connection in `grpc_client_test.go` to also use `grpc.NewClient`.
- Imported `google.golang.org/grpc/credentials/insecure` where needed.

## Context

The `grpc.Dial` function has been deprecated, and this change aligns the codebase with the recommended `grpc.NewClient` usage, avoiding deprecation warnings and ensuring compatibility with future gRPC versions.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

