### PR TITLE
feat: allow separate directory for blockstore

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -220,6 +220,9 @@ type BaseConfig struct { //nolint: maligned
 	// Database directory
 	DBPath string `mapstructure:"db_dir"`
 
+	// Blockstore directory. If not set, defaults to DBPath
+	BlockstorePath string `mapstructure:"blockstore_dir"`
+
 	// Output level for logging
 	LogLevel string `mapstructure:"log_level"`
 
@@ -266,6 +269,7 @@ func DefaultBaseConfig() BaseConfig {
 		FilterPeers:        false,
 		DBBackend:          "goleveldb",
 		DBPath:             DefaultDataDir,
+		BlockstorePath:     DefaultDataDir,
 	}
 }
 
@@ -300,6 +304,14 @@ func (cfg BaseConfig) NodeKeyFile() string {
 // DBDir returns the full path to the database directory
 func (cfg BaseConfig) DBDir() string {
 	return rootify(cfg.DBPath, cfg.RootDir)
+}
+
+// BlockstoreDir returns the full path to the blockstore directory
+func (cfg BaseConfig) BlockstoreDir() string {
+	if cfg.BlockstorePath == "" {
+		return cfg.DBDir()
+	}
+	return rootify(cfg.BlockstorePath, cfg.RootDir)
 }
 
 // ValidateBasic performs basic validation (checking param bounds, etc.) and

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,12 +24,13 @@ func TestDefaultConfig(t *testing.T) {
 	cfg.SetRoot("/foo")
 	cfg.Genesis = "bar"
 	cfg.DBPath = "/opt/data"
+	cfg.BlockstorePath = "/opt/blockstore"
 	cfg.Mempool.WalPath = "wal/mem/"
 
 	assert.Equal("/foo/bar", cfg.GenesisFile())
 	assert.Equal("/opt/data", cfg.DBDir())
+	assert.Equal("/opt/blockstore", cfg.BlockstoreDir())
 	assert.Equal("/foo/wal/mem", cfg.Mempool.WalDir())
-
 }
 
 func TestConfigValidateBasic(t *testing.T) {
@@ -228,4 +229,22 @@ func TestCommitWithCustomTimeout(t *testing.T) {
 	customTimeout := 2 * time.Second
 	expectedTime = inputTime.Add(customTimeout)
 	assert.Equal(t, expectedTime, cfg.CommitWithCustomTimeout(inputTime, customTimeout))
+}
+
+func TestBlockstoreDir(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	// Test 1: When BlockstorePath is not set, it should default to DBDir
+	cfg.SetRoot("/foo")
+	cfg.DBPath = "data"
+	cfg.BlockstorePath = ""
+	assert.Equal(t, cfg.DBDir(), cfg.BlockstoreDir())
+
+	// Test 2: When BlockstorePath is set, it should use that path
+	cfg.BlockstorePath = "blockstore"
+	assert.Equal(t, "/foo/blockstore", cfg.BlockstoreDir())
+
+	// Test 3: Test with absolute paths
+	cfg.BlockstorePath = "/opt/blockstore"
+	assert.Equal(t, "/opt/blockstore", cfg.BlockstoreDir())
 }

--- a/config/db.go
+++ b/config/db.go
@@ -16,6 +16,7 @@ type ServiceProvider func(context.Context, *Config, log.Logger) (service.Service
 type DBContext struct {
 	ID     string
 	Config *Config
+	Path   string
 }
 
 // DBProvider takes a DBContext and returns an instantiated DB.
@@ -25,6 +26,9 @@ type DBProvider func(*DBContext) (dbm.DB, error)
 // specified in the Config.
 func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
 	dbType := dbm.BackendType(ctx.Config.DBBackend)
-
-	return dbm.NewDB(ctx.ID, dbType, ctx.Config.DBDir())
+	path := ctx.Path
+	if path == "" {
+		path = ctx.Config.DBDir()
+	}
+	return dbm.NewDB(ctx.ID, dbType, path)
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -113,6 +113,9 @@ db_backend = "{{ .BaseConfig.DBBackend }}"
 # Database directory
 db_dir = "{{ js .BaseConfig.DBPath }}"
 
+# Blockstore directory. If not set, defaults to db_dir
+blockstore_dir = "{{ js .BaseConfig.BlockstorePath }}"
+
 # Output level for logging, including package level options
 log_level = "{{ .BaseConfig.LogLevel }}"
 

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -66,6 +66,11 @@ db_backend = "goleveldb"
 # Database directory
 db_dir = "data"
 
+# Blockstore directory. If not set, defaults to db_dir.
+# This allows placing the blockstore on a separate volume (e.g. HDD)
+# while keeping the state store on a faster volume (e.g. SSD).
+blockstore_dir = "data"
+
 # Output level for logging, including package level options
 log_level = "info"
 

--- a/node/setup.go
+++ b/node/setup.go
@@ -109,13 +109,13 @@ type blockSyncReactor interface {
 
 func initDBs(config *cfg.Config, dbProvider cfg.DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
 	var blockStoreDB dbm.DB
-	blockStoreDB, err = dbProvider(&cfg.DBContext{ID: "blockstore", Config: config})
+	blockStoreDB, err = dbProvider(&cfg.DBContext{ID: "blockstore", Config: config, Path: config.BlockstoreDir()})
 	if err != nil {
 		return
 	}
 	blockStore = store.NewBlockStore(blockStoreDB)
 
-	stateDB, err = dbProvider(&cfg.DBContext{ID: "state", Config: config})
+	stateDB, err = dbProvider(&cfg.DBContext{ID: "state", Config: config, Path: config.DBDir()})
 	if err != nil {
 		return
 	}

--- a/node/setup_test.go
+++ b/node/setup_test.go
@@ -1,0 +1,66 @@
+package node
+
+import (
+	"testing"
+
+	dbm "github.com/cometbft/cometbft-db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cfg "github.com/cometbft/cometbft/config"
+)
+
+func TestInitDBs(t *testing.T) {
+	testCases := []struct {
+		name           string
+		blockstorePath string
+		expectSamePath bool
+	}{
+		{
+			name:           "custom blockstore path",
+			blockstorePath: "blockstore",
+			expectSamePath: false,
+		},
+		{
+			name:           "default blockstore path",
+			blockstorePath: "", // Should default to DBPath
+			expectSamePath: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := cfg.DefaultConfig()
+			config.SetRoot(t.TempDir())
+			config.DBPath = "data"
+			config.BlockstorePath = tc.blockstorePath
+
+			// Create a custom DBProvider that tracks which paths were used
+			paths := make(map[string]string)
+			dbProvider := func(ctx *cfg.DBContext) (dbm.DB, error) {
+				paths[ctx.ID] = ctx.Path
+				return cfg.DefaultDBProvider(ctx)
+			}
+
+			blockStore, stateDB, err := initDBs(config, dbProvider)
+			require.NoError(t, err)
+			defer func() {
+				if blockStore != nil {
+					blockStore.Close()
+				}
+				if stateDB != nil {
+					stateDB.Close()
+				}
+			}()
+
+			if tc.expectSamePath {
+				assert.Equal(t, paths["state"], paths["blockstore"], "expected state and blockstore to use same path")
+				assert.Equal(t, config.DBDir(), paths["blockstore"])
+			} else {
+				assert.NotEqual(t, paths["state"], paths["blockstore"], "expected state and blockstore to use different paths")
+				assert.Equal(t, config.BlockstoreDir(), paths["blockstore"])
+				assert.Equal(t, config.DBDir(), paths["state"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow specifying a different directory for the blockstore via a new 'blockstore_dir' config option. This enables node operators to place the append-only blockstore on a separate volume (e.g. HDD) while keeping the frequently updated state store on a faster volume (e.g. SSD).

Changes:
- Add BlockstorePath field to BaseConfig
- Add BlockstoreDir() method to get the full path
- Update initDBs to use separate paths for blockstore and state
- Add documentation for the new config option
- Add unit tests for config and database initialization

If blockstore_dir is not set, it defaults to the existing db_dir path for backward compatibility.

Closes #1811 

---

#### PR checklist

- [ ] Tests written/updated
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

