### PR TITLE
ci: disable dependabot for `main`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    target-branch: "main"
+    target-branch: "v0.38.x-celestia"
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -14,56 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    target-branch: "v0.37.x"
+    target-branch: "v0.34.x-celestia"
     open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - automerge
-
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-    target-branch: "v0.34.x"
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - automerge
-
-  ###################################
-  ##
-  ## Update All Go Dependencies
-
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: weekly
-    target-branch: "main"
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - automerge
-
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: daily
-    target-branch: "v0.37.x"
-    # Only allow automated security-related dependency updates on release
-    # branches.
-    open-pull-requests-limit: 0
-    labels:
-      - dependencies
-      - automerge
-
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: daily
-    target-branch: "v0.34.x"
-    # Only allow automated security-related dependency updates on release
-    # branches.
-    open-pull-requests-limit: 0
     labels:
       - dependencies
       - automerge


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/1816 by disabling dependabot on `main`.

After this, we should only get PRs for Github actions dependencies but also open to disabling those and bumping them only when we pull upstream.