### PR TITLE
Corrected typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,7 +284,7 @@ This release contains a few bug fixes and performance improvements.
 
 ### FEATURES
 
-- [`node`] Add `BootstrapStateWithGenProvider` to boostrap state using a custom
+- [`node`] Add `BootstrapStateWithGenProvider` to bootstrap state using a custom
   genesis doc provider ([\#2793](https://github.com/cometbft/cometbft/pull/2793))
 
 ### IMPROVEMENTS

--- a/spec/consensus/evidence.md
+++ b/spec/consensus/evidence.md
@@ -5,7 +5,7 @@ order: 4
 # Evidence
 
 Evidence is an important component of CometBFT's security model. Whilst the core
-consensus protocol provides correctness gaurantees for state machine replication
+consensus protocol provides correctness guarantees for state machine replication
 that can tolerate less than 1/3 failures, the evidence system looks to detect and
 gossip byzantine faults whose combined power is greater than  or equal to 1/3. It is worth noting that
 the evidence system is designed purely to detect possible attacks, gossip them,
@@ -78,7 +78,7 @@ should be committed within a certain period from the point that it occurred
 (timely). Timelines is defined by the `EvidenceParams`: `MaxAgeNumBlocks` and
 `MaxAgeDuration`. In Proof of Stake chains where validators are bonded, evidence
 age should be less than the unbonding period so validators still can be
-punished. Given these two propoerties the following initial checks are made.
+punished. Given these two properties the following initial checks are made.
 
 1. Has the evidence expired? This is done by taking the height of the `Vote`
    within `DuplicateVoteEvidence` or `CommonHeight` within
@@ -127,11 +127,11 @@ Valid Light Client Attack Evidence must adhere to the following rules:
 
 ## Gossiping
 
-If a node verifies evidence it then broadcasts it to all peers, continously sending
+If a node verifies evidence it then broadcasts it to all peers, continuously sending
 the same evidence once every 10 seconds until the evidence is seen on chain or
 expires.
 
-## Commiting on Chain
+## Committing on Chain
 
 Evidence takes strict priority over regular transactions, thus a block is filled
 with evidence first and transactions take up the remainder of the space. To

--- a/spec/consensus/proposer-based-timestamp/pbts_001_draft.md
+++ b/spec/consensus/proposer-based-timestamp/pbts_001_draft.md
@@ -21,7 +21,7 @@ In CometBFT, the first version of how time is computed and stored in a block wor
 1. **Liveness.** The liveness of the protocol:
    1. does not depend on clock synchronization,
    1. depends on bounded message delays.
-1. **Relation to real time.** There is no clock synchronizaton, which implies that there is **no relation** between the computed block `time` and real time.
+1. **Relation to real time.** There is no clock synchronization, which implies that there is **no relation** between the computed block `time` and real time.
 1. **Aggregate signatures.** As the `precommit` messages contain the local times, all these `precommit` messages typically differ in the time field, which **prevents** the use of aggregate signatures.
 
 ## Suggested Proposer-Based Time

--- a/spec/consensus/proposer-selection.md
+++ b/spec/consensus/proposer-selection.md
@@ -94,7 +94,7 @@ Each row shows the priority queue and the process place in it. The proposer is t
 It can be shown that:
 
 - At the end of each run k+1 the sum of the priorities is the same as at end of run k. If a new set's priorities are initialized to 0 then the sum of priorities will be 0 at each run while there are no changes.
-- The max distance between priorites is (n-1) *P.*[formal proof not finished]*
+- The max distance between priorities is (n-1) *P.*[formal proof not finished]*
 
 ## Validator Set Changes
 
@@ -108,7 +108,7 @@ Validator | p1 | p2
 ----------|----|---
 VP        | 4  | 3
 
-Let's also assume that before this change the proposer priorites were as shown in first row (last run). As it can be seen, the selection could run again, without changes, as before.
+Let's also assume that before this change the proposer priorities were as shown in first row (last run). As it can be seen, the selection could run again, without changes, as before.
 
 | Priority   Run | -2 | -1 | 0 | 1  | 2  | Comment           |
 |----------------|----|----|---|----|----|-------------------|
@@ -121,7 +121,7 @@ However, when a validator changes power from a high to a low value, some other v
 As before:
 
 - At the end of each run k+1 the sum of the priorities is the same as at run k.
-- The max distance between priorites is (n-1) * P.
+- The max distance between priorities is (n-1) * P.
 
 ### Validator Removal
 
@@ -274,7 +274,7 @@ The modified selection algorithm is:
 
 Observations:
 
-- With this modification, the maximum distance between priorites becomes 2 * P.
+- With this modification, the maximum distance between priorities becomes 2 * P.
 
 Note also that even during steady state the priority range may increase beyond 2 * P. The scaling introduced here  helps to keep the range bounded.
 

--- a/spec/consensus/signing.md
+++ b/spec/consensus/signing.md
@@ -152,7 +152,7 @@ these basic validation rules.
 
 Signers must be careful not to sign conflicting messages, also known as "double signing" or "equivocating".
 CometBFT has mechanisms to publish evidence of validators that signed conflicting votes, so they can be punished
-by the application. Note CometBFT does not currently handle evidence of conflciting proposals, though it may in the future.
+by the application. Note CometBFT does not currently handle evidence of conflicting proposals, though it may in the future.
 
 ### State
 


### PR DESCRIPTION
Changes made in:

- /CHANGELOG.md ("boostrap" → "bootstrap")

- /spec/consensus/proposer-selection.md ("priorites" → "priorities")

- /spec/consensus/proposer-selection.md ("priorites" → "priorities")

- /spec/consensus/proposer-selection.md ("priorites" → "priorities")

- /spec/consensus/evidence.md ("gaurantees" → "guarantees")

- /spec/consensus/evidence.md ("propoerties" → "properties")

- /spec/consensus/evidence.md ("continously" → "continuously")

- /spec/consensus/evidence.md ("Commiting" → "Committing")

- /spec/consensus/signing.md ("conflciting" → "conflicting")

- /spec/consensus/proposer-based-timestamp/pbts_001_draft.md ("synchronizaton" → "synchronization")
