### PR TITLE
fix: Remove unused const declaration

### DIFF
--- a/state/indexer/sink/psql/backport.go
+++ b/state/indexer/sink/psql/backport.go
@@ -25,10 +25,6 @@ import (
 	"github.com/cometbft/cometbft/types"
 )
 
-const (
-	eventTypeFinalizeBlock = "finalize_block"
-)
-
 // TxIndexer returns a bridge from es to the CometBFT v0.34 transaction indexer.
 func (es *EventSink) TxIndexer() BackportTxIndexer {
 	return BackportTxIndexer{psql: es}


### PR DESCRIPTION
This pull request removes an unused const declaration from the codebase. Keeping unused code leads to clutter and potential confusion for future contributors. Removing such declarations helps maintain code clarity and overall project quality. No functional changes are introduced.


