### PR TITLE
fix: remove TimeIotaMs validation

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -89,11 +89,6 @@ func ValidateConsensusParams(params cmtproto.ConsensusParams) error {
 			params.Block.MaxGas)
 	}
 
-	if params.Block.TimeIotaMs <= 0 {
-		return fmt.Errorf("block.TimeIotaMs must be greater than 0. Got %v",
-			params.Block.TimeIotaMs)
-	}
-
 	if params.Evidence.MaxAgeNumBlocks <= 0 {
 		return fmt.Errorf("evidence.MaxAgeNumBlocks must be greater than 0. Got %d",
 			params.Evidence.MaxAgeNumBlocks)

--- a/types/params_test.go
+++ b/types/params_test.go
@@ -31,7 +31,6 @@ func TestConsensusParamsValidation(t *testing.T) {
 		5: {makeParams(101*1024*1024, 0, 10, 2, 0, valEd25519), false},
 		6: {makeParams(1024*1024*1024, 0, 10, 2, 0, valEd25519), false},
 		7: {makeParams(1024*1024*1024, 0, 10, -1, 0, valEd25519), false},
-		8: {makeParams(1, 0, -10, 2, 0, valEd25519), false},
 		// test evidence params
 		9:  {makeParams(1, 0, 10, 0, 0, valEd25519), false},
 		10: {makeParams(1, 0, 10, 2, 2, valEd25519), false},


### PR DESCRIPTION
Implements https://github.com/celestiaorg/celestia-app/issues/4888#issuecomment-2912992268

Follow ups
- [ ] Create a v0.34.x-celestia release
- [ ] Bump in v3.x on celestia-app
- [ ] Create another v3.x celestia-app release
- [ ] Re-test downgrading from v4.x to v3.x