### PR TITLE
chore: add debug info to `ErrPartSetInvalidProof`

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -301,13 +301,11 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 
 	// The proof should be compatible with the number of parts.
 	if part.Proof.Total != int64(ps.total) {
-		fmt.Printf("part.Proof.Total: %d, ps.total: %d\n", part.Proof.Total, ps.total)
 		return false, fmt.Errorf("%w: part.Proof.Total: %d != ps.total: %d", ErrPartSetInvalidProof, part.Proof.Total, ps.total)
 	}
 
 	// Check hash proof
 	if err := part.Proof.Verify(ps.Hash(), part.Bytes); err != nil {
-		fmt.Printf("part.Proof.Verify(ps.Hash(), part.Bytes) = %v\n", err)
 		return false, fmt.Errorf("%w: part.Proof.Verify(ps.Hash(), part.Bytes) = %v", ErrPartSetInvalidProof, err)
 	}
 


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/4859

## Motivation

Currently the two instances where `ErrPartSetInvalidProof` is returned look identical. This PR modifies the errors so to include additional information that will help with debugging.