### PR TITLE
refactor: use `AddPart` implementation from upstream

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -314,12 +314,12 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 
 	// The proof should be compatible with the number of parts.
 	if part.Proof.Total != int64(ps.total) {
-		return false, ErrPartSetInvalidProof
+		return false, fmt.Errorf("%w: part.Proof.Total: %d != ps.total: %d", ErrPartSetInvalidProof, part.Proof.Total, ps.total)
 	}
 
 	// Check hash proof
-	if part.Proof.Verify(ps.Hash(), part.Bytes) != nil {
-		return false, ErrPartSetInvalidProof
+	if err := part.Proof.Verify(ps.Hash(), part.Bytes); err != nil {
+		return false, fmt.Errorf("%w: part.Proof.Verify(ps.Hash(), part.Bytes) = %v", ErrPartSetInvalidProof, err)
 	}
 
 	// Add part

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -330,8 +330,8 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 	return true, nil
 }
 
-// AddPartWithoutProof was inspired by the AddPart method but it doesn't
-// validate the proof inside part.
+// AddPartWithoutProof is a Celestia-specific method that was inspired by the
+// AddPart method. AddPartWithoutProof ignores the Proof inside part.
 func (ps *PartSet) AddPartWithoutProof(part *Part) (bool, error) {
 	// TODO: remove this? would be preferable if this only returned (false, nil)
 	// when its a duplicate block part

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -224,3 +224,37 @@ func TestPartProtoBuf(t *testing.T) {
 		}
 	}
 }
+
+// TestAddPartWithoutProof is inspired by TestWrongProof. It verifies that
+// AddPartWithoutProof accepts parts with proofs that do not validate.
+func TestAddPartWithoutProof(t *testing.T) {
+	data := cmtrand.Bytes(testPartSize * 100)
+	partSet := NewPartSetFromData(data, testPartSize)
+
+	// Test adding a part with wrong data.
+	partSet2 := NewPartSetFromHeader(partSet.Header())
+
+	// Test adding a part with wrong trail.
+	part := partSet.GetPart(0)
+	part.Proof.Aunts[0][0] += byte(0x01)
+	_, err := partSet2.AddPartWithoutProof(part)
+	require.NoError(t, err)
+
+	// Test adding a part with wrong bytes.
+	part = partSet.GetPart(1)
+	part.Bytes[0] += byte(0x01)
+	_, err = partSet2.AddPartWithoutProof(part)
+	require.NoError(t, err)
+
+	// Test adding a part with wrong proof index.
+	part = partSet.GetPart(2)
+	part.Proof.Index = 1
+	_, err = partSet2.AddPartWithoutProof(part)
+	require.NoError(t, err)
+
+	// Test adding a part with wrong proof total.
+	part = partSet.GetPart(3)
+	part.Proof.Total = int64(partSet.Total() - 1)
+	_, err = partSet2.AddPartWithoutProof(part)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/4859#issuecomment-2916545585

Reverts the `AddPart` implementation in celestia-core to match upstream v0.38.17. See [here](https://github.com/cometbft/cometbft/blob/v0.38.17/types/part_set.go#L294-L331). Now the only diff in `AddPart` is the modification to include more detailed error messages. 