### PR TITLE
refactor: address book to return all peers

### DIFF
--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -386,7 +386,7 @@ func (a *addrBook) ReinstateBadPeers() {
 }
 
 // GetSelection implements AddrBook.
-// It randomly selects some addresses (old & new). Suitable for peer-exchange protocols.
+// It returns all addresses (old & new). Suitable for peer-exchange protocols.
 // Must never return a nil address.
 func (a *addrBook) GetSelection() []*p2p.NetAddress {
 	a.mtx.Lock()
@@ -400,30 +400,12 @@ func (a *addrBook) GetSelection() []*p2p.NetAddress {
 		return nil
 	}
 
-	numAddresses := cmtmath.MaxInt(
-		cmtmath.MinInt(minGetSelection, bookSize),
-		bookSize*getSelectionPercent/100)
-	numAddresses = cmtmath.MinInt(maxGetSelection, numAddresses)
-
-	// XXX: instead of making a list of all addresses, shuffling, and slicing a random chunk,
-	// could we just select a random numAddresses of indexes?
-	allAddr := make([]*p2p.NetAddress, bookSize)
-	i := 0
-	for _, ka := range a.addrLookup {
-		allAddr[i] = ka.Addr
-		i++
+	// Return all addresses from addrLookup
+	addresses := make([]*p2p.NetAddress, 0, len(a.addrLookup))
+	for _, knownAddr := range a.addrLookup {
+		addresses = append(addresses, knownAddr.Addr)
 	}
-
-	// Fisher-Yates shuffle the array. We only need to do the first
-	// `numAddresses' since we are throwing the rest.
-	for i := 0; i < numAddresses; i++ {
-		// pick a number between current index and the end
-		j := cmtrand.Intn(len(allAddr)-i) + i
-		allAddr[i], allAddr[j] = allAddr[j], allAddr[i]
-	}
-
-	// slice off the limit we are willing to share.
-	return allAddr[:numAddresses]
+	return addresses
 }
 
 func percentageOfNum(p, n int) int {

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -265,7 +265,7 @@ func TestAddrBookGetSelection(t *testing.T) {
 	book.SetLogger(log.TestingLogger())
 
 	// 1) empty book
-	assert.Empty(t, book.GetSelection())
+	assert.Nil(t, book.GetSelection())
 
 	// 2) add one address
 	addr := randIPv4Address(t)
@@ -292,9 +292,8 @@ func TestAddrBookGetSelection(t *testing.T) {
 		addrs[addr.String()] = addr
 	}
 
-	if len(selection) > book.Size() {
-		t.Errorf("selection %v could not be bigger than the book", selection)
-	}
+	// assert that selection is the same as the number of addresses in the book
+	assert.Equal(t, len(selection), book.Size())
 }
 
 func TestAddrBookGetSelectionWithBias(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes #1892 

## Testing

There are existing unit tests that I extended to assert that `GetSelection()` returns all peers. Testing this on Mocha will be most useful after we complete https://github.com/celestiaorg/celestia-core/issues/1893 because even though now address book returns all peers current peering implementation will prevent you to actually connect with more peers cc @tzdybal 

