### PR TITLE
fix: set default proxy_app config value to align with app/v4-cosmos-sdk

### DIFF
--- a/abci/cmd/abci-cli/abci-cli.go
+++ b/abci/cmd/abci-cli/abci-cli.go
@@ -107,7 +107,7 @@ func addGlobalFlags() {
 	RootCmd.PersistentFlags().StringVarP(&flagAddress,
 		"address",
 		"",
-		"tcp://0.0.0.0:26658",
+		"tcp://0.0.0.0:36658",
 		"address of application socket")
 	RootCmd.PersistentFlags().StringVarP(&flagAbci, "abci", "", "socket", "either socket or grpc")
 	RootCmd.PersistentFlags().BoolVarP(&flagVerbose,

--- a/abci/tests/client_server_test.go
+++ b/abci/tests/client_server_test.go
@@ -13,7 +13,7 @@ import (
 func TestClientServerNoAddrPrefix(t *testing.T) {
 	t.Helper()
 
-	addr := "localhost:26658"
+	addr := "localhost:36658"
 	transport := "socket"
 	app := kvstore.NewInMemoryApplication()
 

--- a/abci/tests/test_cli/testHelp.out
+++ b/abci/tests/test_cli/testHelp.out
@@ -22,7 +22,7 @@ Available Commands:
 
 Flags:
       --abci string        either socket or grpc (default "socket")
-      --address string     address of application socket (default "tcp://0.0.0.0:26658")
+      --address string     address of application socket (default "tcp://0.0.0.0:36658")
   -h, --help               help for abci-cli
       --log_level string   set the logger level (default "debug")
   -v, --verbose            print the command and results as if it were a console session

--- a/config/config.go
+++ b/config/config.go
@@ -262,7 +262,7 @@ func DefaultBaseConfig() BaseConfig {
 		PrivValidatorState: defaultPrivValStatePath,
 		NodeKey:            defaultNodeKeyPath,
 		Moniker:            defaultMoniker,
-		ProxyApp:           "tcp://127.0.0.1:26658",
+		ProxyApp:           "tcp://127.0.0.1:36658",
 		ABCI:               "socket",
 		LogLevel:           DefaultLogLevel,
 		LogFormat:          LogFormatPlain,

--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -45,7 +45,7 @@ Available Commands:
 
 Flags:
       --abci string        either socket or grpc (default "socket")
-      --address string     address of application socket (default "tcp://0.0.0.0:26658")
+      --address string     address of application socket (default "tcp://0.0.0.0:36658")
   -h, --help               help for abci-cli
       --log_level string   set the logger level (default "debug")
   -v, --verbose            print the command and results as if it were a console session

--- a/docs/app-dev/getting-started.md
+++ b/docs/app-dev/getting-started.md
@@ -64,7 +64,7 @@ Available Commands:
 
 Flags:
       --abci string        either socket or grpc (default "socket")
-      --address string     address of application socket (default "tcp://0.0.0.0:26658")
+      --address string     address of application socket (default "tcp://0.0.0.0:36658")
   -h, --help               help for abci-cli
       --log_level string   set the logger level (default "debug")
   -v, --verbose            print the command and results as if it were a console session

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -35,7 +35,7 @@ version = "0.38.0"
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the CometBFT binary
-proxy_app = "tcp://127.0.0.1:26658"
+proxy_app = "tcp://127.0.0.1:36658"
 
 # A custom human readable name for this node
 moniker = "anonymous"

--- a/docs/core/using-cometbft.md
+++ b/docs/core/using-cometbft.md
@@ -130,7 +130,7 @@ cometbft node
 ```
 
 By default, CometBFT will try to connect to an ABCI application on
-`tcp://127.0.0.1:26658`. If you have the `kvstore` ABCI app installed, run it in
+`tcp://127.0.0.1:36658`. If you have the `kvstore` ABCI app installed, run it in
 another window. If you don't, kill CometBFT and run an in-process version of
 the `kvstore` app:
 

--- a/docs/networks/docker-compose.md
+++ b/docs/networks/docker-compose.md
@@ -158,7 +158,7 @@ Override the [command](https://github.com/cometbft/cometbft/blob/v0.38.x/network
       - LOG=$${LOG:-cometbft.log}
     volumes:
       - ./build:/cometbft:Z
-    command: node --proxy_app=tcp://abci0:26658
+    command: node --proxy_app=tcp://abci0:36658
     networks:
       localnet:
         ipv4_address: 192.167.10.2

--- a/test/e2e/node/socket.toml
+++ b/test/e2e/node/socket.toml
@@ -2,4 +2,4 @@ snapshot_interval = 100
 persist_interval = 1
 chain_id = "test-chain"
 protocol = "socket"
-listen = "tcp://127.0.0.1:26658"
+listen = "tcp://127.0.0.1:36658"


### PR DESCRIPTION
ref: https://github.com/celestiaorg/celestia-app/issues/4940

In celestia-app/v4 and cosmos-sdk-v0.50-celestia the `address` / `proxy_app` default port was updated to `36658` to not collide with celestia-node when node operators would run a bridge node alongside a celestia consensus node running the app in standalone mode (i.e. with multiplexer).

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

