### PR TITLE
fix: validate received haves match wants and adjust canSend logic in propagation

### DIFF
--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -140,7 +140,7 @@ func (blockProp *Reactor) requestFromPeer(ps *PeerState) {
 				parts    *proptypes.CombinedPartSet
 				fullReqs *bits.BitArray
 			)
-			for i := canSend; i > 0; {
+			for i := min(canSend, int64(len(ps.receivedHaves))); i > 0; {
 				if len(ps.receivedHaves) == 0 {
 					break
 				}
@@ -148,6 +148,12 @@ func (blockProp *Reactor) requestFromPeer(ps *PeerState) {
 				have, ok := <-ps.receivedHaves
 				if !ok {
 					return
+				}
+
+				if wants != nil && (have.height != wants.Height || have.round != wants.Round) {
+					// haves for a new height, resetting
+					wants = nil
+					parts = nil
 				}
 
 				if !blockProp.relevantHave(have.height, have.round) {


### PR DESCRIPTION
Fixes audit issue: **Race condition in HaveParts processing during height transitions**

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

