### PR TITLE
feat: Reactor Specific Peers

### DIFF
--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -191,7 +191,7 @@ func (bcR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 }
 
 // AddPeer implements Reactor by sending our state to peer.
-func (bcR *Reactor) AddPeer(peer p2p.Peer) {
+func (bcR *Reactor) AddPeer(peer p2p.Peer) error {
 	peer.Send(p2p.Envelope{
 		ChannelID: BlocksyncChannel,
 		Message: &bcproto.StatusResponse{
@@ -203,6 +203,7 @@ func (bcR *Reactor) AddPeer(peer p2p.Peer) {
 
 	// peer is added to the pool once we receive the first
 	// bcStatusResponseMessage from the peer and call pool.SetPeerRange
+	return nil
 }
 
 // RemovePeer implements Reactor by removing peer from the pool.

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -586,9 +586,9 @@ func NewByzantineReactor(conR *Reactor) *ByzantineReactor {
 
 func (br *ByzantineReactor) SetSwitch(s *p2p.Switch)               { br.reactor.SetSwitch(s) }
 func (br *ByzantineReactor) GetChannels() []*p2p.ChannelDescriptor { return br.reactor.GetChannels() }
-func (br *ByzantineReactor) AddPeer(peer p2p.Peer) {
+func (br *ByzantineReactor) AddPeer(peer p2p.Peer) error {
 	if !br.reactor.IsRunning() {
-		return
+		return nil
 	}
 
 	// Create peerState for peer
@@ -600,6 +600,7 @@ func (br *ByzantineReactor) AddPeer(peer p2p.Peer) {
 	if !br.reactor.waitSync {
 		br.reactor.sendNewRoundStepMessage(peer)
 	}
+	return nil
 }
 
 func (br *ByzantineReactor) RemovePeer(peer p2p.Peer, reason interface{}) {

--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -191,7 +191,8 @@ func (blockProp *Reactor) AddPeer(peer p2p.Peer) error {
 
 	cb, _, found := blockProp.GetCurrentCompactBlock()
 	if !found {
-		return fmt.Errorf("failed to get current compact block, peer: %v", peer.ID())
+		blockProp.Logger.Error("failed to get current compact block", "peer", peer.ID())
+		return nil
 	}
 
 	// send the current proposal

--- a/consensus/propagation/reactor_test.go
+++ b/consensus/propagation/reactor_test.go
@@ -109,11 +109,11 @@ func TestCountRequests(t *testing.T) {
 	reactor := reactors[0]
 
 	peer1 := mock.NewPeer(nil)
-	reactor.AddPeer(peer1)
+	require.NoError(t, reactor.AddPeer(peer1))
 	peer2 := mock.NewPeer(nil)
-	reactor.AddPeer(peer2)
+	require.NoError(t, reactor.AddPeer(peer2))
 	peer3 := mock.NewPeer(nil)
-	reactor.AddPeer(peer3)
+	require.NoError(t, reactor.AddPeer(peer3))
 
 	peer1State := reactor.getPeer(peer1.ID())
 	// peer1 requests part=0 at height=10, round=0

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -203,9 +203,9 @@ func (conR *Reactor) InitPeer(peer p2p.Peer) p2p.Peer {
 
 // AddPeer implements Reactor by spawning multiple gossiping goroutines for the
 // peer.
-func (conR *Reactor) AddPeer(peer p2p.Peer) {
+func (conR *Reactor) AddPeer(peer p2p.Peer) error {
 	if !conR.IsRunning() {
-		return
+		return nil
 	}
 
 	peerState, ok := peer.Get(types.PeerStateKey).(*PeerState)
@@ -228,6 +228,7 @@ func (conR *Reactor) AddPeer(peer p2p.Peer) {
 	if !conR.WaitSync() {
 		conR.sendNewRoundStepMessage(peer)
 	}
+	return nil
 }
 
 func isLegacyPropagation(peer p2p.Peer) (bool, error) {

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -286,7 +286,7 @@ func TestReactorReceiveDoesNotPanicIfAddPeerHasntBeenCalledYet(t *testing.T) {
 				Type:   cmtproto.PrevoteType,
 			},
 		})
-		reactor.AddPeer(peer)
+		require.NoError(t, reactor.AddPeer(peer))
 	})
 }
 

--- a/docs/celestia-architecture/adr-010-reactor-specific-peers.md
+++ b/docs/celestia-architecture/adr-010-reactor-specific-peers.md
@@ -1,0 +1,123 @@
+# ADR 010: Reactor Specific Peers
+
+## Changelog
+
+- {date}: Initial creation of Reactor Specific Peers ADR.
+
+## Context
+
+Currently, the `Switch` component handles all peer connections and interactions with reactors in a centralized manner. Peers are shared across all reactors, and the same logic applies to every reactor during operations such as **peer addition**, **removal**, or **broadcasting**.
+
+However, there are cases where specific reactors may need to operate on different subsets of the peer set. For example:
+1. A consensus reactor might need persistent connections with validators but not with non-validator nodes.
+2. A state sync reactor might only require peers currently engaged in state synchronization.
+
+The current design does not allow such flexibility, as all reactors share the same peer set managed by the `Switch`. Separating peer management by reactor would unlock enhanced flexibility and scalability without introducing unnecessary complexity.
+
+## Alternative Approaches
+
+### Centralized Peer Set
+
+Keep the peer set centralized in the `Switch` and rely on reactor-specific conditions or tags for filtering:
+- **Pros**:
+    - No additional component or API (`PeerManager`) needed.
+    - Reduces coordination between the `Switch` and other components.
+- **Cons**:
+    - Reactors depend on global filtering logic, which adds complexity for handling peer subsets.
+    - Centralizing conditions reduces flexibility and may lead to inefficiency.
+
+### Reactor-Defined Policies
+
+Allow reactors to implement custom logic for peer lifecycle management independently:
+- **Pros**:
+    - Greater independence for reactors.
+    - Reactors control their own state and subset of peers directly.
+- **Cons**:
+    - Duplicates common lifecycle logic and peer management tasks across reactors.
+    - No centralized enforcement of connection policies, leading to inconsistencies.
+
+## Decision
+
+This change introduces a `PeerManager` component that delegates **peer lifecycle management** and allows subsets of the peer set to be assigned to individual reactors. This enables reactors to maintain and interact with a **reactor-specific subset** of peers.
+
+### Proposed Solution: Combined Alternative
+
+There will be two main components:
+1. **PeerManager**:
+    - Centrally manages the lifecycle of peers (e.g., validation, filtering, reconnection, termination).
+    - Maintains the full peer set and allows subsets of peers to be defined for individual reactors.
+    - Maps and tracks peer-reactor assignments based on reactor-specific criteria.
+
+2. **Switch**:
+    - Delegates peer management responsibilities to the `PeerManager`.
+    - Routes reactor interactions only to their assigned peer subsets.
+    - Starts and stops reactors independently, without worrying about connection states.
+
+#### Key Features:
+- Reactors can define customized criteria for which peers they interact with and operate only on their assigned subset.
+- The `PeerManager` controls connection policies such as reconnection for persistent peers, filtering, and connection limits.
+
+## Detailed Design
+
+> Must be completed prior to the merging of the implementation.
+
+### Workflow
+
+1. **Peer Addition**:
+    - The transport layer notifies the `PeerManager` when a new peer is connected.
+    - The `PeerManager` validates, filters, and, if approved, assigns the peer to one or multiple reactors based on their criteria.
+
+2. **Reactor-Specific Peer Interaction**:
+    - Each reactor interacts only with its assigned subset of peers.
+    - Reactors may independently add or remove specific peers from their subset.
+
+3. **Broadcasting**:
+    - When broadcasting messages, the `Switch` ensures only peers within the corresponding reactor's subset are targeted.
+
+4. **Reconnection and Removal**:
+    - The `PeerManager` implements policies for reconnection, persistent peers, and termination.
+    - If a peer is removed, all reactors interacting with that peer are notified.
+
+### Systems Affected
+- The `Switch` must delegate peer lifecycle management to the `PeerManager`.
+- Transport layers that add or remove peers will now interact with the `PeerManager` instead of the `Switch`.
+
+### API Changes
+- A new API will allow reactors to specify the subsets of peers they interact with.
+- APIs for broadcasting or managing peers within the `Switch` will now use the `PeerManager`'s subset handling logic.
+
+### Efficiency Considerations
+- Minimal performance overhead due to centralized peer lifecycle logic in the `PeerManager`.
+- Enhanced filtering enables reactors to scale efficiently by avoiding overhead caused by irrelevant peers.
+
+### Observability
+- Peer management metrics (e.g., reconnections, filtering) will be tracked centrally within the `PeerManager`.
+
+## Status
+
+**Proposed**
+
+## Consequences
+
+### Positive
+1. **Reactor-Specific Peer Sets**:
+    - Reactors can define and operate on different subsets of peers without affecting other reactors.
+2. **Single Responsibility Principle (SRP)**:
+    - The `PeerManager` focuses on connection and lifecycle management, freeing the `Switch` to handle reactor coordination and communication.
+3. **Scalability**:
+    - Clear separation of concerns simplifies scaling policies, such as dynamic peer scoring or adaptive subsets per reactor.
+4. **Flexibility**:
+    - Reactors gain independence to operate on peers that make sense for their specific functions.
+5. **Observability**:
+    - Centralized metrics and events related to peer management (e.g., reconnections, filtering) are handled by the `PeerManager`.
+
+### Negative
+1. **Implementation Overhead**:
+    - Introducing the `PeerManager` and refactoring existing `Switch` responsibilities require significant effort.
+2. **Coordination Complexity**:
+    - Additional communication paths are necessary between the `PeerManager` and `Switch`.
+
+### Neutral
+- The flexibility provided by this approach may not be needed by all reactors upfront. However, it lays a foundation for future scaling.
+
+## References

--- a/docs/celestia-architecture/adr-010-reactor-specific-peers.md
+++ b/docs/celestia-architecture/adr-010-reactor-specific-peers.md
@@ -3,6 +3,7 @@
 ## Changelog
 
 - 28.05.2025: Initial creation of Reactor Specific Peers ADR.
+- 24.06.2025: Update ADR after with learnings from initial development.
 
 ## Context
 
@@ -26,53 +27,93 @@ Keep the peer set centralized in the `Switch` and rely on reactor-specific condi
     - Reactors depend on global filtering logic, which adds complexity for handling peer subsets.
     - Centralizing conditions reduces flexibility and may lead to inefficiency.
 
-### Reactor-Defined Policies
+### Reactor-Defined Policies with PeerManager Component
 
-Allow reactors to implement custom logic for peer lifecycle management independently:
+Allow reactors to implement custom logic for peer lifecycle management independently with a dedicated `PeerManager` component:
 - **Pros**:
     - Greater independence for reactors.
     - Reactors control their own state and subset of peers directly.
+    - Clear separation of concerns with dedicated peer management component.
 - **Cons**:
     - Duplicates common lifecycle logic and peer management tasks across reactors.
     - No centralized enforcement of connection policies, leading to inconsistencies.
+    - Requires significant refactoring across the entire codebase.
+    - Introduces complex coordination between `PeerManager` and `Switch`.
+
+### Minimal Invasive Approach (Chosen Implementation)
+
+Extend the existing `Switch` with per-channel peer sets and reactor-specific peer acceptance logic:
+- **Pros**:
+    - Minimal changes to existing architecture.
+    - Backward compatible with existing reactors.
+    - Infrastructure-first approach enables future enhancements.
+    - No new components required.
+- **Cons**:
+    - Limited initial differentiation of peer sets.
+    - Requires reactors to opt-in to selective peer management.
 
 ## Decision
 
-This change introduces a `PeerManager` component that delegates **peer lifecycle management** and allows subsets of the peer set to be assigned to individual reactors. This enables reactors to maintain and interact with a **reactor-specific subset** of peers.
+This change introduces **reactor-specific peer sets** by extending the existing `Switch` component with per-channel peer management and reactor-specific peer acceptance logic. This enables reactors to maintain and interact with a **reactor-specific subset** of peers while maintaining backward compatibility.
 
-### Proposed Solution: Combined Alternative
+### Chosen Solution: Minimal Invasive Approach
 
-**Architecture Decision: Two-Component vs Single-Component Approach**
+**Architecture Decision: Extend Existing Switch vs New PeerManager Component**
 
-We chose a two-component approach (`PeerManager` + updated `Switch`) instead of consolidating everything into the `Switch` for the following reasons:
+We chose to extend the existing `Switch` component rather than introducing a new `PeerManager` component for the following reasons:
 
-**Benefits of Separation**:
-1. **Single Responsibility Principle**: The `PeerManager` focuses solely on peer lifecycle (connection, validation, assignment), while the `Switch` handles reactor coordination and message routing.
-2. **Testability**: Peer management logic can be tested independently of reactor coordination logic.
-3. **Future Extensibility**: The `PeerManager` can be enhanced with advanced features (peer scoring, adaptive peer selection) without cluttering the `Switch`.
-4. **Clear Interface Boundaries**: Well-defined APIs between components reduce coupling.
-5. **Code Reuse Potential**: With clear separation of concerns, we might be able to reuse some peer management code from libp2p libraries.
+**Benefits of Extension**:
+1. **Minimal Disruption**: Leverages existing architecture without requiring changes across the entire codebase.
+2. **Backward Compatibility**: Existing reactors continue to work without modification.
+3. **Infrastructure-First**: Provides the capability for selective peer management without forcing immediate behavioral changes.
+4. **Gradual Migration**: Reactors can opt-in to selective peer management as needed.
+5. **Simplified Testing**: Changes are contained within the existing P2P layer.
 
-**Communication Complexity Mitigation**:
-- The `PeerManager` will expose a simple interface to the `Switch` for peer assignment and retrieval operations.
-- The `Switch` will delegate peer lifecycle events to `PeerManager` but retain control over message routing.
-
-There will be two main components:
-1. **PeerManager**:
-    - Centrally manages the lifecycle of peers (e.g., validation, filtering, reconnection, termination).
-    - Maintains the full peer set and allows subsets of peers to be defined for individual reactors.
-    - Maps and tracks peer-reactor assignments based on reactor-specific criteria.
-
-2. **Switch**:
-    - Delegates peer management responsibilities to the `PeerManager`.
-    - Routes reactor interactions only to their assigned peer subsets.
-    - Starts and stops reactors independently, without worrying about connection states.
+**Implementation Details**:
+- The `Switch` now maintains `peerSetByChID map[byte]*PeerSet` to track peers per channel
+- Reactors can reject peers during `AddPeer()` by returning an error
+- Broadcasting is isolated per reactor using `peersForEnvelope()`
+- **Reference counting mechanism**: Tracks how many reactor peer sets contain each peer
+- **Conditional peer disconnection**: Only drops connections when reference count reaches zero
+- **Graceful peer removal**: Reactors can remove peers from their sets without affecting other reactors
+- **Error-based immediate disconnection**: Bypasses reference counting for error conditions
 
 #### Key Features:
-- Reactors can define customized criteria for which peers they interact with and operate only on their assigned subset.
-- The `PeerManager` controls connection policies such as reconnection for persistent peers, filtering, and connection limits.
+- **Per-channel peer sets**: Each reactor's channels get their own peer set
+- **Reactor-specific peer acceptance**: Reactors can implement custom logic in `AddPeer()` to accept or reject peers
+- **Isolated broadcasting**: Messages are only sent to peers that belong to the specific reactor's peer set
+- **Graceful peer rejection**: The switch handles peer rejections gracefully without breaking the connection
+- **Smart peer removal**: Peers are only disconnected when no reactors need them or on error conditions
 
 ## Detailed Design
+
+### Peer Removal Logic
+
+The peer removal logic implements a reference-counting approach to determine when to actually disconnect peers:
+
+#### Removal Scenarios:
+
+1. **Error-based Removal**:
+   - When a peer encounters an error (network issues, protocol violations, etc.)
+   - The peer is immediately removed from all reactor peer sets
+   - The underlying connection is dropped regardless of other reactors' needs
+
+2. **Graceful Reactor Removal**:
+   - When a reactor no longer needs a peer (e.g., state sync completed, peer limit reached)
+   - The peer is removed from that reactor's peer set only
+   - The underlying connection is maintained if other reactors still have the peer in their sets
+   - Only when the peer is removed from ALL reactor peer sets is the connection dropped
+
+3. **Reactor Shutdown**:
+   - When a reactor is stopped, all its peer references are removed
+   - Peers are only disconnected if no other reactors reference them
+
+#### Implementation Requirements:
+
+- **Reference Counting**: Track how many reactors have each peer in their peer sets
+- **Conditional Disconnection**: Only drop the connection when reference count reaches zero
+- **Error Handling**: Immediate disconnection on errors, bypassing reference counting
+- **Reactor Coordination**: Ensure reactors can independently remove peers without affecting others
 
 ### Reactor-Specific Peer Requirements
 
@@ -109,65 +150,86 @@ This section defines which reactors require which types of peers and the behavio
 #### Backward Compatibility for Existing Reactors:
 - **Default Behavior**: Reactors that don't specify peer criteria will receive all available peers (current behavior).
 - **Opt-in Migration**: Existing reactors can gradually adopt peer-specific criteria without breaking changes.
-- **Interface Compatibility**: Current reactor interfaces (`AddPeer`, `RemovePeer`) remain unchanged.
+- **Interface Compatibility**: Current reactor interfaces (`AddPeer`, `RemovePeer`) remain unchanged, with `AddPeer` now returning an error.
 
 ### Workflow
 
 1. **Peer Addition**:
-    - The transport layer notifies the `PeerManager` when a new peer is connected.
-    - The `PeerManager` validates, filters, and, if approved, assigns the peer to one or multiple reactors based on their criteria.
+    - The transport layer notifies the `Switch` when a new peer is connected.
+    - The `Switch` attempts to add the peer to each reactor via `AddPeer()`.
+    - If a reactor returns an error from `AddPeer()`, the peer is not added to that reactor's peer set.
+    - The peer is only added to peer sets of reactors that successfully accept it.
 
 2. **Reactor-Specific Peer Interaction**:
     - Each reactor interacts only with its assigned subset of peers.
-    - Reactors may independently add or remove specific peers from their subset.
+    - Reactors may independently reject peers during the connection process.
 
 3. **Broadcasting**:
-    - When broadcasting messages, the `Switch` ensures only peers within the corresponding reactor's subset are targeted.
+    - When broadcasting messages, the `Switch` uses `peersForEnvelope()` to target only peers within the corresponding reactor's peer set.
 
 4. **Reconnection and Removal**:
-    - The `PeerManager` implements policies for reconnection, persistent peers, and termination.
-    - If a peer is removed, all reactors interacting with that peer are notified.
+    - The `Switch` continues to handle reconnection, persistent peers, and termination.
+    - If a peer is removed, it is removed from all reactor peer sets.
+    - **Reference Counting**: The switch maintains a reference count for each peer across all reactor peer sets.
+    - **Graceful Removal**: When a reactor removes a peer from its set, the reference count is decremented. The connection is only dropped when the count reaches zero.
+    - **Error-based Removal**: On peer errors, the peer is immediately removed from all reactor sets and the connection is dropped.
+    - **Reactor Shutdown**: When a reactor stops, all its peer references are removed, potentially triggering disconnections for peers no longer needed by any reactor.
 
 ### Systems Affected
-- The `Switch` must delegate peer lifecycle management to the `PeerManager`.
-- Transport layers that add or remove peers will now interact with the `PeerManager` instead of the `Switch`.
+- The `Switch` now maintains per-channel peer sets alongside the global peer set.
+- All reactor implementations have updated `AddPeer()` signatures to return errors.
+- Broadcasting logic is modified to use reactor-specific peer sets.
 
 ### API Changes
-- A new API will allow reactors to specify the subsets of peers they interact with.
-- APIs for broadcasting or managing peers within the `Switch` will now use the `PeerManager`'s subset handling logic.
+- `AddPeer(peer Peer)` → `AddPeer(peer Peer) error` in the Reactor interface
+- New `peersForEnvelope(e Envelope) []Peer` method in Switch
+- Enhanced `TxStatus` RPC endpoint with `REJECTED` status for mempool transactions
+- **New peer removal methods**: Reactors can call `RemovePeerFromReactor(peer Peer)` to gracefully remove a peer from their set without affecting other reactors
+- **Reference counting API**: Internal methods to track peer references across reactor peer sets
+- **Error-based removal**: Existing `StopPeerForError(peer Peer, reason interface{})` continues to work but now immediately drops connections
 
 ### Efficiency Considerations
-- Minimal performance overhead due to centralized peer lifecycle logic in the `PeerManager`.
+- Minimal performance overhead due to maintaining both global and per-channel peer sets.
 - Enhanced filtering enables reactors to scale efficiently by avoiding overhead caused by irrelevant peers.
 
 ### Observability
-- Peer management metrics (e.g., reconnections, filtering) will be tracked centrally within the `PeerManager`.
+- Peer management metrics (e.g., peer rejections, reactor-specific peer counts) are tracked within the existing metrics system.
 
 ## Status
 
-**Proposed**
+**Partialy implemented**
 
 ## Consequences
 
 ### Positive
 1. **Reactor-Specific Peer Sets**:
     - Reactors can define and operate on different subsets of peers without affecting other reactors.
-2. **Single Responsibility Principle (SRP)**:
-    - The `PeerManager` focuses on connection and lifecycle management, freeing the `Switch` to handle reactor coordination and communication.
-3. **Scalability**:
-    - Clear separation of concerns simplifies scaling policies, such as dynamic peer scoring or adaptive subsets per reactor.
+2. **Backward Compatibility**:
+    - Existing reactors continue to work without modification.
+3. **Infrastructure-First Approach**:
+    - Provides the capability for selective peer management without forcing immediate behavioral changes.
 4. **Flexibility**:
     - Reactors gain independence to operate on peers that make sense for their specific functions.
-5. **Observability**:
-    - Centralized metrics and events related to peer management (e.g., reconnections, filtering) are handled by the `PeerManager`.
+5. **Minimal Disruption**:
+    - Leverages existing architecture without requiring changes across the entire codebase.
+6. **Efficient Resource Management**:
+    - Reference counting prevents unnecessary peer disconnections when multiple reactors share peers.
+7. **Graceful Degradation**:
+    - Reactors can independently manage their peer relationships without affecting others.
 
 ### Negative
-1. **Implementation Overhead**:
-    - Introducing the `PeerManager` and refactoring existing `Switch` responsibilities require significant effort.
-2. **Coordination Complexity**:
-    - Additional communication paths are necessary between the `PeerManager` and `Switch`, though mitigated by clear interface boundaries.
+1. **Limited Initial Differentiation**:
+    - All peer sets are currently identical as most reactors accept all peers.
+2. **Dual Peer Set Maintenance**:
+    - Both global and per-channel peer sets are maintained, adding some complexity.
+3. **Opt-in Nature**:
+    - Reactors must explicitly implement selective peer management to benefit from the feature.
+4. **Reference Counting Complexity**:
+    - Additional logic required to track peer references across reactor sets.
+5. **Peer Removal Coordination**:
+    - Need to ensure reactors can safely remove peers without race conditions.
 
 ### Neutral
-- The flexibility provided by this approach may not be needed by all reactors upfront. However, it lays a foundation for future scaling.
+- The flexibility provided by this approach may not be needed by all reactors upfront. However, it lays a foundation for future scaling and more sophisticated peer management strategies.
 
 ## References

--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -65,8 +65,9 @@ func (evR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 }
 
 // AddPeer implements Reactor.
-func (evR *Reactor) AddPeer(peer p2p.Peer) {
+func (evR *Reactor) AddPeer(peer p2p.Peer) error {
 	go evR.broadcastEvidenceRoutine(peer)
+	return nil
 }
 
 // Receive implements Reactor.

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -221,7 +221,7 @@ func TestReactorBroadcastEvidenceMemoryLeak(t *testing.T) {
 
 	r := evidence.NewReactor(pool)
 	r.SetLogger(log.TestingLogger())
-	r.AddPeer(p)
+	require.NoError(t, r.AddPeer(p))
 
 	_ = sendEvidence(t, pool, val, 2)
 	r.OnStop()

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -274,7 +274,7 @@ func TestLegacyReactorReceiveBasic(t *testing.T) {
 	}()
 
 	reactor.InitPeer(peer)
-	reactor.AddPeer(peer)
+	require.NoError(t, reactor.AddPeer(peer))
 
 	msg := &protomem.Message{
 		Sum: &protomem.Message_Txs{

--- a/mempool/nop_mempool.go
+++ b/mempool/nop_mempool.go
@@ -101,7 +101,7 @@ var _ p2p.Reactor = &NopMempoolReactor{}
 func (*NopMempoolReactor) GetChannels() []*p2p.ChannelDescriptor { return nil }
 
 // AddPeer does nothing.
-func (*NopMempoolReactor) AddPeer(p2p.Peer) {}
+func (*NopMempoolReactor) AddPeer(p2p.Peer) error { return nil }
 
 // InitPeer always returns nil.
 func (*NopMempoolReactor) InitPeer(p2p.Peer) p2p.Peer { return nil }

--- a/mempool/priority/reactor.go
+++ b/mempool/priority/reactor.go
@@ -156,10 +156,11 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 
 // AddPeer implements Reactor.
 // It starts a broadcast routine ensuring all txs are forwarded to the given peer.
-func (memR *Reactor) AddPeer(peer p2p.Peer) {
+func (memR *Reactor) AddPeer(peer p2p.Peer) error {
 	if memR.config.Broadcast {
 		go memR.broadcastTxRoutine(peer)
 	}
+	return nil
 }
 
 // RemovePeer implements Reactor.

--- a/mempool/priority/reactor_test.go
+++ b/mempool/priority/reactor_test.go
@@ -148,7 +148,7 @@ func TestLegacyReactorReceiveBasic(t *testing.T) {
 	}()
 
 	reactor.InitPeer(peer)
-	reactor.AddPeer(peer)
+	require.NoError(t, reactor.AddPeer(peer))
 	m := &memproto.Txs{}
 	wm := m.Wrap()
 

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -89,7 +89,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 
 // AddPeer implements Reactor.
 // It starts a broadcast routine ensuring all txs are forwarded to the given peer.
-func (memR *Reactor) AddPeer(peer p2p.Peer) {
+func (memR *Reactor) AddPeer(peer p2p.Peer) error {
 	if memR.config.Broadcast {
 		go func() {
 			// Always forward transactions to unconditional peers.
@@ -128,6 +128,7 @@ func (memR *Reactor) AddPeer(peer p2p.Peer) {
 			memR.broadcastTxRoutine(peer)
 		}()
 	}
+	return nil
 }
 
 // RemovePeer implements Reactor.

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -257,7 +257,7 @@ func TestDontExhaustMaxActiveIDs(t *testing.T) {
 			Message:   &memproto.Message{}, // This uses the wrong message type on purpose to stop the peer as in an error state in the reactor.
 		},
 		)
-		reactor.AddPeer(peer)
+		require.NoError(t, reactor.AddPeer(peer))
 	}
 }
 

--- a/p2p/base_reactor.go
+++ b/p2p/base_reactor.go
@@ -37,7 +37,7 @@ type Reactor interface {
 
 	// AddPeer is called by the switch after the peer is added and successfully
 	// started. Use it to start goroutines communicating with the peer.
-	AddPeer(peer Peer)
+	AddPeer(peer Peer) error
 
 	// RemovePeer is called by the switch when the peer is stopped (due to error
 	// or other reason).
@@ -70,7 +70,7 @@ func (br *BaseReactor) SetSwitch(sw *Switch) {
 	br.Switch = sw
 }
 func (*BaseReactor) GetChannels() []*conn.ChannelDescriptor { return nil }
-func (*BaseReactor) AddPeer(Peer)                           {}
+func (*BaseReactor) AddPeer(Peer) error                     { return nil }
 func (*BaseReactor) RemovePeer(Peer, interface{})           {}
 func (*BaseReactor) Receive(Envelope)                       {}
 func (*BaseReactor) InitPeer(peer Peer) Peer                { return peer }

--- a/p2p/mock/reactor.go
+++ b/p2p/mock/reactor.go
@@ -20,6 +20,6 @@ func NewReactor() *Reactor {
 }
 
 func (r *Reactor) GetChannels() []*conn.ChannelDescriptor { return r.Channels }
-func (r *Reactor) AddPeer(_ p2p.Peer)                     {}
+func (r *Reactor) AddPeer(peer p2p.Peer) error            { return nil }
 func (r *Reactor) RemovePeer(_ p2p.Peer, _ interface{})   {}
 func (r *Reactor) Receive(_ p2p.Envelope)                 {}

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -189,7 +189,7 @@ func (r *Reactor) GetChannels() []*conn.ChannelDescriptor {
 
 // AddPeer implements Reactor by adding peer to the address book (if inbound)
 // or by requesting more addresses (if outbound).
-func (r *Reactor) AddPeer(p Peer) {
+func (r *Reactor) AddPeer(p p2p.Peer) error {
 	if p.IsOutbound() {
 		// For outbound peers, the address is already in the books -
 		// either via DialPeersAsync or r.Receive.
@@ -202,7 +202,7 @@ func (r *Reactor) AddPeer(p Peer) {
 		addr, err := p.NodeInfo().NetAddress()
 		if err != nil {
 			r.Logger.Error("Failed to get peer NetAddress", "err", err, "peer", p)
-			return
+			return nil
 		}
 
 		// Make it explicit that addr and src are the same for an inbound peer.
@@ -213,6 +213,7 @@ func (r *Reactor) AddPeer(p Peer) {
 		err = r.book.AddAddress(addr, src)
 		r.logErrAddrBook(err)
 	}
+	return nil
 }
 
 // RemovePeer implements Reactor by resetting peer's requests info.

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -189,7 +189,7 @@ func (r *Reactor) GetChannels() []*conn.ChannelDescriptor {
 
 // AddPeer implements Reactor by adding peer to the address book (if inbound)
 // or by requesting more addresses (if outbound).
-func (r *Reactor) AddPeer(p p2p.Peer) error {
+func (r *Reactor) AddPeer(p Peer) error {
 	if p.IsOutbound() {
 		// For outbound peers, the address is already in the books -
 		// either via DialPeersAsync or r.Receive.

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -42,14 +42,14 @@ func TestPEXReactorAddRemovePeer(t *testing.T) {
 	size := book.Size()
 	peer := p2p.CreateRandomPeer(false)
 
-	r.AddPeer(peer)
+	require.NoError(t, r.AddPeer(peer))
 	assert.Equal(t, size+1, book.Size())
 
 	r.RemovePeer(peer, "peer not available")
 
 	outboundPeer := p2p.CreateRandomPeer(true)
 
-	r.AddPeer(outboundPeer)
+	require.NoError(t, r.AddPeer(outboundPeer))
 	assert.Equal(t, size+1, book.Size(), "outbound peers should not be added to the address book")
 
 	r.RemovePeer(outboundPeer, "peer not available")
@@ -512,7 +512,7 @@ func TestPEXReactorDoesNotAddPrivatePeersToAddrBook(t *testing.T) {
 	})
 	assert.Equal(t, size, book.Size())
 
-	pexR.AddPeer(peer)
+	require.NoError(t, pexR.AddPeer(peer))
 	assert.Equal(t, size, book.Size())
 }
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -909,8 +910,7 @@ func (sw *Switch) addPeer(p Peer) error {
 		chs := reactor.GetChannels()
 		if len(chs) > 0 { // for each reactor there is exactly one PeerSet, no need to iterate over channels
 			if err := sw.peerSetByChID[chs[0].ID].Add(p); err != nil {
-				switch err.(type) {
-				case ErrPeerRemoval:
+				if errors.Is(err, ErrPeerRemoval{}) {
 					sw.Logger.Error("Error starting peer ",
 						" err ", "Peer has already errored and removal was attempted.",
 						"peer", p.ID())

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -65,7 +65,7 @@ func (tr *TestReactor) GetChannels() []*conn.ChannelDescriptor {
 	return tr.channels
 }
 
-func (tr *TestReactor) AddPeer(Peer) {}
+func (tr *TestReactor) AddPeer(Peer) error { return nil }
 
 func (tr *TestReactor) RemovePeer(Peer, interface{}) {}
 

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -86,12 +86,13 @@ func (r *Reactor) OnStart() error {
 }
 
 // AddPeer implements p2p.Reactor.
-func (r *Reactor) AddPeer(peer p2p.Peer) {
+func (r *Reactor) AddPeer(peer p2p.Peer) error {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 	if r.syncer != nil {
 		r.syncer.AddPeer(peer)
 	}
+	return nil
 }
 
 // RemovePeer implements p2p.Reactor.


### PR DESCRIPTION
This PR introduces reactor-specific peer management to the P2P switch, enabling different reactors to maintain their own peer sets rather than sharing a single global peer set. While the infrastructure is now in place for selective peer management, all peer sets are currently identical as most reactors accept all peers.

Almost all peer sets are currently identical because:
- Most reactors (consensus, blocksync, evidence, statesync, mempool, pex) return nil from AddPeer(), accepting all peers
- Only the consensus propagation reactor rejects self-peers and duplicate peers

Testing
 - The test reactor demonstrates the concept with a configurable peerLimit
 - Per-reactor broadcasting is thoroughly tested

This PR provides the foundation for more sophisticated peer management while maintaining backward compatibility for existing reactor implementations.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

