### PR TITLE
feat: purpose -1 to return all unconfirmed transactions in UnconfirmedTxs RPC (Backport #1675)

### DIFF
--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -146,9 +146,13 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 // UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
 // including their number.
 // More: https://docs.cometbft.com/v0.38.x/rpc/#/Info/unconfirmed_txs
+// If limitPtr == -1, it will return all the unconfirmed transactions in the mempool.
 func (env *Environment) UnconfirmedTxs(_ *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
-	// reuse per_page validator
-	limit := env.validatePerPage(limitPtr)
+	limit := *limitPtr
+	if limit != -1 {
+		// reuse per_page validator
+		limit = env.validatePerPage(limitPtr)
+	}
 
 	txs := env.Mempool.ReapMaxTxs(limit)
 	return &ctypes.ResultUnconfirmedTxs{

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -823,7 +823,7 @@ paths:
       parameters:
         - in: query
           name: limit
-          description: Maximum number of unconfirmed transactions to return (max 100)
+          description: Maximum number of unconfirmed transactions to return (max 100). If set to -1, it will return all the unconfirmed mempool transactions.
           required: false
           schema:
             type: integer


### PR DESCRIPTION
Backport: purpose -1 to return all unconfirmed transactions in UnconfirmedTxs RPC  #1675