### PR TITLE
chore: fix golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,8 +249,8 @@ format:
 
 #? lint: Run latest golangci-lint linter
 lint:
-	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
+	@echo "--> Running golangci-lint"
+	@golangci-lint run
 .PHONY: lint
 
 # https://github.com/cometbft/cometbft/pull/1925#issuecomment-1875127862

--- a/abci/client/grpc_client_test.go
+++ b/abci/client/grpc_client_test.go
@@ -40,8 +40,7 @@ func TestGRPC(t *testing.T) {
 	})
 
 	// Connect to the socket
-	//nolint:staticcheck // SA1019 Existing use of deprecated but supported dial option.
-	conn, err := grpc.Dial(socket, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc))
+	conn, err := grpc.Dial(socket, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc)) //nolint:staticcheck
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -202,7 +202,7 @@ type blockedABCIApplication struct {
 
 func (b blockedABCIApplication) CheckTxAsync(ctx context.Context, r *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
 	b.wg.Wait()
-	return b.BaseApplication.CheckTx(ctx, r)
+	return b.BaseApplication.CheckTx(ctx, r) //nolint:staticcheck
 }
 
 // TestCallbackInvokedWhenSetEarly ensures that the callback is invoked when

--- a/blocksync/metrics.go
+++ b/blocksync/metrics.go
@@ -29,8 +29,8 @@ type Metrics struct {
 }
 
 func (m *Metrics) recordBlockMetrics(block *types.Block) {
-	m.NumTxs.Set(float64(len(block.Data.Txs)))
-	m.TotalTxs.Add(float64(len(block.Data.Txs)))
+	m.NumTxs.Set(float64(len(block.Data.Txs)))   //nolint:staticcheck
+	m.TotalTxs.Add(float64(len(block.Data.Txs))) //nolint:staticcheck
 	m.BlockSizeBytes.Set(float64(block.Size()))
 	m.LatestBlockHeight.Set(float64(block.Height))
 }

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -128,7 +128,7 @@ func NewReactorWithAddr(state sm.State, blockExec *sm.BlockExecutor, store *stor
 
 // SetLogger implements service.Service by setting the logger on reactor and pool.
 func (bcR *Reactor) SetLogger(l log.Logger) {
-	bcR.BaseService.Logger = l
+	bcR.BaseService.Logger = l //nolint:staticcheck
 	bcR.pool.Logger = l
 }
 

--- a/blocksync/reactor_test.go
+++ b/blocksync/reactor_test.go
@@ -146,9 +146,9 @@ func newReactor(
 		// Simulate a commit for the current height
 		vote, err := types.MakeVote(
 			privVals[0],
-			thisBlock.Header.ChainID,
+			thisBlock.Header.ChainID, //nolint:staticcheck
 			idx,
-			thisBlock.Header.Height,
+			thisBlock.Header.Height, //nolint:staticcheck
 			0,
 			cmtproto.PrecommitType,
 			blockID,
@@ -220,7 +220,7 @@ func TestNoBlockResponse(t *testing.T) {
 	}
 
 	for {
-		if reactorPairs[1].reactor.pool.IsCaughtUp() {
+		if reactorPairs[1].reactor.pool.IsCaughtUp() { //nolint:staticcheck
 			break
 		}
 
@@ -317,7 +317,7 @@ func TestBadBlockStopsPeer(t *testing.T) {
 	}
 
 	for {
-		if lastReactorPair.reactor.pool.IsCaughtUp() || lastReactorPair.reactor.Switch.Peers().Size() == 0 {
+		if lastReactorPair.reactor.pool.IsCaughtUp() || lastReactorPair.reactor.Switch.Peers().Size() == 0 { //nolint:staticcheck
 			break
 		}
 

--- a/cmd/cometbft/commands/testnet.go
+++ b/cmd/cometbft/commands/testnet.go
@@ -140,8 +140,8 @@ func testnetFiles(*cobra.Command, []string) error {
 			return err
 		}
 
-		pvKeyFile := filepath.Join(nodeDir, config.BaseConfig.PrivValidatorKey)
-		pvStateFile := filepath.Join(nodeDir, config.BaseConfig.PrivValidatorState)
+		pvKeyFile := filepath.Join(nodeDir, config.BaseConfig.PrivValidatorKey)     //nolint:staticcheck
+		pvStateFile := filepath.Join(nodeDir, config.BaseConfig.PrivValidatorState) //nolint:staticcheck
 		pv := privval.LoadFilePV(pvKeyFile, pvStateFile)
 
 		pubKey, err := pv.GetPubKey()
@@ -189,7 +189,7 @@ func testnetFiles(*cobra.Command, []string) error {
 	// Write genesis file.
 	for i := 0; i < nValidators+nNonValidators; i++ {
 		nodeDir := filepath.Join(outputDir, fmt.Sprintf("%s%d", nodeDirPrefix, i))
-		if err := genDoc.SaveAs(filepath.Join(nodeDir, config.BaseConfig.Genesis)); err != nil {
+		if err := genDoc.SaveAs(filepath.Join(nodeDir, config.BaseConfig.Genesis)); err != nil { //nolint:staticcheck
 			_ = os.RemoveAll(outputDir)
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -128,7 +128,7 @@ func TestConfig() *Config {
 
 // SetRoot sets the RootDir for all Config structs
 func (cfg *Config) SetRoot(root string) *Config {
-	cfg.BaseConfig.RootDir = root
+	cfg.BaseConfig.RootDir = root //nolint:staticcheck
 	cfg.RPC.RootDir = root
 	cfg.P2P.RootDir = root
 	cfg.Mempool.RootDir = root
@@ -179,7 +179,7 @@ func (cfg *Config) CheckDeprecated() []string {
 // BaseConfig
 
 // BaseConfig defines the base configuration for a CometBFT node
-type BaseConfig struct { //nolint: maligned
+type BaseConfig struct {
 
 	// The version of the CometBFT binary that created
 	// or last modified the config file
@@ -560,7 +560,7 @@ func (cfg RPCConfig) IsTLSEnabled() bool {
 // P2PConfig
 
 // P2PConfig defines the configuration options for the CometBFT peer-to-peer networking layer
-type P2PConfig struct { //nolint: maligned
+type P2PConfig struct {
 	RootDir string `mapstructure:"home"`
 
 	// Address to listen for incoming connections

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -96,7 +96,7 @@ func (vs *validatorStub) signVote(
 	voteExtension []byte,
 	extEnabled bool,
 ) (*types.Vote, error) {
-	pubKey, err := vs.PrivValidator.GetPubKey()
+	pubKey, err := vs.PrivValidator.GetPubKey() //nolint:staticcheck
 	if err != nil {
 		return nil, fmt.Errorf("can't get pubkey: %w", err)
 	}
@@ -111,7 +111,7 @@ func (vs *validatorStub) signVote(
 		Extension:        voteExtension,
 	}
 	v := vote.ToProto()
-	if err = vs.PrivValidator.SignVote(test.DefaultTestChainID, v); err != nil {
+	if err = vs.PrivValidator.SignVote(test.DefaultTestChainID, v); err != nil { //nolint:staticcheck
 		return nil, fmt.Errorf("sign vote failed: %w", err)
 	}
 

--- a/consensus/propagation/reactor_test.go
+++ b/consensus/propagation/reactor_test.go
@@ -435,7 +435,7 @@ func TestPropagationSmokeTest(t *testing.T) {
 		prop, ps, block, metaData := createTestProposal(t, sm, i, 2, 1000000)
 
 		// predistribute portions of the block
-		for _, tx := range block.Data.Txs {
+		for _, tx := range block.Data.Txs { //nolint:staticcheck
 			for j := 0; j < nodes/2; j++ {
 				r := reactors[j]
 				pool := r.mempool.(*mockMempool)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -928,7 +928,7 @@ OUTER_LOOP:
 			}
 		}
 
-		if sleeping == 0 {
+		if sleeping == 0 { //nolint:staticcheck
 			// We sent nothing. Sleep...
 			sleeping = 1
 			logger.Debug("No votes to send, sleeping", "rs.Height", rs.Height, "prs.Height", prs.Height,
@@ -1489,7 +1489,7 @@ func (ps *PeerState) EnsureVoteBitArrays(height int64, numValidators int) {
 }
 
 func (ps *PeerState) ensureVoteBitArrays(height int64, numValidators int) {
-	if ps.PRS.Height == height {
+	if ps.PRS.Height == height { //nolint:staticcheck
 		if ps.PRS.Prevotes == nil {
 			ps.PRS.Prevotes = bits.NewBitArray(numValidators)
 		}

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -730,7 +730,7 @@ func waitForAndValidateBlockWithTx(
 			// check that txs match the txs we're waiting for.
 			// note they could be spread over multiple blocks,
 			// but they should be in order.
-			for _, tx := range newBlock.Data.Txs {
+			for _, tx := range newBlock.Data.Txs { //nolint:staticcheck
 				assert.EqualValues(t, txs[ntxs], tx)
 				ntxs++
 			}
@@ -819,7 +819,7 @@ func timeoutWaitGroup(n int, f func(int)) {
 // Ensure basic validation of structs is functioning
 
 func TestNewRoundStepMessageValidateBasic(t *testing.T) {
-	testCases := []struct { //nolint: maligned
+	testCases := []struct {
 		expectErr              bool
 		messageRound           int32
 		messageLastCommitRound int32
@@ -858,7 +858,7 @@ func TestNewRoundStepMessageValidateBasic(t *testing.T) {
 
 func TestNewRoundStepMessageValidateHeight(t *testing.T) {
 	initialHeight := int64(10)
-	testCases := []struct { //nolint: maligned
+	testCases := []struct {
 		expectErr              bool
 		messageLastCommitRound int32
 		messageHeight          int64
@@ -1010,7 +1010,7 @@ func TestHasVoteMessageValidateBasic(t *testing.T) {
 		invalidSignedMsgType cmtproto.SignedMsgType = 0x03
 	)
 
-	testCases := []struct { //nolint: maligned
+	testCases := []struct {
 		expectErr     bool
 		messageRound  int32
 		messageIndex  int32
@@ -1055,7 +1055,7 @@ func TestVoteSetMaj23MessageValidateBasic(t *testing.T) {
 		},
 	}
 
-	testCases := []struct { //nolint: maligned
+	testCases := []struct {
 		expectErr      bool
 		messageRound   int32
 		messageHeight  int64

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -408,7 +408,7 @@ func (h *Handshaker) ReplayBlocksWithContext(
 	var err error
 	// Now either store is equal to state, or one ahead.
 	// For each, consider all cases of where the app could be, given app <= store
-	if storeBlockHeight == stateBlockHeight {
+	if storeBlockHeight == stateBlockHeight { //nolint:staticcheck
 		// CometBFT ran Commit and saved the state.
 		// Either the app is asking for replay, or we're all synced up.
 		if appBlockHeight < storeBlockHeight {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -230,7 +230,7 @@ func NewState(
 
 // SetLogger implements Service.
 func (cs *State) SetLogger(l log.Logger) {
-	cs.BaseService.Logger = l
+	cs.BaseService.Logger = l //nolint:staticcheck
 	cs.timeoutTicker.SetLogger(l)
 }
 
@@ -274,7 +274,7 @@ func (cs *State) GetState() sm.State {
 func (cs *State) GetLastHeight() int64 {
 	cs.mtx.RLock()
 	defer cs.mtx.RUnlock()
-	return cs.RoundState.Height - 1
+	return cs.RoundState.Height - 1 //nolint:staticcheck
 }
 
 // GetRoundState returns a shallow copy of the internal consensus state.
@@ -296,7 +296,7 @@ func (cs *State) GetRoundStateJSON() ([]byte, error) {
 func (cs *State) GetRoundStateSimpleJSON() ([]byte, error) {
 	cs.mtx.RLock()
 	defer cs.mtx.RUnlock()
-	return cmtjson.Marshal(cs.RoundState.RoundStateSimple())
+	return cmtjson.Marshal(cs.RoundState.RoundStateSimple()) //nolint:staticcheck
 }
 
 // GetValidators returns a copy of the current validators.
@@ -1960,8 +1960,8 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	// trace some metadata about the block
 	schema.WriteBlockSummary(cs.traceClient, block, blockSize)
 
-	cs.metrics.NumTxs.Set(float64(len(block.Data.Txs)))
-	cs.metrics.TotalTxs.Add(float64(len(block.Data.Txs)))
+	cs.metrics.NumTxs.Set(float64(len(block.Data.Txs)))   //nolint:staticcheck
+	cs.metrics.TotalTxs.Add(float64(len(block.Data.Txs))) //nolint:staticcheck
 	cs.metrics.BlockSizeBytes.Set(float64(block.Size()))
 	cs.metrics.ChainSizeBytes.Add(float64(block.Size()))
 	cs.metrics.CommittedHeight.Set(float64(block.Height))

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1738,7 +1738,7 @@ func TestPrepareProposalReceivesVoteExtensions(t *testing.T) {
 		}
 		extSignBytes, err := protoio.MarshalDelimited(&cve)
 		require.NoError(t, err)
-		pubKey, err := vss[i].PrivValidator.GetPubKey()
+		pubKey, err := vss[i].PrivValidator.GetPubKey() //nolint:staticcheck
 		require.NoError(t, err)
 		require.True(t, pubKey.VerifySignature(extSignBytes, vote.ExtensionSignature))
 	}

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -117,7 +117,7 @@ func (wal *BaseWAL) Group() *auto.Group {
 }
 
 func (wal *BaseWAL) SetLogger(l log.Logger) {
-	wal.BaseService.Logger = l
+	wal.BaseService.Logger = l //nolint:staticcheck
 	wal.group.SetLogger(l)
 }
 

--- a/crypto/armor/armor.go
+++ b/crypto/armor/armor.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"golang.org/x/crypto/openpgp/armor" //nolint: staticcheck
+	"golang.org/x/crypto/openpgp/armor" //nolint:staticcheck
 )
 
 func EncodeArmor(blockType string, headers map[string]string, data []byte) string {

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"golang.org/x/crypto/ripemd160" //nolint: gosec,staticcheck // necessary for Bitcoin address format
+	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
 
 	"github.com/cometbft/cometbft/crypto"
 	cmtjson "github.com/cometbft/cometbft/libs/json"

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -417,8 +417,8 @@ func initializeBlockStore(db dbm.DB, state sm.State, valAddr []byte) (*store.Blo
 		if err != nil {
 			return nil, err
 		}
-		block.Header.Time = defaultEvidenceTime.Add(time.Duration(i) * time.Minute)
-		block.Header.Version = cmtversion.Consensus{Block: version.BlockProtocol, App: 1}
+		block.Header.Time = defaultEvidenceTime.Add(time.Duration(i) * time.Minute)       //nolint:staticcheck
+		block.Header.Version = cmtversion.Consensus{Block: version.BlockProtocol, App: 1} //nolint:staticcheck
 
 		seenCommit := makeExtCommit(i, valAddr)
 		blockStore.SaveBlockWithExtendedCommit(block, partSet, seenCommit)

--- a/evidence/verify_test.go
+++ b/evidence/verify_test.go
@@ -155,8 +155,8 @@ func TestVerify_ForwardLunaticAttack(t *testing.T) {
 	}
 
 	// modify trusted light block so that it is of a height less than the conflicting one
-	trusted.Header.Height = state.LastBlockHeight
-	trusted.Header.Time = state.LastBlockTime
+	trusted.Header.Height = state.LastBlockHeight //nolint:staticcheck
+	trusted.Header.Time = state.LastBlockTime     //nolint:staticcheck
 
 	stateStore := &smmocks.Store{}
 	stateStore.On("LoadValidators", commonHeight).Return(common.ValidatorSet, nil)
@@ -245,12 +245,12 @@ func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
 
 	// conflicting header has different next validators hash which should have been correctly derived from
 	// the previous round
-	ev.ConflictingBlock.Header.NextValidatorsHash = crypto.CRandBytes(tmhash.Size)
+	ev.ConflictingBlock.Header.NextValidatorsHash = crypto.CRandBytes(tmhash.Size) //nolint:staticcheck
 	err = evidence.VerifyLightClientAttack(ev, trustedSignedHeader, trustedSignedHeader, nil,
 		defaultEvidenceTime.Add(1*time.Minute), 2*time.Hour)
 	assert.Error(t, err)
 	// revert next validators hash
-	ev.ConflictingBlock.Header.NextValidatorsHash = trustedHeader.NextValidatorsHash
+	ev.ConflictingBlock.Header.NextValidatorsHash = trustedHeader.NextValidatorsHash //nolint:staticcheck
 
 	state := sm.State{
 		LastBlockTime:   defaultEvidenceTime.Add(1 * time.Minute),

--- a/inspect/inspect_test.go
+++ b/inspect/inspect_test.go
@@ -59,8 +59,8 @@ func TestInspectRun(t *testing.T) {
 func TestBlock(t *testing.T) {
 	testHeight := int64(1)
 	testBlock := new(types.Block)
-	testBlock.Header.Height = testHeight
-	testBlock.Header.LastCommitHash = []byte("test hash")
+	testBlock.Header.Height = testHeight                  //nolint:staticcheck
+	testBlock.Header.LastCommitHash = []byte("test hash") //nolint:staticcheck
 	stateStoreMock := &statemocks.Store{}
 	stateStoreMock.On("Close").Return(nil)
 
@@ -342,7 +342,7 @@ func TestCommit(t *testing.T) {
 	res, err := cli.Commit(context.Background(), &testHeight)
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	require.Equal(t, res.SignedHeader.Commit.Round, testRound)
+	require.Equal(t, res.SignedHeader.Commit.Round, testRound) //nolint:staticcheck
 
 	cancel()
 	wg.Wait()
@@ -355,8 +355,8 @@ func TestBlockByHash(t *testing.T) {
 	testHeight := int64(1)
 	testHash := []byte("test hash")
 	testBlock := new(types.Block)
-	testBlock.Header.Height = testHeight
-	testBlock.Header.LastCommitHash = testHash
+	testBlock.Header.Height = testHeight       //nolint:staticcheck
+	testBlock.Header.LastCommitHash = testHash //nolint:staticcheck
 	stateStoreMock := &statemocks.Store{}
 	stateStoreMock.On("Close").Return(nil)
 	blockStoreMock := &statemocks.BlockStore{}
@@ -408,8 +408,8 @@ func TestBlockchain(t *testing.T) {
 	testHeight := int64(1)
 	testBlock := new(types.Block)
 	testBlockHash := []byte("test hash")
-	testBlock.Header.Height = testHeight
-	testBlock.Header.LastCommitHash = testBlockHash
+	testBlock.Header.Height = testHeight            //nolint:staticcheck
+	testBlock.Header.LastCommitHash = testBlockHash //nolint:staticcheck
 	stateStoreMock := &statemocks.Store{}
 	stateStoreMock.On("Close").Return(nil)
 

--- a/libs/autofile/group.go
+++ b/libs/autofile/group.go
@@ -357,7 +357,7 @@ func (g *Group) ReadGroupInfo() GroupInfo {
 func (g *Group) readGroupInfo() GroupInfo {
 	groupDir := filepath.Dir(g.Head.Path)
 	headBase := filepath.Base(g.Head.Path)
-	var minIndex, maxIndex int = -1, -1
+	var minIndex, maxIndex int = -1, -1 //nolint:staticcheck
 	var totalSize, headSize int64 = 0, 0
 
 	dir, err := os.Open(groupDir)
@@ -502,11 +502,11 @@ func (gr *GroupReader) openFile(index int) error {
 	gr.Group.mtx.Lock()
 	defer gr.Group.mtx.Unlock()
 
-	if index > gr.Group.maxIndex {
+	if index > gr.Group.maxIndex { //nolint:staticcheck
 		return io.EOF
 	}
 
-	curFilePath := filePathForIndex(gr.Head.Path, index, gr.Group.maxIndex)
+	curFilePath := filePathForIndex(gr.Head.Path, index, gr.Group.maxIndex) //nolint:staticcheck
 	curFile, err := os.OpenFile(curFilePath, os.O_RDONLY|os.O_CREATE, autoFilePerms)
 	if err != nil {
 		return err

--- a/libs/bytes/bytes.go
+++ b/libs/bytes/bytes.go
@@ -67,9 +67,9 @@ func (bz HexBytes) String() string {
 func (bz HexBytes) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'p':
-		s.Write([]byte(fmt.Sprintf("%p", bz))) //nolint: errcheck
+		s.Write([]byte(fmt.Sprintf("%p", bz))) //nolint: errcheck,staticcheck
 	default:
-		s.Write([]byte(fmt.Sprintf("%X", []byte(bz)))) //nolint: errcheck
+		s.Write([]byte(fmt.Sprintf("%X", []byte(bz)))) //nolint:errcheck,staticcheck
 	}
 }
 

--- a/libs/clist/clist_test.go
+++ b/libs/clist/clist_test.go
@@ -69,7 +69,7 @@ func TestSmall(t *testing.T) {
 // This test is quite hacky because it relies on SetFinalizer
 // which isn't guaranteed to run at all.
 //
-//nolint:unused,deadcode
+//nolint:unused
 func _TestGCFifo(t *testing.T) {
 	if runtime.GOARCH != "amd64" {
 		t.Skipf("Skipping on non-amd64 machine")
@@ -119,7 +119,7 @@ func _TestGCFifo(t *testing.T) {
 // This test is quite hacky because it relies on SetFinalizer
 // which isn't guaranteed to run at all.
 //
-//nolint:unused,deadcode
+//nolint:unused
 func _TestGCRandom(t *testing.T) {
 	if runtime.GOARCH != "amd64" {
 		t.Skipf("Skipping on non-amd64 machine")

--- a/libs/flowrate/io_test.go
+++ b/libs/flowrate/io_test.go
@@ -164,7 +164,7 @@ const maxDeviationForRate int64 = 50
 // `time.Sleep` has ended).
 func statusesAreEqual(s1 *Status, s2 *Status) bool {
 	if s1.Active == s2.Active &&
-		s1.Start == s2.Start &&
+		s1.Start == s2.Start && //nolint:staticcheck
 		durationsAreEqual(s1.Duration, s2.Duration, maxDeviationForDuration) &&
 		s1.Idle == s2.Idle &&
 		s1.Bytes == s2.Bytes &&

--- a/libs/tempfile/tempfile_test.go
+++ b/libs/tempfile/tempfile_test.go
@@ -114,7 +114,7 @@ func TestWriteFileAtomicManyDuplicates(t *testing.T) {
 		fname := "/tmp/" + atomicWriteFilePrefix + fileRand
 		f, err := os.OpenFile(fname, atomicWriteFileFlag, 0777)
 		require.Nil(t, err)
-		_, err = f.WriteString(fmt.Sprintf(testString, i))
+		_, err = f.WriteString(fmt.Sprintf(testString, i)) //nolint:staticcheck
 		require.NoError(t, err)
 		defer os.Remove(fname)
 	}

--- a/libs/trace/schema/consensus.go
+++ b/libs/trace/schema/consensus.go
@@ -168,7 +168,7 @@ func WriteBlockSummary(client trace.Tracer, block *types.Block, size int) {
 	client.Write(BlockSummary{
 		Height:                   block.Height,
 		UnixMillisecondTimestamp: block.Time.UnixMilli(),
-		TxCount:                  len(block.Data.Txs),
+		TxCount:                  len(block.Data.Txs), //nolint:staticcheck
 		SquareSize:               block.SquareSize,
 		BlockSize:                size,
 		Proposer:                 block.ProposerAddress.String(),

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -189,7 +189,7 @@ func (p *http) signedHeader(ctx context.Context, height *int64) (*types.SignedHe
 			// If the node is starting at a non-zero height, but does not yet
 			// have any blocks, it can return an empty signed header without
 			// returning an error.
-			if commit.SignedHeader.IsEmpty() {
+			if commit.SignedHeader.IsEmpty() { //nolint:staticcheck
 				// Technically this means that the provider still needs to
 				// catch up.
 				return nil, provider.ErrHeightTooHigh

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -447,9 +447,9 @@ func (c *Client) HeaderByHash(ctx context.Context, hash cmtbytes.HexBytes) (*cty
 		return nil, err
 	}
 
-	if !bytes.Equal(lb.Header.Hash(), res.Header.Hash()) {
+	if !bytes.Equal(lb.Header.Hash(), res.Header.Hash()) { //nolint:staticcheck
 		return nil, fmt.Errorf("primary header hash does not match trusted header hash. (%X != %X)",
-			lb.Header.Hash(), res.Header.Hash())
+			lb.Header.Hash(), res.Header.Hash()) //nolint:staticcheck
 	}
 
 	return res, nil
@@ -728,12 +728,12 @@ func (c *Client) SignedBlock(ctx context.Context, height *int64) (*ctypes.Result
 		return nil, err
 	}
 
-	if bmH, bH := l.Header.Hash(), res.Header.Hash(); !bytes.Equal(bmH, bH) {
+	if bmH, bH := l.Header.Hash(), res.Header.Hash(); !bytes.Equal(bmH, bH) { //nolint:staticcheck
 		return nil, fmt.Errorf("light client header %X does not match with response header %X",
 			bmH, bH)
 	}
 
-	if bmH, bH := l.Header.DataHash, res.Data.Hash(); !bytes.Equal(bmH, bH) {
+	if bmH, bH := l.Header.DataHash, res.Data.Hash(); !bytes.Equal(bmH, bH) { //nolint:staticcheck
 		return nil, fmt.Errorf("light client data hash %X does not match with response data %X",
 			bmH, bH)
 	}

--- a/mempool/cat/pool.go
+++ b/mempool/cat/pool.go
@@ -449,7 +449,7 @@ func (txmp *TxPool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) []*types.CachedTx
 // The result may have fewer than max elements (possibly zero) if the mempool
 // does not have that many transactions available.
 func (txmp *TxPool) ReapMaxTxs(max int) []*types.CachedTx {
-	var keep []*types.CachedTx //nolint:prealloc
+	var keep []*types.CachedTx
 
 	txmp.store.iterateOrderedTxs(func(w *wrappedTx) bool {
 		if max >= 0 && len(keep) >= max {

--- a/mempool/priority/mempool_test.go
+++ b/mempool/priority/mempool_test.go
@@ -806,7 +806,7 @@ func TestConcurrentCheckTxDataRace(t *testing.T) {
 				// Use different transactions for different goroutines
 				// but ensure some overlap to trigger the race
 				var tx types.Tx
-				if id%3 == 0 {
+				if id%3 == 0 { //nolint:staticcheck
 					tx = tx1 // Already in cache, will access txByKey
 				} else if id%3 == 1 {
 					tx = tx2 // New transaction

--- a/node/node.go
+++ b/node/node.go
@@ -875,8 +875,7 @@ func (n *Node) startRPC() ([]net.Listener, error) {
 			return nil, err
 		}
 		go func() {
-			//nolint:staticcheck // SA1019: core_grpc.StartGRPCClient is deprecated: A new gRPC API will be introduced after v0.38.
-			if err := grpccore.StartGRPCServer(env, listener); err != nil {
+			if err := grpccore.StartGRPCServer(env, listener); err != nil { //nolint:staticcheck
 				n.Logger.Error("Error starting gRPC server", "err", err)
 			}
 		}()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -162,7 +162,7 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 
 	config := test.ResetTestRoot("node_priv_val_tcp_test")
 	defer os.RemoveAll(config.RootDir)
-	config.BaseConfig.PrivValidatorListenAddr = addr
+	config.BaseConfig.PrivValidatorListenAddr = addr //nolint:staticcheck
 
 	dialer := privval.DialTCPFn(addr, 100*time.Millisecond, ed25519.GenPrivKey())
 	dialerEndpoint := privval.NewSignerDialerEndpoint(
@@ -196,7 +196,7 @@ func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 
 	config := test.ResetTestRoot("node_priv_val_tcp_test")
 	defer os.RemoveAll(config.RootDir)
-	config.BaseConfig.PrivValidatorListenAddr = addrNoPrefix
+	config.BaseConfig.PrivValidatorListenAddr = addrNoPrefix //nolint:staticcheck
 
 	_, err := DefaultNewNode(config, log.TestingLogger())
 	assert.Error(t, err)
@@ -208,7 +208,7 @@ func TestNodeSetPrivValIPC(t *testing.T) {
 
 	config := test.ResetTestRoot("node_priv_val_tcp_test")
 	defer os.RemoveAll(config.RootDir)
-	config.BaseConfig.PrivValidatorListenAddr = "unix://" + tmpfile
+	config.BaseConfig.PrivValidatorListenAddr = "unix://" + tmpfile //nolint:staticcheck
 
 	dialer := privval.DialUnixFn(tmpfile)
 	dialerEndpoint := privval.NewSignerDialerEndpoint(

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -255,7 +255,7 @@ func (na *NetAddress) Routable() bool {
 		return false
 	}
 	// TODO(oga) bitcoind doesn't include RFC3849 here, but should we?
-	return !(na.RFC1918() || na.RFC3927() || na.RFC4862() ||
+	return !(na.RFC1918() || na.RFC3927() || na.RFC4862() || //nolint:staticcheck
 		na.RFC4193() || na.RFC4843() || na.Local())
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -261,12 +261,12 @@ func (p *peer) ID() ID {
 
 // IsOutbound returns true if the connection is outbound, false otherwise.
 func (p *peer) IsOutbound() bool {
-	return p.peerConn.outbound
+	return p.peerConn.outbound //nolint:staticcheck
 }
 
 // IsPersistent returns true if the peer is persitent, false otherwise.
 func (p *peer) IsPersistent() bool {
-	return p.peerConn.persistent
+	return p.peerConn.persistent //nolint:staticcheck
 }
 
 // NodeInfo returns a copy of the peer's NodeInfo.
@@ -291,7 +291,7 @@ func (p *peer) HasIPChanged() bool {
 // For inbound peers, it's the address returned by the underlying connection
 // (not what's reported in the peer's NodeInfo).
 func (p *peer) SocketAddr() *NetAddress {
-	return p.peerConn.socketAddr
+	return p.peerConn.socketAddr //nolint:staticcheck
 }
 
 // Status returns the peer's ConnectionStatus.
@@ -371,7 +371,7 @@ func (p *peer) hasChannel(chID byte) bool {
 
 // CloseConn closes original connection. Used for cleaning up in cases where the peer had not been started at all.
 func (p *peer) CloseConn() error {
-	return p.peerConn.conn.Close()
+	return p.peerConn.conn.Close() //nolint:staticcheck
 }
 
 func (p *peer) SetRemovalFailed() {
@@ -393,7 +393,7 @@ func (pc *peerConn) CloseConn() {
 
 // RemoteAddr returns peer's remote network address.
 func (p *peer) RemoteAddr() net.Addr {
-	return p.peerConn.conn.RemoteAddr()
+	return p.peerConn.conn.RemoteAddr() //nolint:staticcheck
 }
 
 // CanSend returns true if the send queue is not full, false otherwise.

--- a/privval/signer_dialer_endpoint.go
+++ b/privval/signer_dialer_endpoint.go
@@ -60,7 +60,7 @@ func NewSignerDialerEndpoint(
 	}
 
 	sd.BaseService = *service.NewBaseService(logger, "SignerDialerEndpoint", sd)
-	sd.signerEndpoint.timeoutReadWrite = defaultTimeoutReadWriteSeconds * time.Second
+	sd.signerEndpoint.timeoutReadWrite = defaultTimeoutReadWriteSeconds * time.Second //nolint:staticcheck
 
 	for _, optionFunc := range options {
 		optionFunc(sd)

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -20,7 +20,7 @@ type SignerListenerEndpointOption func(*SignerListenerEndpoint)
 //
 // Default: 5s
 func SignerListenerEndpointTimeoutReadWrite(timeout time.Duration) SignerListenerEndpointOption {
-	return func(sl *SignerListenerEndpoint) { sl.signerEndpoint.timeoutReadWrite = timeout }
+	return func(sl *SignerListenerEndpoint) { sl.signerEndpoint.timeoutReadWrite = timeout } //nolint:staticcheck
 }
 
 // SignerListenerEndpoint listens for an external process to dial in and keeps
@@ -55,7 +55,7 @@ func NewSignerListenerEndpoint(
 	}
 
 	sl.BaseService = *service.NewBaseService(logger, "SignerListenerEndpoint", sl)
-	sl.signerEndpoint.timeoutReadWrite = defaultTimeoutReadWriteSeconds * time.Second
+	sl.signerEndpoint.timeoutReadWrite = defaultTimeoutReadWriteSeconds * time.Second //nolint:staticcheck
 
 	for _, optionFunc := range options {
 		optionFunc(sl)
@@ -70,7 +70,7 @@ func (sl *SignerListenerEndpoint) OnStart() error {
 	sl.connectionAvailableCh = make(chan net.Conn)
 
 	// NOTE: ping timeout must be less than read/write timeout.
-	sl.pingInterval = time.Duration(sl.signerEndpoint.timeoutReadWrite.Milliseconds()*2/3) * time.Millisecond
+	sl.pingInterval = time.Duration(sl.signerEndpoint.timeoutReadWrite.Milliseconds()*2/3) * time.Millisecond //nolint:staticcheck
 	sl.pingTimer = time.NewTicker(sl.pingInterval)
 
 	go sl.serviceLoop()

--- a/privval/signer_listener_endpoint_test.go
+++ b/privval/signer_listener_endpoint_test.go
@@ -194,7 +194,7 @@ func TestDuplicateListenReject(t *testing.T) {
 
 		// wait for successful connection
 		for {
-			if listenerEndpoint.IsConnected() {
+			if listenerEndpoint.IsConnected() { //nolint:staticcheck
 				break
 			}
 		}

--- a/privval/socket_listeners.go
+++ b/privval/socket_listeners.go
@@ -169,7 +169,7 @@ func newTimeoutConn(conn net.Conn, timeout time.Duration) *timeoutConn {
 func (c timeoutConn) Read(b []byte) (n int, err error) {
 	// Reset deadline
 	deadline := time.Now().Add(c.timeout)
-	err = c.Conn.SetReadDeadline(deadline)
+	err = c.Conn.SetReadDeadline(deadline) //nolint:staticcheck
 	if err != nil {
 		return
 	}
@@ -181,7 +181,7 @@ func (c timeoutConn) Read(b []byte) (n int, err error) {
 func (c timeoutConn) Write(b []byte) (n int, err error) {
 	// Reset deadline
 	deadline := time.Now().Add(c.timeout)
-	err = c.Conn.SetWriteDeadline(deadline)
+	err = c.Conn.SetWriteDeadline(deadline) //nolint:staticcheck
 	if err != nil {
 		return
 	}

--- a/proxy/multi_app_conn_test.go
+++ b/proxy/multi_app_conn_test.go
@@ -53,7 +53,7 @@ func TestAppConns_Failure(t *testing.T) {
 	}()
 
 	quitCh := make(chan struct{})
-	var recvQuitCh <-chan struct{} //nolint:gosimple
+	var recvQuitCh <-chan struct{} //nolint:staticcheck
 	recvQuitCh = quitCh
 
 	clientCreatorMock := &mocks.ClientCreator{}

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -89,10 +89,10 @@ func TestBlockEvents(t *testing.T) {
 				block := blockEvent.Block
 
 				if firstBlockHeight == 0 {
-					firstBlockHeight = block.Header.Height
+					firstBlockHeight = block.Header.Height //nolint:staticcheck
 				}
 
-				require.Equal(t, firstBlockHeight+i, block.Header.Height)
+				require.Equal(t, firstBlockHeight+i, block.Header.Height) //nolint:staticcheck
 			}
 		})
 	}

--- a/rpc/client/helpers_test.go
+++ b/rpc/client/helpers_test.go
@@ -53,7 +53,7 @@ func TestWaitForHeight(t *testing.T) {
 	// we use the callback to update the status height
 	myWaiter := func(delta int64) error {
 		// update the height for the next call
-		m.Call.Response = &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{LatestBlockHeight: 15}}
+		m.Call.Response = &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{LatestBlockHeight: 15}} //nolint:staticcheck
 		return client.DefaultWaitStrategy(delta)
 	}
 

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -232,7 +232,7 @@ func (c *Local) Subscribe(
 	if outCap > 0 {
 		sub, err = c.EventBus.Subscribe(ctx, subscriber, q, outCap)
 	} else {
-		sub, err = c.EventBus.SubscribeUnbuffered(ctx, subscriber, q)
+		sub, err = c.EventBus.SubscribeUnbuffered(ctx, subscriber, q) //nolint:staticcheck
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to subscribe: %w", err)

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -277,9 +277,9 @@ func TestAppCalls(t *testing.T) {
 		// and we can even check the block is added
 		block, err := c.Block(context.Background(), &apph)
 		require.NoError(err)
-		appHash := block.Block.Header.AppHash
+		appHash := block.Block.Header.AppHash //nolint:staticcheck
 		assert.True(len(appHash) > 0)
-		assert.EqualValues(apph, block.Block.Header.Height)
+		assert.EqualValues(apph, block.Block.Header.Height) //nolint:staticcheck
 
 		blockByHash, err := c.BlockByHash(context.Background(), block.BlockID.Hash)
 		require.NoError(err)
@@ -311,14 +311,14 @@ func TestAppCalls(t *testing.T) {
 			lastMeta := info.BlockMetas[0]
 			assert.EqualValues(apph, lastMeta.Header.Height)
 			blockData := block.Block
-			assert.Equal(blockData.Header.AppHash, lastMeta.Header.AppHash)
+			assert.Equal(blockData.Header.AppHash, lastMeta.Header.AppHash) //nolint:staticcheck
 			assert.Equal(block.BlockID, lastMeta.BlockID)
 		}
 
 		// and get the corresponding commit with the same apphash
 		commit, err := c.Commit(context.Background(), &apph)
 		require.NoError(err)
-		cappHash := commit.Header.AppHash
+		cappHash := commit.Header.AppHash //nolint:staticcheck
 		assert.Equal(appHash, cappHash)
 		assert.NotNil(commit.Commit)
 

--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -392,11 +392,11 @@ func (store mockBlockStore) LoadBlock(height int64) *types.Block {
 
 func (store mockBlockStore) LoadTxInfo(hash []byte) *cmtstore.TxInfo {
 	for _, block := range store.blocks {
-		for i, tx := range block.Data.Txs {
+		for i, tx := range block.Data.Txs { //nolint:staticcheck
 			// Check if transaction hash matches
 			if bytes.Equal(tx.Hash(), hash) {
 				return &cmtstore.TxInfo{
-					Height: block.Header.Height,
+					Height: block.Header.Height, //nolint:staticcheck
 					//nolint:gosec
 					Index: uint32(i),
 					Code:  uint32(0),

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -99,7 +99,7 @@ func (u parsedURL) GetDialAddress() string {
 			// http and ws default to port 80, https and wss default to port 443
 			// https://www.rfc-editor.org/rfc/rfc9110#section-4.2
 			// https://www.rfc-editor.org/rfc/rfc6455.html#section-3
-			if u.Scheme == protoHTTP || u.Scheme == protoWS {
+			if u.Scheme == protoHTTP || u.Scheme == protoWS { //nolint:staticcheck
 				return u.Host + `:80`
 			} else if u.Scheme == protoHTTPS || u.Scheme == protoWSS {
 				return u.Host + `:443`

--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -31,7 +31,7 @@ const (
 // the remote server.
 //
 // WSClient is safe for concurrent use by multiple goroutines.
-type WSClient struct { //nolint: maligned
+type WSClient struct {
 	conn *websocket.Conn
 
 	Address  string // IP:PORT or /path/to/socket

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -108,7 +108,7 @@ func TestMain(m *testing.M) {
 var colorFn = func(keyvals ...interface{}) term.FgBgColor {
 	for i := 0; i < len(keyvals)-1; i += 2 {
 		if keyvals[i] == "socket" {
-			if keyvals[i+1] == "tcp" {
+			if keyvals[i+1] == "tcp" { //nolint:staticcheck
 				return term.FgBgColor{Fg: term.DarkBlue}
 			} else if keyvals[i+1] == "unix" {
 				return term.FgBgColor{Fg: term.DarkCyan}

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -236,7 +236,7 @@ func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[st
 
 	for _, name := range noArgNames {
 		link := fmt.Sprintf("//%s/%s", r.Host, name)
-		buf.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a></br>", link, link))
+		buf.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a></br>", link, link)) //nolint:staticcheck
 	}
 
 	buf.WriteString("<br>Endpoints that require arguments:<br>")
@@ -249,7 +249,7 @@ func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[st
 				link += "&"
 			}
 		}
-		buf.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a></br>", link, link))
+		buf.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a></br>", link, link)) //nolint:staticcheck
 	}
 	buf.WriteString("</body></html>")
 	w.Header().Set("Content-Type", "text/html")

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -119,8 +119,7 @@ func GetConfig(forceCreate ...bool) *cfg.Config {
 
 func GetGRPCClient() core_grpc.BroadcastAPIClient {
 	grpcAddr := globalConfig.RPC.GRPCListenAddress
-	//nolint:staticcheck // SA1019: core_grpc.StartGRPCClient is deprecated: A new gRPC API will be introduced after v0.38.
-	return core_grpc.StartGRPCClient(grpcAddr)
+	return core_grpc.StartGRPCClient(grpcAddr) //nolint:staticcheck
 }
 
 // StartTendermint starts a test CometBFT server in a go routine and returns when it is initialized

--- a/scripts/wal2json/main.go
+++ b/scripts/wal2json/main.go
@@ -49,7 +49,7 @@ func main() {
 
 		if err == nil {
 			if endMsg, ok := msg.Msg.(cs.EndHeightMessage); ok {
-				_, err = os.Stdout.Write([]byte(fmt.Sprintf("ENDHEIGHT %d\n", endMsg.Height)))
+				_, err = os.Stdout.Write([]byte(fmt.Sprintf("ENDHEIGHT %d\n", endMsg.Height))) //nolint:staticcheck
 			}
 		}
 

--- a/state/compatibility_test.go
+++ b/state/compatibility_test.go
@@ -68,7 +68,7 @@ func (multi MultiStore) SaveABCIResponses(height int64, abciResponses *cmtstate.
 
 	// If the flag is false then we save the ABCIResponse. This can be used for the /block_results
 	// query or to reindex an event using the command line.
-	if !multi.StoreOptions.DiscardABCIResponses {
+	if !multi.StoreOptions.DiscardABCIResponses { //nolint:staticcheck
 		bz, err := abciResponses.Marshal()
 		if err != nil {
 			return err

--- a/state/execution.go
+++ b/state/execution.go
@@ -192,10 +192,10 @@ func (blockExec *BlockExecutor) ProcessProposal(
 	pbHeader := block.Header.ToProto()
 	resp, err := blockExec.proxyApp.ProcessProposal(context.TODO(), &abci.RequestProcessProposal{
 		Hash:               block.Header.Hash(),
-		Height:             block.Header.Height,
-		Time:               block.Header.Time,
-		Txs:                block.Data.Txs.ToSliceOfBytes(),
-		SquareSize:         block.Data.SquareSize,
+		Height:             block.Header.Height,             //nolint:staticcheck
+		Time:               block.Header.Time,               //nolint:staticcheck
+		Txs:                block.Data.Txs.ToSliceOfBytes(), //nolint:staticcheck
+		SquareSize:         block.Data.SquareSize,           //nolint:staticcheck
 		DataRootHash:       block.Data.Hash(),
 		ProposedLastCommit: buildLastCommitInfoFromStore(block, blockExec.store, state.InitialHeight),
 		Misbehavior:        block.Evidence.Evidence.ToABCI(),
@@ -294,8 +294,8 @@ func (blockExec *BlockExecutor) applyBlock(state State, blockID types.BlockID, b
 	)
 
 	// Assert that the application correctly returned tx results for each of the transactions provided in the block
-	if len(block.Data.Txs) != len(abciResponse.TxResults) {
-		return state, fmt.Errorf("expected tx results length to match size of transactions in block. Expected %d, got %d", len(block.Data.Txs), len(abciResponse.TxResults))
+	if len(block.Data.Txs) != len(abciResponse.TxResults) { //nolint:staticcheck
+		return state, fmt.Errorf("expected tx results length to match size of transactions in block. Expected %d, got %d", len(block.Data.Txs), len(abciResponse.TxResults)) //nolint:staticcheck
 	}
 
 	blockExec.logger.Info("executed block", "height", block.Height, "app_hash", fmt.Sprintf("%X", abciResponse.AppHash))
@@ -777,7 +777,7 @@ func fireEvents(
 		}
 	}
 
-	for i, tx := range block.Data.Txs {
+	for i, tx := range block.Data.Txs { //nolint:staticcheck
 		blobTx, isBlobTx := types.UnmarshalBlobTx(tx)
 		if isBlobTx {
 			tx = blobTx.Tx
@@ -834,8 +834,8 @@ func ExecCommitBlock(
 	}
 
 	// Assert that the application correctly returned tx results for each of the transactions provided in the block
-	if len(block.Data.Txs) != len(resp.TxResults) {
-		return nil, fmt.Errorf("expected tx results length to match size of transactions in block. Expected %d, got %d", len(block.Data.Txs), len(resp.TxResults))
+	if len(block.Data.Txs) != len(resp.TxResults) { //nolint:staticcheck
+		return nil, fmt.Errorf("expected tx results length to match size of transactions in block. Expected %d, got %d", len(block.Data.Txs), len(resp.TxResults)) //nolint:staticcheck
 	}
 
 	logger.Info("executed block", "height", block.Height, "app_hash", fmt.Sprintf("%X", resp.AppHash))

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -347,7 +347,7 @@ func TestFinalizeBlockMisbehavior(t *testing.T) {
 	block, ops, err := makeBlock(state, 1, new(types.Commit))
 	require.NoError(t, err)
 	block.Evidence = types.EvidenceData{Evidence: ev}
-	block.Header.EvidenceHash = block.Evidence.Hash()
+	block.Header.EvidenceHash = block.Evidence.Hash() //nolint:staticcheck
 	blockID = types.BlockID{Hash: block.Hash(), PartSetHeader: ops.Header()}
 
 	_, err = blockExec.ApplyBlock(state, blockID, block, nil)
@@ -398,7 +398,7 @@ func TestProcessProposal(t *testing.T) {
 		pk, err := privVal.GetPubKey()
 		require.NoError(t, err)
 		idx, _ := state.Validators.GetByAddress(pk.Address())
-		vote := types.MakeVoteNoError(t, privVal, block0.Header.ChainID, idx, height-1, 0, 2, blockID, time.Now())
+		vote := types.MakeVoteNoError(t, privVal, block0.Header.ChainID, idx, height-1, 0, 2, blockID, time.Now()) //nolint:staticcheck
 		addr := pk.Address()
 		voteInfos = append(voteInfos,
 			abci.VoteInfo{
@@ -423,8 +423,8 @@ func TestProcessProposal(t *testing.T) {
 		Header:      block1.Header.ToProto(),
 		Txs:         block1.Txs.ToSliceOfBytes(),
 		Hash:        block1.Hash(),
-		Height:      block1.Header.Height,
-		Time:        block1.Header.Time,
+		Height:      block1.Header.Height, //nolint:staticcheck
+		Time:        block1.Header.Time,   //nolint:staticcheck
 		Misbehavior: block1.Evidence.Evidence.ToABCI(),
 		ProposedLastCommit: abci.CommitInfo{
 			Round: 0,
@@ -432,7 +432,7 @@ func TestProcessProposal(t *testing.T) {
 		},
 		NextValidatorsHash: block1.NextValidatorsHash,
 		ProposerAddress:    block1.ProposerAddress,
-		DataRootHash:       block1.Header.DataHash,
+		DataRootHash:       block1.Header.DataHash, //nolint:staticcheck
 	}
 
 	acceptBlock, err := blockExec.ProcessProposal(block1, state)
@@ -789,7 +789,7 @@ func TestPrepareProposalTxsAllIncluded(t *testing.T) {
 	block, _, err := blockExec.CreateProposalBlock(ctx, height, state, commit, pa)
 	require.NoError(t, err)
 
-	for i, tx := range block.Data.Txs {
+	for i, tx := range block.Data.Txs { //nolint:staticcheck
 		require.Equal(t, txs[i], tx)
 	}
 
@@ -844,7 +844,7 @@ func TestPrepareProposalReorderTxs(t *testing.T) {
 	require.NoError(t, err)
 	block, _, err := blockExec.CreateProposalBlock(ctx, height, state, commit, pa)
 	require.NoError(t, err)
-	for i, tx := range block.Data.Txs {
+	for i, tx := range block.Data.Txs { //nolint:staticcheck
 		require.Equal(t, txs[i], tx)
 	}
 

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -419,7 +419,7 @@ func (idx *BlockerIndexer) match(
 
 	tmpHeights := make(map[string][]byte)
 
-	switch {
+	switch { //nolint:staticcheck
 	case c.Op == syntax.TEq:
 		it, err := dbm.IteratePrefix(idx.store, startKeyBz)
 		if err != nil {

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -123,7 +123,7 @@ func TestRollbackHard(t *testing.T) {
 
 	currState := state.State{
 		Version: cmtstate.Version{
-			Consensus: block.Header.Version,
+			Consensus: block.Header.Version, //nolint:staticcheck
 			Software:  version.TMCoreSemVer,
 		},
 		LastBlockHeight:                  block.Height,
@@ -180,7 +180,7 @@ func TestRollbackHard(t *testing.T) {
 
 	nextState := state.State{
 		Version: cmtstate.Version{
-			Consensus: block.Header.Version,
+			Consensus: block.Header.Version, //nolint:staticcheck
 			Software:  version.TMCoreSemVer,
 		},
 		LastBlockHeight:                  nextBlock.Height,

--- a/state/state.go
+++ b/state/state.go
@@ -182,7 +182,7 @@ func (state *State) ToProto() (*cmtstate.State, error) {
 }
 
 // FromProto takes a state proto message & returns the local state type
-func FromProto(pb *cmtstate.State) (*State, error) { //nolint:golint
+func FromProto(pb *cmtstate.State) (*State, error) {
 	if pb == nil {
 		return nil, errors.New("nil State")
 	}
@@ -260,7 +260,7 @@ func (state State) MakeBlock(
 	}
 
 	// Fill rest of header with state data.
-	block.Header.Populate(
+	block.Header.Populate( //nolint:staticcheck
 		state.Version.Consensus, state.ChainID,
 		timestamp, state.LastBlockID,
 		state.Validators.Hash(), state.NextValidators.Hash(),

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -353,7 +353,7 @@ func (txi *TxIndex) match(
 
 	tmpHashes := make(map[string][]byte)
 
-	switch {
+	switch { //nolint:staticcheck
 	case c.Op == syntax.TEq:
 		it, err := dbm.IteratePrefix(txi.store, startKeyBz)
 		if err != nil {
@@ -702,7 +702,7 @@ func extractValueFromKey(key []byte) string {
 }
 
 func extractEventSeqFromKey(key []byte) string {
-	parts := strings.SplitN(string(key), tagKeySeparator, -1)
+	parts := strings.SplitN(string(key), tagKeySeparator, -1) //nolint:staticcheck
 
 	lastEl := parts[len(parts)-1]
 

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -316,7 +316,7 @@ func TestTxSearchEventMatchByHeight(t *testing.T) {
 			assert.Len(t, results, tc.resultsLength)
 			if tc.resultsLength > 0 {
 				for _, txr := range results {
-					if txr.Height == 1 {
+					if txr.Height == 1 { //nolint:staticcheck
 						assert.True(t, proto.Equal(txResult, txr))
 					} else if txr.Height == 10 {
 						assert.True(t, proto.Equal(txResult10, txr))

--- a/statesync/snapshots.go
+++ b/statesync/snapshots.go
@@ -31,7 +31,7 @@ type snapshot struct {
 func (s *snapshot) Key() snapshotKey {
 	// Hash.Write() never returns an error.
 	hasher := sha256.New()
-	hasher.Write([]byte(fmt.Sprintf("%v:%v:%v", s.Height, s.Format, s.Chunks)))
+	hasher.Write([]byte(fmt.Sprintf("%v:%v:%v", s.Height, s.Format, s.Chunks))) //nolint:staticcheck
 	hasher.Write(s.Hash)
 	hasher.Write(s.Metadata)
 	var key snapshotKey

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -170,10 +170,10 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	require.GreaterOrEqual(t, validPartSet.Total(), uint32(2))
 	part2 := validPartSet.GetPart(1)
 
-	seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now())
+	seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now()) //nolint:staticcheck
 	bs.SaveBlockWithExtendedCommit(block, validPartSet, seenCommit)
 	require.EqualValues(t, 1, bs.Base(), "expecting the new height to be changed")
-	require.EqualValues(t, block.Header.Height, bs.Height(), "expecting the new height to be changed")
+	require.EqualValues(t, block.Header.Height, bs.Height(), "expecting the new height to be changed") //nolint:staticcheck
 
 	incompletePartSet := types.NewPartSetFromHeader(types.PartSetHeader{Total: 2})
 	uncontiguousPartSet := types.NewPartSetFromHeader(types.PartSetHeader{Total: 0})
@@ -409,7 +409,7 @@ func TestSaveBlockWithExtendedCommitPanicOnAbsentExtension(t *testing.T) {
 			block, ps, err := state.MakeBlock(h, types.MakeData(test.MakeNTxs(h, 10)), new(types.Commit), nil, state.Validators.GetProposer().Address)
 			require.NoError(t, err)
 
-			seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now())
+			seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now()) //nolint:staticcheck
 			require.NoError(t, err)
 			testCase.malleateCommit(seenCommit)
 			if testCase.shouldPanic {
@@ -449,7 +449,7 @@ func TestLoadBlockExtendedCommit(t *testing.T) {
 			h := bs.Height() + 1
 			block, ps, err := state.MakeBlock(h, types.MakeData(test.MakeNTxs(h, 10)), new(types.Commit), nil, state.Validators.GetProposer().Address)
 			require.NoError(t, err)
-			seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now())
+			seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now()) //nolint:staticcheck
 			if testCase.saveExtended {
 				bs.SaveBlockWithExtendedCommit(block, ps, seenCommit)
 			} else {
@@ -698,9 +698,9 @@ func TestLoadBlockMetaByHash(t *testing.T) {
 	bs.SaveBlock(b1, partSet, seenCommit.ToCommit())
 
 	baseBlock := bs.LoadBlockMetaByHash(b1.Hash())
-	assert.EqualValues(t, b1.Header.Height, baseBlock.Header.Height)
-	assert.EqualValues(t, b1.Header.LastBlockID, baseBlock.Header.LastBlockID)
-	assert.EqualValues(t, b1.Header.ChainID, baseBlock.Header.ChainID)
+	assert.EqualValues(t, b1.Header.Height, baseBlock.Header.Height)           //nolint:staticcheck
+	assert.EqualValues(t, b1.Header.LastBlockID, baseBlock.Header.LastBlockID) //nolint:staticcheck
+	assert.EqualValues(t, b1.Header.ChainID, baseBlock.Header.ChainID)         //nolint:staticcheck
 }
 
 func TestBlockFetchAtHeight(t *testing.T) {
@@ -710,9 +710,9 @@ func TestBlockFetchAtHeight(t *testing.T) {
 	block, partSet, err := state.MakeBlock(bs.Height()+1, types.MakeData(nil), new(types.Commit), nil, state.Validators.GetProposer().Address)
 
 	require.NoError(t, err)
-	seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now())
+	seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now()) //nolint:staticcheck
 	bs.SaveBlockWithExtendedCommit(block, partSet, seenCommit)
-	require.Equal(t, bs.Height(), block.Header.Height, "expecting the new height to be changed")
+	require.Equal(t, bs.Height(), block.Header.Height, "expecting the new height to be changed") //nolint:staticcheck
 
 	blockAtHeight := bs.LoadBlock(bs.Height())
 	b1, err := block.ToProto()

--- a/test/app/grpc_client.go
+++ b/test/app/grpc_client.go
@@ -25,8 +25,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	//nolint:staticcheck // SA1019: core_grpc.StartGRPCClient is deprecated: A new gRPC API will be introduced after v0.38.
-	clientGRPC := coregrpc.StartGRPCClient(grpcAddr)
+	clientGRPC := coregrpc.StartGRPCClient(grpcAddr) //nolint:staticcheck
 	res, err := clientGRPC.BroadcastTx(context.Background(), &coregrpc.RequestBroadcastTx{Tx: txBytes})
 	if err != nil {
 		fmt.Println(err)

--- a/test/e2e/node/config.go
+++ b/test/e2e/node/config.go
@@ -58,8 +58,6 @@ func LoadConfig(file string) (*Config, error) {
 
 // Validate validates the configuration. We don't do exhaustive config
 // validation here, instead relying on Testnet.Validate() to handle it.
-//
-//nolint:goconst
 func (cfg Config) Validate() error {
 	switch {
 	case cfg.ChainID == "":

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -70,7 +70,7 @@ func run(configFile string) error {
 		if err = startSigner(cfg); err != nil {
 			return err
 		}
-		if cfg.Protocol == "builtin" || cfg.Protocol == "builtin_connsync" {
+		if cfg.Protocol == "builtin" || cfg.Protocol == "builtin_connsync" { //nolint:goconst
 			time.Sleep(1 * time.Second)
 		}
 	}

--- a/test/e2e/runner/benchmark.go
+++ b/test/e2e/runner/benchmark.go
@@ -208,7 +208,7 @@ func extractTestnetStats(intervals []time.Duration) testnetStats {
 
 	for _, interval := range intervals {
 		diff := (interval - mean).Seconds()
-		std += math.Pow(diff, 2)
+		std += math.Pow(diff, 2) //nolint:staticcheck
 	}
 	std = math.Sqrt(std / float64(len(intervals)))
 

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -31,20 +31,20 @@ func TestBlock_Header(t *testing.T) {
 		}
 
 		for _, block := range blocks {
-			if block.Header.Height < first {
+			if block.Header.Height < first { //nolint:staticcheck
 				continue
 			}
-			if block.Header.Height > last {
+			if block.Header.Height > last { //nolint:staticcheck
 				break
 			}
-			resp, err := client.Block(ctx, &block.Header.Height)
+			resp, err := client.Block(ctx, &block.Header.Height) //nolint:staticcheck
 			require.NoError(t, err)
 
 			require.Equal(t, block, resp.Block,
-				"block mismatch for height %d", block.Header.Height)
+				"block mismatch for height %d", block.Header.Height) //nolint:staticcheck
 
 			require.NoError(t, resp.Block.ValidateBasic(),
-				"block at height %d is invalid", block.Header.Height)
+				"block at height %d is invalid", block.Header.Height) //nolint:staticcheck
 		}
 	})
 }

--- a/test/loadtime/report/report.go
+++ b/test/loadtime/report/report.go
@@ -202,7 +202,7 @@ func GenerateFromBlockStore(s BlockStore) (*Reports, error) {
 			// be used in the latency calculations because the last block whose
 			// transactions are used is the block one before the last.
 			cur := s.LoadBlock(i)
-			for _, tx := range prev.Data.Txs {
+			for _, tx := range prev.Data.Txs { //nolint:staticcheck
 				txc <- txData{tx: tx, bt: cur.Time}
 			}
 			prev = cur

--- a/types/block_meta.go
+++ b/types/block_meta.go
@@ -22,7 +22,7 @@ func NewBlockMeta(block *Block, blockParts *PartSet) *BlockMeta {
 		BlockID:   BlockID{block.Hash(), blockParts.Header()},
 		BlockSize: block.Size(),
 		Header:    block.Header,
-		NumTxs:    len(block.Data.Txs),
+		NumTxs:    len(block.Data.Txs), //nolint:staticcheck
 	}
 }
 

--- a/types/light.go
+++ b/types/light.go
@@ -34,9 +34,9 @@ func (lb LightBlock) ValidateBasic(chainID string) error {
 	}
 
 	// make sure the validator set is consistent with the header
-	if valSetHash := lb.ValidatorSet.Hash(); !bytes.Equal(lb.SignedHeader.ValidatorsHash, valSetHash) {
+	if valSetHash := lb.ValidatorSet.Hash(); !bytes.Equal(lb.SignedHeader.ValidatorsHash, valSetHash) { //nolint:staticcheck
 		return fmt.Errorf("expected validator hash of header to match validator set hash (%X != %X)",
-			lb.SignedHeader.ValidatorsHash, valSetHash,
+			lb.SignedHeader.ValidatorsHash, valSetHash, //nolint:staticcheck
 		)
 	}
 
@@ -154,7 +154,7 @@ func (sh SignedHeader) ValidateBasic(chainID string) error {
 	if sh.Commit.Height != sh.Height {
 		return fmt.Errorf("header and commit height mismatch: %d vs %d", sh.Height, sh.Commit.Height)
 	}
-	if hhash, chash := sh.Header.Hash(), sh.Commit.BlockID.Hash; !bytes.Equal(hhash, chash) {
+	if hhash, chash := sh.Header.Hash(), sh.Commit.BlockID.Hash; !bytes.Equal(hhash, chash) { //nolint:staticcheck
 		return fmt.Errorf("commit signs block %X, header is block %X", chash, hhash)
 	}
 

--- a/types/light_test.go
+++ b/types/light_test.go
@@ -153,7 +153,7 @@ func TestSignedHeaderValidateBasic(t *testing.T) {
 				Header: tc.shHeader,
 				Commit: tc.shCommit,
 			}
-			err := sh.ValidateBasic(validSignedHeader.Header.ChainID)
+			err := sh.ValidateBasic(validSignedHeader.Header.ChainID) //nolint:staticcheck
 			assert.Equalf(
 				t,
 				tc.expectErr,


### PR DESCRIPTION
Fixes golangci-lint by ignoring the linters in upstream code.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

