### PR TITLE
Update RFC link in CONTRIBUTING.md to current location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ heartfelt emoji.
 
 If the issue would benefit from thorough discussion, maintainers may request
 that you create a [Request For
-Comment](https://github.com/cometbft/cometbft/tree/main/docs/rfc) in the
+Comment](https://github.com/cometbft/cometbft/tree/main/docs/references/rfc/) in the
 CometBFT repo. Discussion at the RFC stage will build collective
 understanding of the dimensions of the problems and help structure conversations
 around trade-offs.


### PR DESCRIPTION
The old link to the RFCs directory in the CometBFT repository was outdated and resulted in a 404 error. This commit updates the link to point to the current RFCs location at docs/references/rfc/, ensuring contributors can easily find and reference the relevant documentation.