### PR TITLE
chore: run CI when pushing to v0.38.x-celestia

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
 
 jobs:
   build:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -7,7 +7,7 @@ name: Check generated code
 on:
   pull_request:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
 
 permissions:
   contents: read

--- a/.github/workflows/cometbft-docker.yml
+++ b/.github/workflows/cometbft-docker.yml
@@ -4,7 +4,7 @@ name: Docker
 on:
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"               # Push events to matching v*, i.e. v1.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"  # e.g. v0.37.0-alpha.1, v0.38.0-alpha.10

--- a/.github/workflows/docs-toc.yml
+++ b/.github/workflows/docs-toc.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     push:
       branches:
-        - v0.38.x
+        - v0.38.x-celestia
 
 jobs:
   check:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
 
 jobs:
   e2e-test:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 3 * * *'
   pull_request:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
     paths:
       - "test/fuzz/**/*.go"
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
 
 jobs:
   govulncheck:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
 jobs:
   golangci:
     name: golangci-lint

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -2,14 +2,14 @@ name: Markdown Linter
 on:
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
     paths:
       - "**.md"
       - "**.yml"
       - "**.yaml"
   pull_request:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
     paths:
       - "**.md"
       - "**.yml"

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -5,7 +5,7 @@ on:
       - 'proto/**'
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
     paths:
       - 'proto/**'
 

--- a/.github/workflows/testapp-docker.yml
+++ b/.github/workflows/testapp-docker.yml
@@ -4,7 +4,7 @@ name: Docker E2E Node
 on:
   push:
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"               # Push events to matching v*, i.e. v1.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"  # e.g. v0.37.0-alpha.1, v0.38.0-alpha.10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "**.go"
     branches:
-      - v0.38.x
+      - v0.38.x-celestia
 
 jobs:
   tests:


### PR DESCRIPTION
Runs CI when pushing to v0.38.x-celestia

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

