### PR TITLE
feat: feed any existing data to the consensus reactor with every height/round

### DIFF
--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -163,16 +163,13 @@ func (blockProp *Reactor) handleCompactBlock(cb *proptypes.CompactBlock, peer p2
 		return
 	}
 
-	blockProp.broadcastCompactBlock(cb, peer)
-
-	if proposer {
-		return
+	if !proposer {
+		blockProp.proposalChan <- cb.Proposal
+		// check if we have any transactions that are in the compact block
+		go blockProp.recoverPartsFromMempool(cb)
 	}
 
-	blockProp.proposalChan <- cb.Proposal
-
-	// check if we have any transactions that are in the compact block
-	go blockProp.recoverPartsFromMempool(cb)
+	blockProp.broadcastCompactBlock(cb, peer)
 }
 
 // recoverPartsFromMempool queries the mempool to see if we can recover any block parts locally.


### PR DESCRIPTION
This fixes the E2E. The issue we had was during catchup, if the network is at a higher height, when we start catching up, we don't feed the data we received in the propagation reactor to the consensus reactor -> halt. 

This adds a channel to notify whenever there is a new height/round to check if the propagation reactor has any relevant data to the consensus reactor and feeds it to it.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

