### PR TITLE
fix: combined partset complete == original partset complete

### DIFF
--- a/consensus/propagation/types/combined_partset.go
+++ b/consensus/propagation/types/combined_partset.go
@@ -104,7 +104,7 @@ func (cps *CombinedPartSet) Total() uint32 {
 func (cps *CombinedPartSet) IsComplete() bool {
 	cps.mtx.Lock()
 	defer cps.mtx.Unlock()
-	return cps.original.IsComplete() && cps.parity.IsComplete()
+	return cps.original.IsComplete()
 }
 
 // CanDecode determines if enough parts have been added to decode the block.


### PR DESCRIPTION
Fixes audit issue: **The check for complete CombinedPartSet during catchup is incorrect**

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

