### PR TITLE
chore: update Go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/cometbft/cometbft
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.4
 
 require (
 	github.com/BurntSushi/toml v1.4.0
@@ -60,7 +60,7 @@ require (
 	google.golang.org/protobuf v1.36.4
 )
 
-require github.com/golang/snappy v0.0.4
+require github.com/golang/snappy v0.0.4 // indirect
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f h1:otljaYPt5hWxV3MUfO5dFPFiOXg9CyG5/kCfayTqsJ4=
 github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=

--- a/scripts/mockery_generate.sh
+++ b/scripts/mockery_generate.sh
@@ -2,4 +2,4 @@
 #
 # Invoke Mockery v2 to update generated mocks for the given type.
 
-go run github.com/vektra/mockery/v2@v2.49.2 --disable-version-string --case underscore --name "$*"
+go run github.com/vektra/mockery/v2@v2.53.3 --disable-version-string --case underscore --name "$*"

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.24.0
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.23.6
+FROM golang:1.24.0
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION

### description: 
Bump go version to 1.24.0 to fix govuln CI in v0.38.x-celestia: https://github.com/celestiaorg/celestia-core/actions/runs/15562910160/job/43819564223?pr=1955

Closes #1983

