### PR TITLE
fix: correctly set the proposer when updating the round

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -586,7 +586,6 @@ func (cs *State) updateRoundStep(round int32, step cstypes.RoundStepType) {
 	}
 	cs.Round = round
 	cs.Step = step
-	cs.propagator.SetProposer(cs.Validators.GetProposer().PubKey)
 	select {
 	case cs.newHeightOrRoundChan <- struct{}{}:
 	default:
@@ -1154,6 +1153,10 @@ func (cs *State) enterNewRound(height int64, round int32) {
 	}
 
 	cs.propagator.SetConsensusRound(height, round)
+	proposer := cs.Validators.GetProposer()
+	if proposer != nil {
+		cs.propagator.SetProposer(proposer.PubKey)
+	}
 
 	// Wait for txs to be available in the mempool
 	// before we enterPropose in round 0. If the last block changed the app hash,
@@ -1877,6 +1880,10 @@ func (cs *State) finalizeCommit(height int64) {
 
 	// prune the propagation reactor
 	cs.propagator.Prune(height)
+	proposer := cs.Validators.GetProposer()
+	if proposer != nil {
+		cs.propagator.SetProposer(proposer.PubKey)
+	}
 	// By here,
 	// * cs.Height has been increment to height+1
 	// * cs.Step is now cstypes.RoundStepNewHeight

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -586,6 +586,7 @@ func (cs *State) updateRoundStep(round int32, step cstypes.RoundStepType) {
 	}
 	cs.Round = round
 	cs.Step = step
+	cs.propagator.SetProposer(cs.Validators.GetProposer().PubKey)
 	select {
 	case cs.newHeightOrRoundChan <- struct{}{}:
 	default:
@@ -1875,7 +1876,6 @@ func (cs *State) finalizeCommit(height int64) {
 	cs.scheduleRound0(&cs.RoundState)
 
 	// prune the propagation reactor
-	cs.propagator.SetProposer(cs.Validators.GetProposer().PubKey)
 	cs.propagator.Prune(height)
 	// By here,
 	// * cs.Height has been increment to height+1


### PR DESCRIPTION
This fixes the issue where blocks rounds >= 1 are not verified because the proposer key is for round == 0

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

