### PR TITLE
chore: bump dockerfile go version to 1.24

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,6 +1,6 @@
 # Use a build arg to ensure that both stages use the same,
 # hopefully current, go version.
-ARG GOLANG_BASE_IMAGE=golang:1.22-alpine
+ARG GOLANG_BASE_IMAGE=golang:1.24-alpine
 
 # stage 1 Generate CometBFT Binary
 FROM --platform=$BUILDPLATFORM $GOLANG_BASE_IMAGE as builder

--- a/README.md
+++ b/README.md
@@ -62,10 +62,9 @@ looking for, see [our security policy](SECURITY.md).
 
 | CometBFT version | Requirement | Notes             |
 |------------------|-------------|-------------------|
-| main             | Go version  | Go 1.22 or higher |
-| v0.38.x          | Go version  | Go 1.22 or higher |
-| v0.37.x          | Go version  | Go 1.22 or higher |
-| v0.34.x          | Go version  | Go 1.12 or higher |
+| main             | Go version  | Go 1.24 or higher |
+| v0.38.x          | Go version  | Go 1.24 or higher |
+| v0.34.x          | Go version  | Go 1.23 or higher |
 
 ### Install
 
@@ -173,7 +172,7 @@ maintains [cometbft.com](https://cometbft.com).
 [version-url]: https://github.com/cometbft/cometbft/releases/latest
 [api-badge]: https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
 [api-url]: https://pkg.go.dev/github.com/cometbft/cometbft
-[go-badge]: https://img.shields.io/badge/go-1.22-blue.svg
+[go-badge]: https://img.shields.io/badge/go-1.24-blue.svg
 [go-url]: https://github.com/moovweb/gvm
 [discord-badge]: https://img.shields.io/discord/669268347736686612.svg
 [discord-url]: https://discord.gg/interchain

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.24.0
+go 1.24.2
 
 toolchain go1.24.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.24.2
+go 1.24.0
 
 toolchain go1.24.4
 


### PR DESCRIPTION
Fixes CI in https://github.com/celestiaorg/celestia-core/actions/runs/15675634512/job/44155160210

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

