### PR TITLE
Fix broken OpenAPI reference link in RPC documentation

### DIFF
--- a/docs/core/rpc.md
+++ b/docs/core/rpc.md
@@ -6,7 +6,7 @@ order: 9
 
 The RPC documentation is hosted here:
 
-- [OpenAPI reference](../rpc)
+- [OpenAPI reference](../../rpc/openapi/index.html)
 
 <!--
 NOTE: The OpenAPI reference (../rpc) is injected into the documentation during


### PR DESCRIPTION
Updated the OpenAPI reference link in docs/core/rpc.md to point to the correct location (../../rpc/openapi/index.html). The previous link was broken due to a missing or relocated target. This change ensures users can access the OpenAPI documentation for RPC endpoints directly from the docs.


