### PR TITLE
Fix batch leak in SaveTxInfo

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -780,6 +780,7 @@ func (bs *BlockStore) SaveTxInfo(block *types.Block, txResponseCodes []uint32, l
 
 	// Create a new batch
 	batch := bs.db.NewBatch()
+	defer batch.Close()
 
 	// Batch and save txs from the block
 	for i, tx := range block.Txs {


### PR DESCRIPTION
## Summary

Note experimenting with codex. Please ignore for now. 

- close the DB batch opened in `SaveTxInfo`

## Testing
- `go vet ./store` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*
- `go test ./store` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_6835cf8a8684832992040a677cbe848f