### PR TITLE
chore: exit early when already has recovery part

### DIFF
--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -235,8 +235,6 @@ func (blockProp *Reactor) recoverPartsFromMempool(cb *proptypes.CompactBlock) {
 	for _, p := range parts {
 		p.Proof = *proofs[p.Index]
 
-		// adding the part without checking the proof since the proof was just
-		// created above.
 		added, err := originalParts.AddPart(p)
 		if err != nil {
 			blockProp.Logger.Error("failed to add locally recovered part", "err", err)

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -420,7 +420,7 @@ func (blockProp *Reactor) handleRecoveryPart(peer p2p.ID, part *proptypes.Recove
 		return
 	}
 
-	if parts.IsComplete() {
+	if parts.HasPart(int(part.Index)) || parts.IsComplete() {
 		return
 	}
 

--- a/consensus/propagation/types/combined_partset.go
+++ b/consensus/propagation/types/combined_partset.go
@@ -157,6 +157,10 @@ func (cps *CombinedPartSet) AddPart(part *RecoveryPart, proof merkle.Proof) (boo
 	return added, err
 }
 
+func (cps *CombinedPartSet) HasPart(index int) bool {
+	return cps.totalMap.GetIndex(index)
+}
+
 func (cps *CombinedPartSet) GetPart(index uint32) (*types.Part, bool) {
 	cps.mtx.Lock()
 	defer cps.mtx.Unlock()


### PR DESCRIPTION
Fixes audit issue: **Proofs are verified for received parts that the node already has**

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

