### PR TITLE
Update actions/cache to v4.2.3

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -26,14 +26,14 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Cache Go binaries
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-binary-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION


Updates all instances of actions/cache@v3 to actions/cache@v4

Changes:
- Updates all instances of actions/cache@v3 to actions/cache@v4

Reference:
Latest version confirmation: https://github.com/actions/cache/releases/tag/v4.2.3

This update ensures we're using the most recent stable version of the GitHub cache action across our CI/CD pipelines, with improved security features like masking of SAS tokens in debug logs.

