### PR TITLE
test: update assertions in TestProvider

### DIFF
--- a/light/provider/http/http_test.go
+++ b/light/provider/http/http_test.go
@@ -61,7 +61,7 @@ func TestProvider(t *testing.T) {
 	lb, err := p.LightBlock(context.Background(), 0)
 	require.NoError(t, err)
 	require.NotNil(t, lb)
-	assert.True(t, lb.Height < 1000)
+	assert.True(t, lb.Height > 0)
 
 	// let's check this is valid somehow
 	assert.Nil(t, lb.ValidateBasic(chainID))
@@ -73,7 +73,7 @@ func TestProvider(t *testing.T) {
 	assert.Equal(t, lower, lb.Height)
 
 	// fetching missing heights (both future and pruned) should return appropriate errors
-	lb, err = p.LightBlock(context.Background(), 1000)
+	lb, err = p.LightBlock(context.Background(), lb.Height+1000)
 	require.Error(t, err)
 	require.Nil(t, lb)
 	assert.Equal(t, provider.ErrHeightTooHigh, err)


### PR DESCRIPTION
On faster machines this test always fails, because latest block is way above height 1000 when first checked. This is a simple solution that makes this test a bit more elastic.

Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contribution guidelines.

