### PR TITLE
chore: change "Failed to load block meta" catchup log to debug

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -684,7 +684,7 @@ OUTER_LOOP:
 			if prs.ProposalBlockParts == nil {
 				blockMeta := conR.conS.blockStore.LoadBlockMeta(prs.Height)
 				if blockMeta == nil {
-					heightLogger.Error("Failed to load block meta",
+					heightLogger.Debug("Failed to load block meta",
 						"blockstoreBase", blockStoreBase, "blockstoreHeight", conR.conS.blockStore.Height())
 					time.Sleep(conR.conS.config.PeerGossipSleepDuration)
 				} else {
@@ -770,7 +770,7 @@ func (conR *Reactor) gossipDataForCatchup(logger log.Logger, rs *cstypes.RoundSt
 		// Ensure that the peer's PartSetHeader is correct
 		blockMeta := conR.conS.blockStore.LoadBlockMeta(prs.Height)
 		if blockMeta == nil {
-			logger.Error("Failed to load block meta", "ourHeight", rs.Height,
+			logger.Debug("Failed to load block meta", "ourHeight", rs.Height,
 				"blockstoreBase", conR.conS.blockStore.Base(), "blockstoreHeight", conR.conS.blockStore.Height())
 			time.Sleep(conR.conS.config.PeerGossipSleepDuration)
 			return


### PR DESCRIPTION
the node operator shouldn't need to do anything here and this log occurs every single time they try to send them a block part... so seems like a bad thing to error on.

to clarify further this log only gets hit when a peer is catching up from a block height the host doesn't have due to pruning or syncing.