### PR TITLE
fix: adjust PEX request interval to match specification (backport #2140)

### DIFF
--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -98,9 +98,12 @@ type Reactor struct {
 }
 
 func (r *Reactor) minReceiveRequestInterval() time.Duration {
-	// NOTE: must be around ensurePeersPeriod, otherwise we'll request
+	// NOTE: must be less than ensurePeersPeriod, otherwise we'll request
 	// peers too quickly from others and they'll think we're bad!
-	return r.ensurePeersPeriod
+	// According to the spec, the minimum accepted interval should be
+	// ensurePeersPeriod / 3 to allow for timing variations while still
+	// preventing abuse.
+	return r.ensurePeersPeriod / 3
 }
 
 // ReactorConfig holds reactor specific configuration data.

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -170,6 +170,92 @@ func TestPEXReactorRequestMessageAbuse(t *testing.T) {
 	assert.True(t, book.IsBanned(peerAddr))
 }
 
+func TestPEXReactorRequestIntervalValidation(t *testing.T) {
+	r, book := createReactor(&ReactorConfig{})
+	defer teardownReactor(book)
+
+	// Set a shorter ensurePeersPeriod to avoid long test times
+	// Using 3 seconds instead of default 30 seconds
+	testEnsurePeersPeriod := 3 * time.Second
+	r.SetEnsurePeersPeriod(testEnsurePeersPeriod)
+
+	sw := createSwitchAndAddReactors(r)
+	sw.SetAddrBook(book)
+
+	peer := mock.NewPeer(nil)
+	peerAddr := peer.SocketAddr()
+	p2p.AddPeerToSwitchPeerSet(sw, peer)
+	assert.True(t, sw.Peers().Has(peer.ID()))
+	err := book.AddAddress(peerAddr, peerAddr)
+	require.NoError(t, err)
+	require.True(t, book.HasAddress(peerAddr))
+
+	id := string(peer.ID())
+
+	// With ensurePeersPeriod of 3s, minReceiveRequestInterval should be 1s (3s / 3)
+	expectedMinInterval := testEnsurePeersPeriod / 3
+	assert.Equal(t, expectedMinInterval, r.minReceiveRequestInterval())
+
+	// First request should always be accepted (creates the entry)
+	r.Receive(p2p.Envelope{ChannelID: PexChannel, Src: peer, Message: &tmp2p.PexRequest{}})
+	assert.True(t, r.lastReceivedRequests.Has(id))
+	assert.True(t, sw.Peers().Has(peer.ID()))
+
+	// Second request should also be accepted (sets the lastReceived time)
+	r.Receive(p2p.Envelope{ChannelID: PexChannel, Src: peer, Message: &tmp2p.PexRequest{}})
+	assert.True(t, r.lastReceivedRequests.Has(id))
+	assert.True(t, sw.Peers().Has(peer.ID()))
+
+	// Third request sent too soon (within minInterval) should be rejected
+	// Sleep for half the minimum interval to ensure we're too early
+	time.Sleep(expectedMinInterval / 2)
+	r.Receive(p2p.Envelope{ChannelID: PexChannel, Src: peer, Message: &tmp2p.PexRequest{}})
+	assert.False(t, r.lastReceivedRequests.Has(id), "Peer should be disconnected for sending request too soon")
+	assert.False(t, sw.Peers().Has(peer.ID()), "Peer should be removed from switch")
+	assert.True(t, book.IsBanned(peerAddr), "Peer should be banned")
+}
+
+func TestPEXReactorRequestIntervalAccepted(t *testing.T) {
+	r, book := createReactor(&ReactorConfig{})
+	defer teardownReactor(book)
+
+	// Set a shorter ensurePeersPeriod to avoid long test times
+	// Using 3 seconds instead of default 30 seconds
+	testEnsurePeersPeriod := 3 * time.Second
+	r.SetEnsurePeersPeriod(testEnsurePeersPeriod)
+
+	sw := createSwitchAndAddReactors(r)
+	sw.SetAddrBook(book)
+
+	peer := mock.NewPeer(nil)
+	peerAddr := peer.SocketAddr()
+	p2p.AddPeerToSwitchPeerSet(sw, peer)
+	assert.True(t, sw.Peers().Has(peer.ID()))
+	err := book.AddAddress(peerAddr, peerAddr)
+	require.NoError(t, err)
+	require.True(t, book.HasAddress(peerAddr))
+
+	id := string(peer.ID())
+
+	// With ensurePeersPeriod of 3s, minReceiveRequestInterval should be 1s (3s / 3)
+	expectedMinInterval := testEnsurePeersPeriod / 3
+	assert.Equal(t, expectedMinInterval, r.minReceiveRequestInterval())
+
+	// First and second requests for initialization
+	r.Receive(p2p.Envelope{ChannelID: PexChannel, Src: peer, Message: &tmp2p.PexRequest{}})
+	r.Receive(p2p.Envelope{ChannelID: PexChannel, Src: peer, Message: &tmp2p.PexRequest{}})
+	assert.True(t, sw.Peers().Has(peer.ID()))
+
+	// Wait for the minimum interval to pass
+	time.Sleep(expectedMinInterval + 10*time.Millisecond)
+
+	// Third request sent after appropriate interval should be accepted
+	r.Receive(p2p.Envelope{ChannelID: PexChannel, Src: peer, Message: &tmp2p.PexRequest{}})
+	assert.True(t, r.lastReceivedRequests.Has(id), "Peer should remain connected after sending request at proper interval")
+	assert.True(t, sw.Peers().Has(peer.ID()), "Peer should remain in switch")
+	assert.False(t, book.IsBanned(peerAddr), "Peer should not be banned")
+}
+
 func TestPEXReactorAddrsMessageAbuse(t *testing.T) {
 	r, book := createReactor(&ReactorConfig{})
 	defer teardownReactor(book)


### PR DESCRIPTION
## Problem

The PEX (Peer Exchange) reactor was causing frequent blacklisting of legitimate nodes due to overly strict timing requirements. From the logs:

```
peer (05ab6aa55a2cedadde73506b14cdf90ea2164986) sent next PEX request too soon.
lastReceived: 2025-07-04 10:55:27.652801791 +0000 UTC,
now: 2025-07-04 10:55:37.554963683 +0000 UTC,
minInterval: 10s. Disconnecting
```

The time difference was 9.902 seconds, which was less than the 10-second minimum interval, causing the peer to be disconnected and blacklisted.

## Root Cause

The implementation didn't match the specification in two key areas:

1. **`defaultEnsurePeersPeriod`** was set to 10 seconds instead of 30 seconds as specified
2. **`minReceiveRequestInterval()`** was returning the full `ensurePeersPeriod` instead of `ensurePeersPeriod / 3`

According to the [PEX protocol
specification](https://github.com/celestiaorg/celestia-core/blob/main/spec/p2p/implementation/pex-protocol.md):

> Since nodes are expected to send PEX requests every
`ensurePeersPeriod`, the minimum accepted interval between requests from the same peer is set to `ensurePeersPeriod / 3`, 10 seconds by default.

## Solution

```diff
// ensure we have enough peers
- defaultEnsurePeersPeriod = 10 * time.Second
+ defaultEnsurePeersPeriod = 30 * time.Second

func (r *Reactor) minReceiveRequestInterval() time.Duration {
-    // NOTE: must be around ensurePeersPeriod, otherwise we'll request
+    // NOTE: must be around ensurePeersPeriod/3, otherwise we'll request
     // peers too quickly from others and they'll think we're bad!
-    return r.ensurePeersPeriod
+    // According to the spec, the minimum accepted interval should be
+    // ensurePeersPeriod / 3 to allow for timing variations while still
+    // preventing abuse.
+    return r.ensurePeersPeriod / 3
}
```

## Impact

- **Default `ensurePeersPeriod`**: Now 30 seconds (was 10 seconds)
- **Default `minReceiveRequestInterval`**: Now 10 seconds (30s ÷ 3, was 10s)
- **Result**: Allows for reasonable timing variations while maintaining abuse protection
- **Backward compatibility**: All existing tests pass

This fix prevents legitimate PEX requests from being rejected due to minor timing variations, while still protecting against abuse as intended by the specification.

Fixes #2139.

(cherry picked from commit 43e1f4e578df2c018c2baa6a048971a012b47498)

