### PR TITLE
fix(ci): backport rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,51 +1,22 @@
-queue_rules:
-  - name: default
-    queue_conditions:
-      - base=main
-      - label=automerge
-    merge_conditions:
-      - base=main
-      - label=automerge
-    commit_message_template: |
-      {{ title }} (#{{ number }})
-
-      {{ body }}
-    merge_method: squash
-
 pull_request_rules:
-  - name: backport patches to main branch
+  - name: backport patches to main
     conditions:
-      - base=v0.38.x-celestia
-      - label=S:backport-to-main
+      - label=backport-to-main
     actions:
       backport:
         branches:
           - main
-  - name: backport patches to v0.38.x-celestia branch
+  - name: backport patches to v0.38.x-celestia
     conditions:
-      - base=main
-      - label=backport-to-v0.38.x-celestia
+      - label=backport-to-v0.38.x
     actions:
       backport:
         branches:
           - v0.38.x-celestia
-  - name: backport patches to v0.37.x branch
+  - name: backport patches to v0.34.x-celestia
     conditions:
-      - base=main
-      - label=backport-to-v0.37.x
-    actions:
-      backport:
-        branches:
-          - v0.37.x
-  - name: backport patches to v0.34.x branch
-    conditions:
-      - base=main
       - label=backport-to-v0.34.x
     actions:
       backport:
         branches:
-          - v0.34.x
-  - name: Automerge to main
-    conditions: []
-    actions:
-      queue:
+          - v0.34.x-celestia


### PR DESCRIPTION
Mergify hasn't been backporting any PRs to v0.38.x-celestia. The import issue is that the labels in the config didn't match the labels on the repo.

While I was here, I removed the merge queue which we don't use, some unnecessary conditions, a backport section for v0.37.x which we don't maintain

Reviewers should verify the labels in this PR match the labels on the repo at https://github.com/celestiaorg/celestia-core/labels?q=backport

![Screenshot 2025-07-07 at 10 09 52 PM](https://github.com/user-attachments/assets/a019dc87-e6ff-42aa-b49c-dd5f98b7a415)

