### PR TITLE
docs: remove "This server only supports /broadcast_tx_commit"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -354,7 +354,6 @@ type RPCConfig struct {
 	CORSAllowedHeaders []string `mapstructure:"cors_allowed_headers"`
 
 	// TCP or UNIX socket address for the gRPC server to listen on
-	// NOTE: This server only supports /broadcast_tx_commit
 	GRPCListenAddress string `mapstructure:"grpc_laddr"`
 
 	// Maximum number of simultaneous connections.

--- a/config/toml.go
+++ b/config/toml.go
@@ -172,7 +172,6 @@ cors_allowed_methods = [{{ range .RPC.CORSAllowedMethods }}{{ printf "%q, " . }}
 cors_allowed_headers = [{{ range .RPC.CORSAllowedHeaders }}{{ printf "%q, " . }}{{end}}]
 
 # TCP or UNIX socket address for the gRPC server to listen on
-# NOTE: This server only supports /broadcast_tx_commit
 grpc_laddr = "{{ .RPC.GRPCListenAddress }}"
 
 # Maximum number of simultaneous connections.


### PR DESCRIPTION
https://github.com/celestiaorg/celestia-core/pull/1513 appears to have added a BlockAPI to the RPC GRPC server.

If that's the case, then this line has been extremely misleading.

cc: @rach-id 