### PR TITLE
chore: remove the message from rpc-server timeout error

### DIFF
--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -440,7 +440,7 @@ func (wsc *wsConnection) writeRoutine() {
 				continue
 			}
 			if err = wsc.writeMessageWithDeadline(websocket.TextMessage, jsonBytes); err != nil {
-				wsc.Logger.Error("Failed to write response", "err", err, "msg", msg)
+				wsc.Logger.Error("Failed to write response", "err", err)
 				return
 			}
 		}


### PR DESCRIPTION
This error shows mostly in 128mb squares tests. It pollutes the logs because it outputs 1mb blobs in the logs which render navigating them hard.
