### PR TITLE
fix: make json decoding old v0.34 EventAttribute backwards compatible

### DIFF
--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -117,6 +117,10 @@ func (r *EventAttribute) MarshalJSON() ([]byte, error) {
 	return []byte(s), err
 }
 
+// UnmarshalJSON is modified to be backwards compatible with the old EventAttribute
+// that was broken in comet v0.38. That message used bytes and not strings, which differs
+// in that the go protobindings that marhalled json would encode bytes as base64. Here we do
+// the conversion, make that a non-issue.
 func (r *EventAttribute) UnmarshalJSON(b []byte) error {
 	// Parse the JSON into a raw struct to inspect the format
 	var raw struct {

--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 
 	"github.com/cosmos/gogoproto/jsonpb"
@@ -117,8 +118,49 @@ func (r *EventAttribute) MarshalJSON() ([]byte, error) {
 }
 
 func (r *EventAttribute) UnmarshalJSON(b []byte) error {
-	reader := bytes.NewBuffer(b)
-	return jsonpbUnmarshaller.Unmarshal(reader, r)
+	// Parse the JSON into a raw struct to inspect the format
+	var raw struct {
+		Key   string `json:"key,omitempty"`
+		Value string `json:"value,omitempty"`
+		Index bool   `json:"index,omitempty"`
+	}
+	
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	// Try to decode Key as base64, fallback to raw string
+	if raw.Key != "" {
+		if keyBytes, err := base64.StdEncoding.DecodeString(raw.Key); err == nil {
+			// Check if the base64 decoded content looks like it should be decoded
+			// (i.e., it's not the same as the original and produces valid output)
+			if string(keyBytes) != raw.Key {
+				r.Key = string(keyBytes)
+			} else {
+				r.Key = raw.Key
+			}
+		} else {
+			r.Key = raw.Key
+		}
+	}
+
+	// Try to decode Value as base64, fallback to raw string
+	if raw.Value != "" {
+		if valueBytes, err := base64.StdEncoding.DecodeString(raw.Value); err == nil {
+			// Check if the base64 decoded content looks like it should be decoded
+			// (i.e., it's not the same as the original and produces valid output)
+			if string(valueBytes) != raw.Value {
+				r.Value = string(valueBytes)
+			} else {
+				r.Value = raw.Value
+			}
+		} else {
+			r.Value = raw.Value
+		}
+	}
+
+	r.Index = raw.Index
+	return nil
 }
 
 // Some compile time assertions to ensure we don't

--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -124,7 +124,7 @@ func (r *EventAttribute) UnmarshalJSON(b []byte) error {
 		Value string `json:"value,omitempty"`
 		Index bool   `json:"index,omitempty"`
 	}
-	
+
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}

--- a/abci/types/types_test.go
+++ b/abci/types/types_test.go
@@ -1,11 +1,13 @@
 package types_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cometbft/cometbft/abci/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/merkle"
 )
@@ -71,4 +73,41 @@ func TestHashDeterministicFieldsOnly(t *testing.T) {
 	r2, err := abci.MarshalTxResults([]*abci.ExecTxResult{&tr2})
 	require.NoError(t, err)
 	require.Equal(t, merkle.HashFromByteSlices(r1), merkle.HashFromByteSlices(r2))
+}
+
+type OldEventAttribute struct {
+	Key   []byte `json:"key,omitempty"`
+	Value []byte `json:"value,omitempty"`
+	Index bool   `json:"index,omitempty"`
+}
+
+func TestJsonEventDecoding(t *testing.T) {
+	t.Run("json_cross_unmarshal", func(t *testing.T) {
+		// 1) JSON from the string‐field type:
+		eventAttr := &types.EventAttribute{Key: "foo", Value: "bar!", Index: true}
+		stringJSON, err := json.Marshal(eventAttr)
+		require.NoError(t, err)
+		// Try to unmarshal that into the bytes‐field type:
+		var intoOld OldEventAttribute
+		err = json.Unmarshal(stringJSON, &intoOld)
+		// encoding/json for []byte will try to base64‐decode "bar!" and fail:
+		require.Error(t, err, "raw UTF-8 should not decode as base64 when unmarshaled into []byte")
+
+		// 2) JSON from the bytes‐field type (base64):
+		oldEventAttr := &OldEventAttribute{
+			Key:   []byte("foo"),
+			Value: []byte("bar!"),
+			Index: true,
+		}
+		bytesJSON, err := json.Marshal(oldEventAttr)
+		require.NoError(t, err)
+		// That JSON.Value is base64("bar!") == "YmFyIQ==".
+		// Unmarshal into the string‐field type:
+		var intoNew types.EventAttribute
+		err = json.Unmarshal(bytesJSON, &intoNew)
+		require.NoError(t, err)
+		// But intoNew.Value is now the literal base64 string, not the original:
+		require.NotEqual(t, "bar!", intoNew.Value,
+			"base64 input becomes the literal string when unmarshaled into a Go string field")
+	})
 }

--- a/abci/types/types_test.go
+++ b/abci/types/types_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cometbft/cometbft/abci/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/merkle"
 )
@@ -83,7 +82,7 @@ type OldEventAttribute struct {
 
 func TestJsonEventDecoding(t *testing.T) {
 	// 1) JSON from the string‐field type:
-	eventAttr := &types.EventAttribute{Key: "foo", Value: "bar!", Index: true}
+	eventAttr := &abci.EventAttribute{Key: "foo", Value: "bar!", Index: true}
 	stringJSON, err := json.Marshal(eventAttr)
 	require.NoError(t, err)
 	// Try to unmarshal that into the bytes‐field type:
@@ -102,7 +101,7 @@ func TestJsonEventDecoding(t *testing.T) {
 	require.NoError(t, err)
 	// That JSON.Value is base64("bar!") == "YmFyIQ==".
 	// Unmarshal into the string‐field type:
-	var intoNew types.EventAttribute
+	var intoNew abci.EventAttribute
 	err = json.Unmarshal(bytesJSON, &intoNew)
 	require.NoError(t, err)
 	// But intoNew.Value is now the literal base64 string, not the original:

--- a/abci/types/types_test.go
+++ b/abci/types/types_test.go
@@ -80,7 +80,7 @@ type OldEventAttribute struct {
 	Index bool   `json:"index,omitempty"`
 }
 
-func TestJsonEventDecoding(t *testing.T) {
+func TestV0_34JsonEventDecoding(t *testing.T) {
 	// 1) JSON from the string‐field type:
 	eventAttr := &abci.EventAttribute{Key: "foo", Value: "bar!", Index: true}
 	stringJSON, err := json.Marshal(eventAttr)

--- a/abci/types/types_test.go
+++ b/abci/types/types_test.go
@@ -82,32 +82,30 @@ type OldEventAttribute struct {
 }
 
 func TestJsonEventDecoding(t *testing.T) {
-	t.Run("json_cross_unmarshal", func(t *testing.T) {
-		// 1) JSON from the string‐field type:
-		eventAttr := &types.EventAttribute{Key: "foo", Value: "bar!", Index: true}
-		stringJSON, err := json.Marshal(eventAttr)
-		require.NoError(t, err)
-		// Try to unmarshal that into the bytes‐field type:
-		var intoOld OldEventAttribute
-		err = json.Unmarshal(stringJSON, &intoOld)
-		// encoding/json for []byte will try to base64‐decode "bar!" and fail:
-		require.Error(t, err, "raw UTF-8 should not decode as base64 when unmarshaled into []byte")
+	// 1) JSON from the string‐field type:
+	eventAttr := &types.EventAttribute{Key: "foo", Value: "bar!", Index: true}
+	stringJSON, err := json.Marshal(eventAttr)
+	require.NoError(t, err)
+	// Try to unmarshal that into the bytes‐field type:
+	var intoOld OldEventAttribute
+	err = json.Unmarshal(stringJSON, &intoOld)
+	// encoding/json for []byte will try to base64‐decode "bar!" and fail:
+	require.Error(t, err)
 
-		// 2) JSON from the bytes‐field type (base64):
-		oldEventAttr := &OldEventAttribute{
-			Key:   []byte("foo"),
-			Value: []byte("bar!"),
-			Index: true,
-		}
-		bytesJSON, err := json.Marshal(oldEventAttr)
-		require.NoError(t, err)
-		// That JSON.Value is base64("bar!") == "YmFyIQ==".
-		// Unmarshal into the string‐field type:
-		var intoNew types.EventAttribute
-		err = json.Unmarshal(bytesJSON, &intoNew)
-		require.NoError(t, err)
-		// But intoNew.Value is now the literal base64 string, not the original:
-		require.NotEqual(t, "bar!", intoNew.Value,
-			"base64 input becomes the literal string when unmarshaled into a Go string field")
-	})
+	// 2) JSON from the bytes‐field type (base64):
+	oldEventAttr := &OldEventAttribute{
+		Key:   []byte("foo"),
+		Value: []byte("bar!"),
+		Index: true,
+	}
+	bytesJSON, err := json.Marshal(oldEventAttr)
+	require.NoError(t, err)
+	// That JSON.Value is base64("bar!") == "YmFyIQ==".
+	// Unmarshal into the string‐field type:
+	var intoNew types.EventAttribute
+	err = json.Unmarshal(bytesJSON, &intoNew)
+	require.NoError(t, err)
+	// But intoNew.Value is now the literal base64 string, not the original:
+	require.Equal(t, "bar!", intoNew.Value,
+		"base64 input becomes the literal string when unmarshaled into a Go string field")
 }

--- a/abci/types/types_test.go
+++ b/abci/types/types_test.go
@@ -104,7 +104,7 @@ func TestV0_34JsonEventDecoding(t *testing.T) {
 	var intoNew abci.EventAttribute
 	err = json.Unmarshal(bytesJSON, &intoNew)
 	require.NoError(t, err)
-	// But intoNew.Value is now the literal base64 string, not the original:
+	// But intoNew.Value is now the base64 decoded string, not the original:
 	require.Equal(t, "bar!", intoNew.Value,
-		"base64 input becomes the literal string when unmarshaled into a Go string field")
+		"base64 input becomes the decoded string when unmarshaled into a Go string field")
 }


### PR DESCRIPTION
makes json decoding the v0.34 proto messages backwards compatible with the new ones.

the main issue is that while the data over the wire is the same for bytes and strings in protobuf, the marhalling and unmarshalling of json is not the same.

The fix here is to decode and encode in a backwards compatible way.