### PR TITLE
feat: build the block pre-emptively during the commit timeout

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -875,6 +875,9 @@ func randConsensusNetWithPeers(
 		css[i] = newStateWithConfig(thisConfig, state, privVal, app)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
+		// set building the block pre-emptively to an empty channel because several tests alter in different consensus steps after the timeout commit
+		// and fail because the block is already built before
+		css[i].nextBlock = nil
 	}
 	return css, genDoc, peer0Config, func() {
 		for _, dir := range configRootDirs {

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -808,6 +808,9 @@ func randConsensusNet(t *testing.T, nValidators int, testName string, tickerFunc
 		css[i] = newStateWithConfigAndBlockStore(thisConfig, state, privVals[i], app, stateDB)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
+		// set building the block pre-emptively to an empty channel because several tests alter in different consensus steps after the timeout commit
+		// and fail because the block is already built before
+		css[i].nextBlock = nil
 	}
 	return css, func() {
 		for _, dir := range configRootDirs {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -208,6 +208,7 @@ func NewState(
 		partChan:             partChan,
 		proposalChan:         proposalChan,
 		newHeightOrRoundChan: make(chan struct{}),
+		nextBlock:            make(chan *blockWithParts, 1),
 	}
 	for _, option := range options {
 		option(cs)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1705,6 +1705,7 @@ func (cs *State) buildNextBlock() {
 		panic("Method createProposalBlock should not provide a nil block without errors")
 	}
 
+	fmt.Println("finished building block preamptively")
 	cs.nextBlock <- &blockWithParts{
 		block: block,
 		parts: blockParts,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1691,7 +1691,7 @@ func (cs *State) enterPrecommitWait(height int64, round int32) {
 
 // buildNextBlock creates the next block pre-amptively if we're the proposer.
 func (cs *State) buildNextBlock() {
-	fmt.Println("building block preamptively")
+	cs.Logger.Info("building block preamptively")
 	select {
 	// flush the next block channel. should only happen when there is already a POL block.
 	case <-cs.nextBlock:
@@ -1705,7 +1705,7 @@ func (cs *State) buildNextBlock() {
 		panic("Method createProposalBlock should not provide a nil block without errors")
 	}
 
-	fmt.Println("finished building block preamptively")
+	cs.Logger.Info("finished building block preamptively")
 	cs.nextBlock <- &blockWithParts{
 		block: block,
 		parts: blockParts,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -159,7 +159,7 @@ type State struct {
 	proposalChan         <-chan types.Proposal
 	newHeightOrRoundChan chan struct{}
 
-	// to build the block during the commit timeout
+	// nextBlock contains the next block to propose when building blocks during the timeout commit
 	nextBlock chan *blockWithParts
 
 	// for reporting metrics


### PR DESCRIPTION
## Overview

This PR adds support for the proposer to build the next block during the timeout commit. It allows saving ~0.5s, which is the time prepare-proposal takes, when proposing the block. So, straight after the timeout commit ends, the propose starts disseminating the block parts.

This optimization only works for first round, i.e., round 0, in the case where the mempool already has txs. The other two cases do not support this:

- For proposing the block for a round >= 1: There is no way to know if the network will reach consensus for a round `r` or not. So, building the block in this case will be meaningless unless we expect the network to frequently have multiple rounds. Also, it would add complicated logic to handle the case where the network reaches consensus for round `r` and needs to discard the pre-emptively built block as it can contain invalid transactions.
- Proposing the block during the timeout propose where the mempool was empty, and during this timeout, new transactions arrived. In this case, we can't build the block pre-emptively because the mempool didn't have the transactions during the timeout commit period.

## Experiments

To verify the throughput gains, we've run talis experiments to measure the block size and the block times for each case, with vs without this optimization. The setup is:

- 97 validator nodes geographically distributed
- The validators have the same staking weight
- Mempool uses CAT of size 80mb
- 100mb/s send/recv rate
- 3.5s timeout commit, 4.5s timeout propose

### Block sizes

**Before**:
<img width="1307" height="620" alt="image" src="https://github.com/user-attachments/assets/c0a4b9ed-7fec-488c-bbdc-ef9600dbadee" />


Note: txsim in this case was running in 2 validators, each sending 20 blobs.

**After**:
<img width="1321" height="629" alt="image" src="https://github.com/user-attachments/assets/340e8c16-ff98-48bc-805b-15b181c02408" />

Note: txsim first was running on 2 validators, each sending 20 blobs. However, given that the block was build pre-emptively, and txsim waits for transactions to be included before sending new ones, block sizes were fluctuating because there wasn't enough transactions in the mempool. So, I ran it in 5 validators, with each sending 20 blobs. This gave the bigger, more consistent blocks you see in the plot.


### Block times

**Before**:

<img width="1346" height="624" alt="image" src="https://github.com/user-attachments/assets/05068be3-4ae4-4e60-9588-7f3f6a3f34b5" />

Note: txsim in this case was running in 2 validators, each sending 20 blobs.

**After**:

<img width="1336" height="624" alt="image" src="https://github.com/user-attachments/assets/4a542cec-1f40-411b-98ee-d35caf2c4d0f" />

Note: txsim first was running on 2 validators, each sending 20 blobs. However, given that the block was build pre-emptively, and txsim waits for transactions to be included before sending new ones, block times were fluctuating. So, I ran it in 5 validators, with each sending 20 blobs. This gave the consistent 6s blocks you see in the plot.

## Conclusion

This change allows going from a throughput of `29mb/6.6s = 4.39mb/s` to `29mb/6s = 4,83mb/s`.

**Let me know if you need any more graphs or curious about other data, I have plenty of other graphs I can generate, :D**.

Closes https://github.com/celestiaorg/celestia-core/issues/2166
