### PR TITLE
fix: Return errors instead of panic on private key generation failure

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -121,18 +121,18 @@ func (privKey PrivKey) Type() string {
 // GenPrivKey generates a new ed25519 private key.
 // It uses OS randomness in conjunction with the current global random seed
 // in cometbft/libs/rand to generate the private key.
-func GenPrivKey() PrivKey {
+func GenPrivKey() (PrivKey, error) {
 	return genPrivKey(crypto.CReader())
 }
 
 // genPrivKey generates a new ed25519 private key using the provided reader.
-func genPrivKey(rand io.Reader) PrivKey {
+func genPrivKey(rand io.Reader) (PrivKey, error) {
 	_, priv, err := ed25519.GenerateKey(rand)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return PrivKey(priv)
+	return PrivKey(priv), nil
 }
 
 // GenPrivKeyFromSecret hashes the secret with SHA2, and uses

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -65,12 +65,12 @@ func (privKey PrivKey) Type() string {
 
 // GenPrivKey generates a new ECDSA private key on curve secp256k1 private key.
 // It uses OS randomness to generate the private key.
-func GenPrivKey() PrivKey {
+func GenPrivKey() (PrivKey, error) {
 	return genPrivKey(crypto.CReader())
 }
 
 // genPrivKey generates a new secp256k1 private key using the provided reader.
-func genPrivKey(rand io.Reader) PrivKey {
+func genPrivKey(rand io.Reader) (PrivKey, error) {
 	var privKeyBytes [PrivKeySize]byte
 	d := new(big.Int)
 
@@ -78,7 +78,7 @@ func genPrivKey(rand io.Reader) PrivKey {
 		privKeyBytes = [PrivKeySize]byte{}
 		_, err := io.ReadFull(rand, privKeyBytes[:])
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		d.SetBytes(privKeyBytes[:])
@@ -89,7 +89,7 @@ func genPrivKey(rand io.Reader) PrivKey {
 		}
 	}
 
-	return PrivKey(privKeyBytes[:])
+	return PrivKey(privKeyBytes[:]), nil
 }
 
 var one = new(big.Int).SetInt64(1)

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -126,15 +126,15 @@ func (privKey *PrivKey) UnmarshalJSON(data []byte) error {
 // GenPrivKey generates a new sr25519 private key.
 // It uses OS randomness in conjunction with the current global random seed
 // in cometbft/libs/rand to generate the private key.
-func GenPrivKey() PrivKey {
+func GenPrivKey() (PrivKey, error) {
 	return genPrivKey(crypto.CReader())
 }
 
 // genPrivKey generates a new sr25519 private key using the provided reader.
-func genPrivKey(rng io.Reader) PrivKey {
+func genPrivKey(rng io.Reader) (PrivKey, error) {
 	msk, err := sr25519.GenerateMiniSecretKey(rng)
 	if err != nil {
-		panic("sr25519: failed to generate MiniSecretKey: " + err.Error())
+		return PrivKey{}, err
 	}
 
 	sk := msk.ExpandEd25519()
@@ -142,7 +142,7 @@ func genPrivKey(rng io.Reader) PrivKey {
 	return PrivKey{
 		msk: *msk,
 		kp:  sk.KeyPair(),
-	}
+	}, nil
 }
 
 // GenPrivKeyFromSecret hashes the secret with SHA2, and uses


### PR DESCRIPTION


---


## Description

This PR improves the reliability and safety of cryptographic key generation for `secp256k1`, `ed25519`, and `sr25519`:

- All private key generation functions now return an error instead of panicking on random source failures.
- This prevents unexpected application crashes and allows proper error handling by the caller.

**Why:**  
Handling errors explicitly in cryptographic code is critical for robustness and security, especially in production and distributed environments.

---
