### PR TITLE
fix: initialize peer state when proposing

### DIFF
--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -95,11 +95,20 @@ func (blockProp *Reactor) ProposeBlock(proposal *types.Proposal, block *types.Pa
 		peer.Initialize(cb.Proposal.Height, cb.Proposal.Round, int(parts.Total()))
 
 		for _, part := range partsMeta {
+			// since this node is proposing, it already has the data and
+			// there's not a lot of reason to update this peer's have
+			// state other than to be consistent atm.
 			err := peer.SetHave(proposal.Height, proposal.Round, int(part.GetIndex()))
 			if err != nil {
 				blockProp.Logger.Debug("failed to set have part peer state", "peer", peer, "height", proposal.Height, "round", proposal.Round, "error", err)
+				// skip saving the old routine's state if the state here
+				// cannot also be saved
 				continue
 			}
+
+			// this might not get set depending on when the consensus peer
+			// state is getting updated. This will result in sending the
+			// peer redundant parts :shrug:
 			peer.consensusPeerState.SetHasProposalBlockPart(proposal.Height, proposal.Round, int(part.GetIndex()))
 		}
 

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -615,7 +615,7 @@ func (blockProp *Reactor) clearWants(part *proptypes.RecoveryPart, proof merkle.
 				continue
 			}
 
-			err := peer.SetHave(part.Height, part.Round, int(part.Index), )
+			err := peer.SetHave(part.Height, part.Round, int(part.Index))
 			if err != nil {
 				continue
 			}

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -614,19 +614,23 @@ func (blockProp *Reactor) clearWants(part *proptypes.RecoveryPart, proof merkle.
 				blockProp.Logger.Error("failed to send part", "peer", peer.peer.ID(), "height", part.Height, "round", part.Round, "part", part.Index)
 				continue
 			}
-			err := peer.SetHave(part.Height, part.Round, int(part.Index))
+
+			err := peer.SetHave(part.Height, part.Round, int(part.Index), )
 			if err != nil {
 				continue
 			}
+
 			err = peer.SetWant(part.Height, part.Round, int(part.Index), false)
 			if err != nil {
 				continue
 			}
+
 			catchup := false
 			blockProp.pmtx.Lock()
 			if part.Height < blockProp.currentHeight {
 				catchup = true
 			}
+
 			blockProp.pmtx.Unlock()
 			peer.DecreaseRemainingRequests(part.Height, part.Round, 1)
 			schema.WriteBlockPart(blockProp.traceClient, part.Height, part.Round, part.Index, catchup, string(peer.peer.ID()), schema.Upload)


### PR DESCRIPTION
part of #2240

initializes the peer state before the proposer attempts to update the peer state for the receiving node. There's not a lot of reason to do this, since the proposer already has all the block data. That's updated as comment in this PR as well.

It's also unclear to me in the consensus peer state is getting updated, which means the redundant part could still be sent.