### PR TITLE
chore: increase propagation/consensus/p2p send queue sizes

### DIFF
--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -95,7 +95,7 @@ func NewReactor(
 		privval:       config.Privval,
 		chainID:       config.ChainID,
 		BlockMaxBytes: config.BlockMaxBytes,
-		partChan:      make(chan types.PartInfo, 2500),
+		partChan:      make(chan types.PartInfo, 30_000),
 		proposalChan:  make(chan types.Proposal, 100),
 	}
 	reactor.BaseReactor = *p2p.NewBaseReactor("Recovery", reactor)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -203,7 +203,7 @@ func (conR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		{
 			ID:                  VoteSetBitsChannel,
 			Priority:            6,
-			SendQueueCapacity:   2,
+			SendQueueCapacity:   10,
 			RecvBufferCapacity:  1024,
 			RecvMessageCapacity: maxMsgSize,
 			MessageType:         &cmtcons.Message{},

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -50,7 +50,7 @@ var (
 	errInvalidProposalHeightRound = errors.New("invalid proposal height/round")
 )
 
-var msgQueueSize = 1000
+var msgQueueSize = 20_000
 
 // msgs from the reactor which may update the state
 type msgInfo struct {

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -2188,6 +2188,7 @@ func (n *fakeTxNotifier) Notify() {
 // and third precommit arrives which leads to the commit of that header and the correct
 // start of the next round
 func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
+	config := ResetConfig("consensus_reactor_test")
 	config.Consensus.SkipTimeoutCommit = false
 	cs1, vss := randState(4)
 	cs1.txNotifier = &fakeTxNotifier{ch: make(chan struct{})}
@@ -2252,6 +2253,7 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	config := ResetConfig("consensus_reactor_test")
 	config.Consensus.SkipTimeoutCommit = false
 	cs1, vss := randState(4)
 

--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -58,6 +58,7 @@ func (evR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		{
 			ID:                  EvidenceChannel,
 			Priority:            6,
+			SendQueueCapacity:   10,
 			RecvMessageCapacity: maxMsgSize,
 			MessageType:         &cmtproto.EvidenceList{},
 		},

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -153,6 +153,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		{
 			ID:                  mempool.MempoolChannel,
 			Priority:            1,
+			SendQueueCapacity:   10,
 			RecvMessageCapacity: txMsg.Size(),
 			MessageType:         &protomem.Message{},
 		},

--- a/mempool/priority/reactor.go
+++ b/mempool/priority/reactor.go
@@ -133,6 +133,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		{
 			ID:                  mempool.MempoolChannel,
 			Priority:            1,
+			SendQueueCapacity:   10,
 			RecvMessageCapacity: batchMsg.Size(),
 			MessageType:         &protomem.Message{},
 		},

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -81,6 +81,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		{
 			ID:                  MempoolChannel,
 			Priority:            5,
+			SendQueueCapacity:   10,
 			RecvMessageCapacity: batchMsg.Size(),
 			MessageType:         &protomem.Message{},
 		},

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -37,7 +37,7 @@ const (
 	// TODO: remove values present in config
 	defaultFlushThrottle = 100 * time.Millisecond
 
-	defaultSendQueueCapacity   = 100
+	defaultSendQueueCapacity   = 1
 	defaultRecvBufferCapacity  = 4096
 	defaultRecvMessageCapacity = 22020096      // 21MB
 	defaultSendRate            = int64(512000) // 500KB/s

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -37,7 +37,7 @@ const (
 	// TODO: remove values present in config
 	defaultFlushThrottle = 100 * time.Millisecond
 
-	defaultSendQueueCapacity   = 1
+	defaultSendQueueCapacity   = 100
 	defaultRecvBufferCapacity  = 4096
 	defaultRecvMessageCapacity = 22020096      // 21MB
 	defaultSendRate            = int64(512000) // 500KB/s


### PR DESCRIPTION
This helps to avoid blocking during messages processing. Also, with these numbers, the RAM usage < 6GB, so it's fine.