### PR TITLE
chore: add more details to the invalid proposal error

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2065,7 +2065,7 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 
 	// Does not apply
 	if proposal.Height != cs.Height || proposal.Round != cs.Round {
-		return fmt.Errorf("%w: proposal height %v round %v does not match state height %v round %v", errInvalidProposalHeightRound, proposal.Height, proposal.Round, cs.Height, cs.Round)
+		return fmt.Errorf("%w: proposal height %v round %v does not match state height %v round %v (if consensus is still reached, please ignore this error as it's a consequence of running two gossip routines at the same time)", errInvalidProposalHeightRound, proposal.Height, proposal.Round, cs.Height, cs.Round)
 	}
 	// Verify POLRound, which must be -1 or in range [0, proposal.Round).
 	if proposal.POLRound < -1 ||


### PR DESCRIPTION
This error happens because we're running two gossip routines. So, naturally the propagation reactor will gossip the proposal first and will be sent to the consensus reactor. Then, the legacy gossip routine also propagates the same proposal which sometimes is outdated.