### PR TITLE
chore: only build the block pre-emptively when the timeout commit is high

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1956,7 +1956,7 @@ func (cs *State) finalizeCommit(height int64) {
 	}
 
 	// build the block pre-emptively if we're the proposer and the timeout commit is higher than 1 s.
-	if cs.config.TimeoutCommit > time.Second && cs.privValidatorPubKey != nil {
+	if cs.config.TimeoutCommit > blockBuildingTime && cs.privValidatorPubKey != nil {
 		if address := cs.privValidatorPubKey.Address(); cs.Validators.HasAddress(address) && cs.isProposer(address) {
 			go cs.buildNextBlock()
 		}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1948,8 +1948,8 @@ func (cs *State) finalizeCommit(height int64) {
 		cs.propagator.SetProposer(proposer.PubKey)
 	}
 
-	// build the block pre-emptively if we're the proposer
-	if cs.privValidatorPubKey != nil {
+	// build the block pre-emptively if we're the proposer and the timeout commit is higher than 1 s.
+	if cs.config.TimeoutCommit > time.Second && cs.privValidatorPubKey != nil {
 		if address := cs.privValidatorPubKey.Address(); cs.Validators.HasAddress(address) && cs.isProposer(address) {
 			go cs.buildNextBlock()
 		}


### PR DESCRIPTION
This only builds the block pre-emptively if the timeout commit is set to > 1s to avoid race conditions when running tests that use ~100ms timeout commit.