### PR TITLE
chore: correctly initialise the new height channel

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -201,7 +201,7 @@ func NewState(
 		evsw:                 cmtevents.NewEventSwitch(),
 		metrics:              NopMetrics(),
 		traceClient:          trace.NoOpTracer(),
-		newHeightOrRoundChan: make(chan struct{}),
+		newHeightOrRoundChan: make(chan struct{}, 1),
 		nextBlock:            make(chan *blockWithParts, 1),
 	}
 	for _, option := range options {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2819,7 +2819,7 @@ func (cs *State) syncData() {
 					continue
 				}
 				part := partset.GetPart(indice)
-				cs.peerMsgQueue <- msgInfo{&BlockPartMessage{height, round, part}, ""}
+				cs.internalMsgQueue <- msgInfo{&BlockPartMessage{height, round, part}, ""}
 			}
 		case part, ok := <-partChan:
 			if !ok {


### PR DESCRIPTION
Previously, it was use an unbuffered channel which required both sender/receiver to be doing the same at the same time. This isn't always the case.