### PR TITLE
Fix ADR link in docs

### DIFF
--- a/docs/architecture/tendermint-core/adr-021-abci-events.md
+++ b/docs/architecture/tendermint-core/adr-021-abci-events.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-ABCI tags were first described in [ADR 002](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-002-event-subscription.md).
+ABCI tags were first described in [ADR 002](https://github.com/celestiaorg/celestia-core/blob/main/docs/architecture/tendermint-core/adr-002-event-subscription.md).
 They are key-value pairs that can be used to index transactions.
 
 Currently, ABCI messages return a list of tags to describe an


### PR DESCRIPTION
Update broken link in adr-021-abci-events.md to point to correct celestia-core repository location.
