### PR TITLE
fix: make the findNewPeerToRequestTx iterative

### DIFF
--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -463,5 +463,4 @@ func (memR *Reactor) findNewPeerToRequestTx(txKey types.TxKey) {
 	// We give up 🤷‍♂️ and hope either a peer responds late or the tx
 	// is gossiped again
 	memR.Logger.Debug("no other peer has the tx we are looking for", "txKey", txKey)
-	return
 }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/2271

The underlying cause seems to be `nil` peers not cleaned up. This also happens in the propagation reactor and we still didn't get to the root of the issue. 

So, I created this PR to avoid the infinite recursions. Then, i'll open another issue to investigate the nil peer issue.