### PR TITLE
chore: remove peer not found error log

### DIFF
--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -36,7 +36,6 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts) {
 	round := haves.Round
 	p := blockProp.getPeer(peer)
 	if p == nil || p.peer == nil {
-		blockProp.Logger.Error("peer not found", "peer", peer)
 		return
 	}
 
@@ -355,7 +354,6 @@ func (blockProp *Reactor) handleWants(peer p2p.ID, wants *proptypes.WantParts) {
 
 	p := blockProp.getPeer(peer)
 	if p == nil {
-		blockProp.Logger.Error("peer not found", "peer", peer)
 		return
 	}
 
@@ -434,7 +432,6 @@ func (blockProp *Reactor) handleRecoveryPart(peer p2p.ID, part *proptypes.Recove
 
 	p := blockProp.getPeer(peer)
 	if p == nil && peer != blockProp.self {
-		blockProp.Logger.Error("peer not found", "peer", peer)
 		return
 	}
 	// the peer must always send the proposal before sending parts, if they did


### PR DESCRIPTION
This removes the peer not found error log. It's redundant and pollutes the logs.

This can happen especially with parallel processing where:

- we receive a lot of messages from a peer that we still didn't process
- we disconnect from the peer for a reason or another
- when we try to process those messages, the peer doesn't exist

So there is no need to signal this every time it happens