### PR TITLE
docs(kv): correct block indexer key format comment

### DIFF
--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -62,7 +62,7 @@ func (idx *BlockerIndexer) Has(height int64) (bool, error) {
 // The following is indexed:
 //
 // primary key: encode(block.height | height) => encode(height)
-// FinalizeBlock events: encode(eventType.eventAttr|eventValue|height|finalize_block|eventSeq) => encode(height)
+// FinalizeBlock events: encode(eventType.eventAttr|eventValue|height|eventSeq) => encode(height)
 func (idx *BlockerIndexer) Index(bh types.EventDataNewBlockEvents) error {
 	batch := idx.store.NewBatch()
 	defer batch.Close()


### PR DESCRIPTION
Update state/indexer/block/kv/kv.go comment to reflect actual event key encoding: eventType.eventAttr|eventValue|height|eventSeq.
Remove misleading finalize_block segment from the described format.