### PR TITLE
fix: use the timeout commit passed from the application to determine if

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1714,7 +1714,8 @@ func (cs *State) buildNextBlock() {
 	}
 
 	// delay pre-emptive block building until the end of the timeout commit
-	time.Sleep(cs.config.TimeoutCommit - blockBuildingTime)
+	tc := cs.state.TimeoutCommit
+	time.Sleep(tc - blockBuildingTime)
 
 	block, blockParts, err := cs.createProposalBlock(context.TODO())
 	if err != nil {
@@ -1956,7 +1957,8 @@ func (cs *State) finalizeCommit(height int64) {
 	}
 
 	// build the block pre-emptively if we're the proposer and the timeout commit is higher than 1 s.
-	if cs.config.TimeoutCommit > blockBuildingTime && cs.privValidatorPubKey != nil {
+	tc := cs.state.TimeoutCommit
+	if tc > blockBuildingTime && cs.privValidatorPubKey != nil {
 		if address := cs.privValidatorPubKey.Address(); cs.Validators.HasAddress(address) && cs.isProposer(address) {
 			go cs.buildNextBlock()
 		}


### PR DESCRIPTION
blocks are built pre-emptively using the timeout commit from the config instead of what is passed back from the application.

I'm not sure, but don't think this is causing any problems currently. It could in the future though so we should change it.