### PR TITLE
refactor!: replace `PartSet` parts slice with buffer

### DIFF
--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -100,7 +100,7 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 		blockProp.proposals[height] = make(map[int32]*proposalData)
 	}
 
-	combinedSet := proptypes.NewCombinedPartSetFromOriginal(types.NewPartSetFromHeader(*psh), true)
+	combinedSet := proptypes.NewCombinedPartSetFromOriginal(types.NewPartSetFromHeader(*psh, types.BlockPartSizeBytes), true)
 
 	if blockProp.proposals[height][round] != nil {
 		existingPSH := blockProp.proposals[height][round].block.Original().Header()

--- a/consensus/propagation/types/combined_partset.go
+++ b/consensus/propagation/types/combined_partset.go
@@ -26,11 +26,11 @@ type CombinedPartSet struct {
 // CompactBlock using the PartSetHeader in the proposal and the BpHash from the
 // CompactBlock.
 func NewCombinedSetFromCompactBlock(cb *CompactBlock) *CombinedPartSet {
-	original := types.NewPartSetFromHeader(cb.Proposal.BlockID.PartSetHeader)
+	original := types.NewPartSetFromHeader(cb.Proposal.BlockID.PartSetHeader, types.BlockPartSizeBytes)
 	parity := types.NewPartSetFromHeader(types.PartSetHeader{
 		Total: original.Total(),
 		Hash:  cb.BpHash,
-	})
+	}, types.BlockPartSizeBytes)
 	total := bits.NewBitArray(int(original.Total() * 2))
 
 	return &CombinedPartSet{

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -1046,10 +1046,7 @@ func makeBlockchainFromWAL(wal WAL) ([]*types.Block, []*types.ExtendedCommit, er
 			// if its not the first one, we have a full block
 			if thisBlockParts != nil {
 				pbb := new(cmtproto.Block)
-				bz, err := io.ReadAll(thisBlockParts.GetReader())
-				if err != nil {
-					panic(err)
-				}
+				bz := thisBlockParts.GetBytes()
 				err = proto.Unmarshal(bz, pbb)
 				if err != nil {
 					panic(err)
@@ -1089,10 +1086,7 @@ func makeBlockchainFromWAL(wal WAL) ([]*types.Block, []*types.ExtendedCommit, er
 		}
 	}
 	// grab the last block too
-	bz, err := io.ReadAll(thisBlockParts.GetReader())
-	if err != nil {
-		panic(err)
-	}
+	bz := thisBlockParts.GetBytes()
 	pbb := new(cmtproto.Block)
 	err = proto.Unmarshal(bz, pbb)
 	if err != nil {

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -1071,7 +1071,7 @@ func makeBlockchainFromWAL(wal WAL) ([]*types.Block, []*types.ExtendedCommit, er
 				height++
 			}
 		case *types.PartSetHeader:
-			thisBlockParts = types.NewPartSetFromHeader(*p)
+			thisBlockParts = types.NewPartSetFromHeader(*p, types.BlockPartSizeBytes)
 		case *types.Part:
 			_, err := thisBlockParts.AddPart(p)
 			if err != nil {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1657,7 +1657,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 
 	if !cs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 		cs.ProposalBlock = nil
-		cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader)
+		cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 		psh := cs.ProposalBlockParts.Header()
 		cs.propagator.AddCommitment(height, round, &psh)
 	}
@@ -1783,7 +1783,7 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 			// We're getting the wrong block.
 			// Set up ProposalBlockParts and keep waiting.
 			cs.ProposalBlock = nil
-			cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader)
+			cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 			psh := blockID.PartSetHeader
 			cs.propagator.AddCommitment(height, commitRound, &psh)
 
@@ -2106,7 +2106,7 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	// This happens if we're already in cstypes.RoundStepCommit or if there is a valid block in the current round.
 	// TODO: We can check if Proposal is for a different block as this is a sign of misbehavior!
 	if cs.ProposalBlockParts == nil {
-		cs.ProposalBlockParts = types.NewPartSetFromHeader(proposal.BlockID.PartSetHeader)
+		cs.ProposalBlockParts = types.NewPartSetFromHeader(proposal.BlockID.PartSetHeader, types.BlockPartSizeBytes)
 	}
 
 	cs.Logger.Info("received proposal", "proposal", proposal, "proposer", pubKey.Address())
@@ -2460,7 +2460,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 				}
 
 				if !cs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
-					cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader)
+					cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 					psh := blockID.PartSetHeader
 					// todo: override in propagator if an existing proposal exists
 					cs.propagator.AddCommitment(height, vote.Round, &psh)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -2166,10 +2165,7 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID p2p.ID) (add
 		)
 	}
 	if added && cs.ProposalBlockParts.IsComplete() {
-		bz, err := io.ReadAll(cs.ProposalBlockParts.GetReader())
-		if err != nil {
-			return added, err
-		}
+		bz := cs.ProposalBlockParts.GetBytes()
 
 		pbb := new(cmtproto.Block)
 		err = proto.Unmarshal(bz, pbb)

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -2479,7 +2479,7 @@ func TestStateOutputsBlockPartsStats(t *testing.T) {
 		Part:   parts.GetPart(0),
 	}
 
-	cs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header())
+	cs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header(), types.BlockPartSizeBytes)
 	cs.handleMsg(msgInfo{msg, peer.ID()})
 
 	statsMessage := <-cs.statsMsgQueue

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -337,7 +337,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.Less(t, partSet.ByteSize(), maxBytes)
 
-	partSetFromHeader := types.NewPartSetFromHeader(partSet.Header())
+	partSetFromHeader := types.NewPartSetFromHeader(partSet.Header(), partSize)
 	for partSetFromHeader.Count() < partSetFromHeader.Total() {
 		added, err := partSetFromHeader.AddPart(partSet.GetPart(int(partSetFromHeader.Count())))
 		require.NoError(t, err)

--- a/store/store.go
+++ b/store/store.go
@@ -139,7 +139,7 @@ func (bs *BlockStore) LoadPartSet(height int64) (*types.PartSet, *types.BlockMet
 	if meta == nil {
 		return nil, nil, fmt.Errorf("block meta not found")
 	}
-	partSet := types.NewPartSetFromHeader(meta.BlockID.PartSetHeader)
+	partSet := types.NewPartSetFromHeader(meta.BlockID.PartSetHeader, types.BlockPartSizeBytes)
 	for i := 0; i < int(meta.BlockID.PartSetHeader.Total); i++ {
 		part := bs.LoadBlockPart(height, i)
 		if part == nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -175,8 +175,8 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	require.EqualValues(t, 1, bs.Base(), "expecting the new height to be changed")
 	require.EqualValues(t, block.Header.Height, bs.Height(), "expecting the new height to be changed") //nolint:staticcheck
 
-	incompletePartSet := types.NewPartSetFromHeader(types.PartSetHeader{Total: 2})
-	uncontiguousPartSet := types.NewPartSetFromHeader(types.PartSetHeader{Total: 0})
+	incompletePartSet := types.NewPartSetFromHeader(types.PartSetHeader{Total: 2}, types.BlockPartSizeBytes)
+	uncontiguousPartSet := types.NewPartSetFromHeader(types.PartSetHeader{Total: 0}, types.BlockPartSizeBytes)
 	_, err = uncontiguousPartSet.AddPart(part2)
 	require.Error(t, err)
 

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -210,13 +210,13 @@ type PartSet struct {
 
 	// partSize specifies the size of each part in bytes (excluding last part)
 	partSize int
-	// Size of the last part (which may be smaller than BlockPartSizeBytes)
+	// lastPartSize is the size of the last part (which may be smaller than partSize)
 	lastPartSize int
-	// Separate storage for merkle proofs
+	// proofs stores part proofs separately
 	proofs        []merkle.Proof
 	partsBitArray *bits.BitArray
 	count         uint32
-	// a count of the total size (in bytes). Used to ensure that the
+	// byteSize is the total size (in bytes). Used to ensure that the
 	// part set doesn't exceed the maximum block bytes
 	byteSize int64
 
@@ -563,7 +563,6 @@ func (ps *PartSet) addPart(part *Part) (bool, error) {
 
 	copy(ps.buffer[start:end], part.Bytes)
 
-	// Store the proof
 	ps.proofs[part.Index] = part.Proof
 
 	// Track last part size if this is the last part
@@ -585,7 +584,6 @@ func (ps *PartSet) addPart(part *Part) (bool, error) {
 // - The index is out of bounds
 // - Buffer access would be out of bounds
 func (ps *PartSet) getPartBytes(index int) []byte {
-	// Check if part exists
 	if !ps.partsBitArray.GetIndex(index) {
 		return nil
 	}

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/klauspost/reedsolomon"
 
@@ -641,14 +640,12 @@ func (ps *PartSet) IsComplete() bool {
 	return ps.count == ps.total
 }
 
-func (ps *PartSet) GetReader() io.Reader {
+func (ps *PartSet) GetBytes() []byte {
 	if !ps.IsComplete() {
-		panic("Cannot GetReader() on incomplete PartSet")
+		panic("Cannot GetBytes() on incomplete PartSet")
 	}
-
-	// Calculate the actual data size (excluding padding in last part)
-	dataSize := int(ps.total-1)*int(BlockPartSizeBytes) + ps.lastPartSize
-	return bytes.NewReader(ps.buffer[:dataSize])
+	dataSize := int(ps.total-1)*ps.partSize + ps.lastPartSize
+	return ps.buffer[:dataSize]
 }
 
 // StringShort returns a short version of String.

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -204,9 +204,9 @@ type PartSet struct {
 	hash  []byte
 
 	mtx cmtsync.Mutex
-	// Single preallocated buffer for all parts
-	buffer []byte
 
+	// buffer is a single preallocated buffer for all parts
+	buffer []byte
 	// partSize specifies the size of each part in bytes (excluding last part)
 	partSize int
 	// lastPartSize is the size of the last part (which may be smaller than partSize)

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -37,7 +37,7 @@ func TestBasicPartSet(t *testing.T) {
 	assert.EqualValues(t, testPartSize*nParts, partSet.ByteSize())
 
 	// Test adding parts to a new partSet.
-	partSet2 := NewPartSetFromHeader(partSet.Header())
+	partSet2 := NewPartSetFromHeader(partSet.Header(), testPartSize)
 
 	assert.True(t, partSet2.HasHeader(partSet.Header()))
 	for i := 0; i < int(partSet.Total()); i++ {
@@ -160,7 +160,7 @@ func TestWrongProof(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test adding a part with wrong data.
-	partSet2 := NewPartSetFromHeader(partSet.Header())
+	partSet2 := NewPartSetFromHeader(partSet.Header(), testPartSize)
 
 	// Test adding a part with wrong trail.
 	part := partSet.GetPart(0)
@@ -386,7 +386,7 @@ func benchPartSetFromData(b *testing.B, data []byte, partSize uint32) (ops *Part
 	ops = NewPartSetFromHeader(PartSetHeader{
 		Total: total,
 		Hash:  root,
-	})
+	}, partSize)
 
 	b.StartTimer()
 	for index, chunk := range chunks {

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/cometbft/cometbft/crypto"
@@ -63,9 +62,7 @@ func TestBasicPartSet(t *testing.T) {
 	assert.True(t, partSet2.IsComplete())
 
 	// Reconstruct data, assert that they are equal.
-	data2Reader := partSet2.GetReader()
-	data2, err := io.ReadAll(data2Reader)
-	require.NoError(t, err)
+	data2 := partSet2.GetBytes()
 
 	assert.Equal(t, data, data2)
 }
@@ -130,8 +127,7 @@ func TestEncodingDecodingRoundTrip(t *testing.T) {
 			ops, _, err = Decode(ops, eps, lastPartLen)
 			require.NoError(t, err)
 
-			bz2, err := io.ReadAll(ops.GetReader())
-			require.NoError(t, err)
+			bz2 := ops.GetBytes()
 
 			pbb := new(cmtproto.Block)
 			err = proto.Unmarshal(bz2, pbb)
@@ -335,10 +331,7 @@ func BenchmarkPartSetRoundTrip(b *testing.B) {
 	}
 	read := func(b *testing.B, partSet *PartSet, expectedSize int) {
 		b.ReportAllocs()
-		all, err := io.ReadAll(partSet.GetReader())
-		if err != nil {
-			b.Error(err)
-		}
+		all := partSet.GetBytes()
 		if len(all) != expectedSize {
 			b.Errorf("expected %d bytes, got %d", expectedSize, len(all))
 		}

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -115,9 +115,17 @@ func TestEncodingDecodingRoundTrip(t *testing.T) {
 			eps, lastPartLen, err := Encode(ops, BlockPartSizeBytes)
 			require.NoError(t, err)
 
-			ops.parts[0] = nil
+			// Remove part 0 to test decode functionality
+			ops.mtx.Lock()
 			ops.count--
 			ops.partsBitArray.SetIndex(0, false)
+			// Clear the buffer area for part 0
+			start := 0 * int(BlockPartSizeBytes)
+			end := start + int(BlockPartSizeBytes)
+			for i := start; i < end && i < len(ops.buffer); i++ {
+				ops.buffer[i] = 0
+			}
+			ops.mtx.Unlock()
 
 			ops, _, err = Decode(ops, eps, lastPartLen)
 			require.NoError(t, err)


### PR DESCRIPTION
## Summary
Enhanced `PartSet` by utilizing a single preallocated buffer for part storage, reducing memory overhead. Updated related methods, removing part array access in favor of buffer management.

The biggest difference is in reading - because we can return entire buffer, it's 0 overhead., while previous implementation using io.ReadAll and custom Reader was way slower.
In artificial benchmarks, inserting parts into PartSet takes similar time, but some allocations are saved - hopefully this could be more significant in real world.

## Results from my machine
### Before changes
```
$ go test -bench BenchmarkPartSetRoundTrip -benchtime 1s
goos: linux
goarch: amd64
pkg: github.com/cometbft/cometbft/types
cpu: Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz
BenchmarkPartSetRoundTrip/dataSize=1000,partSize=256/write-16   	  133821	      8993 ns/op	    2238 B/op	      21 allocs/op
BenchmarkPartSetRoundTrip/dataSize=1000,partSize=256/read-16    	 1319215	       919.1 ns/op	    3056 B/op	       8 allocs/op
BenchmarkPartSetRoundTrip/dataSize=130857600,partSize=65536/write-16         	       3	 354859913 ns/op	148265408 B/op	   27931 allocs/op
BenchmarkPartSetRoundTrip/dataSize=130857600,partSize=65536/read-16          	      12	  95687679 ns/op	769322953 B/op	    2048 allocs/op
BenchmarkPartSetRoundTrip/dataSize=523430400,partSize=65536/write-16         	       1	1460525033 ns/op	593392160 B/op	  127686 allocs/op
BenchmarkPartSetRoundTrip/dataSize=523430400,partSize=65536/read-16          	       3	 386639023 ns/op	2937041840 B/op	    8050 allocs/op
PASS
ok  	github.com/cometbft/cometbft/types	49.068s
```
### After changes
```
$ go test -bench BenchmarkPartSetRoundTrip -benchtime 1s
goos: linux
goarch: amd64
pkg: github.com/cometbft/cometbft/types
cpu: Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz
BenchmarkPartSetRoundTrip/dataSize=1000,partSize=256/write-16   	  133736	      8643 ns/op	    1790 B/op	      17 allocs/op
BenchmarkPartSetRoundTrip/dataSize=1000,partSize=256/read-16    	38419419	        30.62 ns/op	       0 B/op	       0 allocs/op
BenchmarkPartSetRoundTrip/dataSize=130857600,partSize=65536/write-16         	       3	 369702647 ns/op	148041744 B/op	   25934 allocs/op
BenchmarkPartSetRoundTrip/dataSize=130857600,partSize=65536/read-16          	48963622	        24.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkPartSetRoundTrip/dataSize=523430400,partSize=65536/write-16         	       1	1463117711 ns/op	592497568 B/op	  119697 allocs/op
BenchmarkPartSetRoundTrip/dataSize=523430400,partSize=65536/read-16          	44423292	        25.45 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/cometbft/cometbft/types	45.972s
```

Resolves #2321 