### PR TITLE
ci(mergify): use v0.39.x-celestia branch name

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,13 +6,13 @@ pull_request_rules:
       backport:
         branches:
           - main
-  - name: backport patches to v0.39.x
+  - name: backport patches to v0.39.x-celestia
     conditions:
       - label=backport-to-v0.39.x
     actions:
       backport:
         branches:
-          - v0.39.x
+          - v0.39.x-celestia
   - name: backport patches to v0.38.x-celestia
     conditions:
       - label=backport-to-v0.38.x


### PR DESCRIPTION
I renamed the branch to `v0.39.x-celestia` for consistency with other branches in this repo.
