### PR TITLE
fix: increase event bus buffer

### DIFF
--- a/scripts/metricsgen/metricsgen.go
+++ b/scripts/metricsgen/metricsgen.go
@@ -166,16 +166,19 @@ func ParseMetricsDir(dir string, structName string) (TemplateData, error) {
 		return TemplateData{}, fmt.Errorf("no go pacakges found in %s", dir)
 	}
 
-	// Grab the package name.
+	// Grab the package name and files.
 	var pkgName string
-	var pkg *ast.Package
-	for pkgName, pkg = range d {
+	var files map[string]*ast.File
+	for name, pkg := range d {
+		pkgName = name
+		files = pkg.Files
+		break
 	}
 	td := TemplateData{
 		Package: pkgName,
 	}
 	// Grab the metrics struct
-	m, mPkgName, err := findMetricsStruct(pkg.Files, structName)
+	m, mPkgName, err := findMetricsStruct(files, structName)
 	if err != nil {
 		return TemplateData{}, err
 	}

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cometbft/cometbft/libs/service"
 )
 
-const defaultCapacity = 0
+const defaultCapacity = 10000
 
 type EventBusSubscriber interface {
 	Subscribe(ctx context.Context, subscriber string, query cmtpubsub.Query, outCapacity ...int) (Subscription, error)


### PR DESCRIPTION
while debugging I noticed that a value of 0 can result in the consensus reactor slowing down a lot since if this buffer gets caught it will end up holding the consensus mutexes!!

come to find out the default buffer is 0...

iirc, I remember changing this for the first mamo as well although i'm not sure it if fixed or changed anything