### PR TITLE
chore: update DelayedPrecommitTimeout docs and make its log debug level

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1044,8 +1044,9 @@ type ConsensusConfig struct {
 	TimeoutPrecommit time.Duration `mapstructure:"timeout_precommit"`
 	// How much the timeout_precommit increases with each round
 	TimeoutPrecommitDelta time.Duration `mapstructure:"timeout_precommit_delta"`
-	// DelayedPrecommitTimeout how much time to wait before entering precommit starting
-	// from the commit time
+	// DelayedPrecommitTimeout ensures a minimum block time by waiting during the pre-commit time.
+	// The new pre-commit vote time starts at: StartTime (the new block start time) + the delayed pre-commit time.
+	//  Note that this change doesn't affect the rounds >= 1.
 	DelayedPrecommitTimeout time.Duration // TODO dynamically change using the app
 	// How long we wait after committing a block, before starting on the new
 	// height (this gives us a chance to receive some more precommits, even

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1551,7 +1551,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 	}
 
 	if ready, waitTime := cs.isReadyToPrecommit(); !ready {
-		logger.Info("rescheduling precommit", "delay(ms)", waitTime.Milliseconds())
+		logger.Debug("rescheduling precommit", "delay(ms)", waitTime.Milliseconds())
 		cs.scheduleTimeout(waitTime, height, round, cstypes.RoundStepPrevoteWait)
 		return
 	}


### PR DESCRIPTION
Couple chores that improve the docs and make that log debug level so it's not noisy.