### PR TITLE
feat: store proposals with invalid signatures to the data/debug

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1980,6 +1980,32 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	if !pubKey.VerifySignature(
 		types.ProposalSignBytes(cs.state.ChainID, p), proposal.Signature,
 	) {
+		// Save invalid proposal with metadata for debugging
+		metadata := map[string]interface{}{
+			"height":         proposal.Height,
+			"round":          proposal.Round,
+			"chain_id":       cs.state.ChainID,
+			"timestamp":      cmttime.Now(),
+			"reason":         "invalid_signature",
+			"proposer":       cs.Validators.GetProposer().Address.String(),
+			"block_id":       proposal.BlockID.String(),
+			"pol_round":      proposal.POLRound,
+		}
+		timestamp := cmttime.Now().Format("20060102-150405.000000")
+		err := types.SaveInvalidProposalWithMetadata(
+			filepath.Join(cs.config.RootDir, "data", "debug"),
+			fmt.Sprintf("%s-%d-%d_invalid_proposal_signature_%s.json",
+				cs.state.ChainID,
+				proposal.Height,
+				proposal.Round,
+				timestamp,
+			),
+			proposal,
+			metadata,
+		)
+		if err != nil {
+			cs.Logger.Error("failed to save invalid proposal", "err", err.Error())
+		}
 		return ErrInvalidProposalSignature
 	}
 
@@ -2004,6 +2030,7 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	cs.Logger.Info("received proposal", "proposal", proposal, "proposer", pubKey.Address())
 	return nil
 }
+
 
 // NOTE: block is not necessarily valid.
 // Asynchronously triggers either enterPrevote (before we timeout of propose) or tryFinalizeCommit,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1982,14 +1982,14 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	) {
 		// Save invalid proposal with metadata for debugging
 		metadata := map[string]interface{}{
-			"height":         proposal.Height,
-			"round":          proposal.Round,
-			"chain_id":       cs.state.ChainID,
-			"timestamp":      cmttime.Now(),
-			"reason":         "invalid_signature",
-			"proposer":       cs.Validators.GetProposer().Address.String(),
-			"block_id":       proposal.BlockID.String(),
-			"pol_round":      proposal.POLRound,
+			"height":    proposal.Height,
+			"round":     proposal.Round,
+			"chain_id":  cs.state.ChainID,
+			"timestamp": cmttime.Now(),
+			"reason":    "invalid_signature",
+			"proposer":  cs.Validators.GetProposer().Address.String(),
+			"block_id":  proposal.BlockID.String(),
+			"pol_round": proposal.POLRound,
 		}
 		timestamp := cmttime.Now().Format("20060102-150405.000000")
 		err := types.SaveInvalidProposalWithMetadata(
@@ -2030,7 +2030,6 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	cs.Logger.Info("received proposal", "proposal", proposal, "proposer", pubKey.Address())
 	return nil
 }
-
 
 // NOTE: block is not necessarily valid.
 // Asynchronously triggers either enterPrevote (before we timeout of propose) or tryFinalizeCommit,

--- a/types/utils.go
+++ b/types/utils.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,6 +60,42 @@ func SaveBlockToFile(dir string, filename string, block *Block) error {
 
 	if _, err := file.Write(blockBZ); err != nil {
 		return fmt.Errorf("failed to write block to file: %w", err)
+	}
+
+	return nil
+}
+
+// SaveInvalidProposalWithMetadata saves an invalid proposal with metadata to a JSON file for debugging
+func SaveInvalidProposalWithMetadata(dir string, filename string, proposal *Proposal, metadata map[string]interface{}) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	filePath := filepath.Join(dir, filename)
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer file.Close()
+
+	// Create a structure that combines proposal data and metadata
+	proposalData := struct {
+		Metadata map[string]interface{} `json:"metadata"`
+		Proposal *Proposal              `json:"proposal"`
+	}{
+		Metadata: metadata,
+		Proposal: proposal,
+	}
+
+	// Marshal to pretty JSON for readability
+	proposalBZ, err := json.MarshalIndent(proposalData, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal proposal data to JSON: %w", err)
+	}
+
+	if _, err := file.Write(proposalBZ); err != nil {
+		return fmt.Errorf("failed to write proposal data to file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
saves the proposals to data/debug for v0.38 (v5) to help debug
