### PR TITLE
chore: parallelize sending the parts to consensus and `propagation.ProposeBlock()`

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"sort"
+	"sync"
 	"time"
 
 	proptypes "github.com/cometbft/cometbft/consensus/propagation/types"
@@ -1326,12 +1327,17 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 			}
 		}
 
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < int(blockParts.Total()); i++ {
+				part := blockParts.GetPart(i)
+				cs.sendInternalMessage(msgInfo{&BlockPartMessage{cs.rs.Height, cs.rs.Round, part}, ""})
+			}
+		}()
 		cs.propagator.ProposeBlock(proposal, blockParts, metaData)
-
-		for i := 0; i < int(blockParts.Total()); i++ {
-			part := blockParts.GetPart(i)
-			cs.sendInternalMessage(msgInfo{&BlockPartMessage{cs.rs.Height, cs.rs.Round, part}, ""})
-		}
+		wg.Wait()
 
 		cs.Logger.Debug("signed proposal", "height", height, "round", round, "proposal", proposal)
 	} else if !cs.replayMode {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/2400

It's good to have in 128mb blocks to have an extra 2s in case the consensus reactor mutexes start acting up.