### PR TITLE
feat: prioritise sending parity chunks when proposing the block

### DIFF
--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -435,8 +435,9 @@ func (blockProp *Reactor) validateCompactBlock(cb *proptypes.CompactBlock) error
 	if maxBytes == -1 {
 		maxBytes = int64(types.MaxBlockSizeBytes)
 	}
-	if int64(cb.Proposal.BlockID.PartSetHeader.Total) > (maxBytes-1)/int64(types.BlockPartSizeBytes)+1 {
-		return errors.New("proposal block has too many parts")
+	maxBlockPartsCount := (maxBytes-1)/int64(types.BlockPartSizeBytes) + 1
+	if int64(cb.Proposal.BlockID.PartSetHeader.Total) > maxBlockPartsCount {
+		return fmt.Errorf("proposal block has too many parts: %d > %d", cb.Proposal.BlockID.PartSetHeader.Total, maxBlockPartsCount)
 	}
 
 	// validate the compact block

--- a/consensus/propagation/commitment_test.go
+++ b/consensus/propagation/commitment_test.go
@@ -71,6 +71,41 @@ func TestPropose(t *testing.T) {
 	}
 }
 
+func TestPropose_OnlySendParityChunks(t *testing.T) {
+	reactors, _ := testBlockPropReactors(2, cfg.DefaultP2PConfig())
+	reactor1 := reactors[0]
+	reactor2 := reactors[1]
+
+	cleanup, _, sm := state.SetupTestCase(t)
+	t.Cleanup(func() {
+		cleanup(t)
+	})
+
+	// 128 mb block
+	prop, partSet, _, metaData := createTestProposal(t, sm, 1, 30, 4_000_000)
+
+	reactor1.ProposeBlock(prop, partSet, metaData)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// check that the proposal was saved in reactor 1
+	_, _, has := reactor1.GetProposal(prop.Height, prop.Round)
+	require.True(t, has)
+
+	// Check that the proposal was received by the other reactors
+	_, _, has = reactor2.GetProposal(prop.Height, prop.Round)
+	require.True(t, has)
+
+	// Check whether all the received haves are for parity parts
+	haves, has := reactor2.getPeer(reactor1.self).GetHaves(prop.Height, prop.Round)
+	assert.True(t, has)
+	// the parts == total because we only have 2 peers
+	assert.Equal(t, haves.Size(), int(partSet.Total()*2))
+	for _, index := range haves.GetTrueIndices() {
+		assert.GreaterOrEqual(t, index, int(partSet.Total()))
+	}
+}
+
 func createTestProposal(
 	t *testing.T,
 	sm state.State,

--- a/consensus/propagation/reactor_test.go
+++ b/consensus/propagation/reactor_test.go
@@ -51,7 +51,7 @@ func newPropagationReactor(s *p2p.Switch, tr trace.Tracer, pv types.PrivValidato
 		Mempool:       &mockMempool{txs: make(map[types.TxKey]*types.CachedTx)},
 		Privval:       pv,
 		ChainID:       TestChainID,
-		BlockMaxBytes: 100000000,
+		BlockMaxBytes: types.MaxBlockSizeBytes,
 	})
 	blockPropR.traceClient = tr
 	blockPropR.currentProposer = pub


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/1662

This PR only sends parity shares when proposing the block. However, when a node decodes the block, it will send haves for all the block. I opted to leave the second part sending original parts because that's already ~4s in the round, if a node didn't get all the parity parts + mempool parts to decode, it's better to have more choices of peer to download from.