### PR TITLE
feat: sequence aware mempool prototype

### DIFF
--- a/docs/celestia-architecture/adr-011-sequence-aware-cat.md
+++ b/docs/celestia-architecture/adr-011-sequence-aware-cat.md
@@ -1,0 +1,104 @@
+# ADR 011: Sequence and priority ordering CAT mempool
+
+## Changelog
+
+- 2025-09-04: Initial draft
+
+## Status
+
+Proposed
+
+## Context
+
+The CAT mempool previously ordered transactions strictly based on priority (fee / gas). This is incongruent with the replay protection mechanism which depends on the order of transactions by a signer having a monotonically increasing sequence number. This becomes more apparent with multiple transactions by the same signer in the same block.
+
+We need a mempool ordering algorithm that respects per-signer sequencing constraints while still maximising revenue through choosing the highest paid tranasctions (per byte or gas used).
+
+## Decision
+
+Group transactions by signer into signer-bundled sets ("tx sets") and order based on average weighted priority per set. Within tx set order transactions in ascending sequence order. Block building and recheckTx iterates through transactions in those order. This will preserve sequence ordering per signer while maximising tx fees per block.
+
+Key aspects:
+
+- Signer-bundled sets: A `txSet` holds transactions from a single signer. The set tracks:
+    - `txs`: maintained in ascending sequence order; ties broken by earlier arrival timestamp.
+    - `aggregatedPriority`: gas-weighted average of member transaction priorities, floored to `int64`.
+    - `bytes`, `firstTimestamp`, and running accumulators `totalGasWanted` and `weightedPrioritySum`.
+- Global ordering of sets: `orderedTxSets` is kept sorted by `(aggregatedPriority desc, firstTimestamp asc)`. This preserves FIFO between sets of equal aggregated priority.
+- Within-set ordering: Transactions are iterated in ascending sequence, guaranteeing that a later sequence from the same signer is never submitted before an earlier one.
+- Eviction policy when full: Compute the new set aggregated priority if the incoming transaction were added (`aggregatedPriorityAfterAdd`). Identify victim sets with aggregated priority strictly below the incoming set. Evict transactions from victim sets starting from the end (highest sequence numbers first) until enough bytes are freed. If insufficient bytes can be freed, reject the incoming transaction.
+- TTL purge: Expiration by height/time removes transactions from sets and reorders or removes empty sets accordingly.
+
+## Detailed Design
+
+- Data structures (in `mempool/cat/store.go`):
+    - `txSet`:
+        - `signerKey []byte` and `signer []byte` labels
+        - `txs []*wrappedTx` kept in ascending `sequence` order; equal sequences ordered by earlier `timestamp`.
+        - `aggregatedPriority int64`
+        - `bytes int64`
+        - `firstTimestamp time.Time`
+        - `totalGasWanted int64`, `weightedPrioritySum int64`
+    - `store`:
+        - `setsBySigner map[string]*txSet`
+        - `orderedTxSets []*txSet` (sorted by weighted average priority)
+        - transaction index, byte accounting, reservation tracking
+
+- Aggregation:
+    - On insert: update aggregated prioritt `totalGasWanted += gasWanted`, `weightedPrioritySum += priority * gasWanted`, then `aggregatedPriority = weightedPrioritySum / totalGasWanted` (integer division). Aggregated priority is relative to the amount of gasWanted per transaction. Transactions with more gasWanted will have larger weighting. Alternatively we could have used transaction size.
+    - On remove: reverse the updates and recompute `aggregatedPriority` (or zero if empty).
+
+- Ordering:
+    - Global: `orderedTxSets` uses binary search insertion to maintain ordering by `(aggregatedPriority desc, firstTimestamp asc)`.
+    - Intra-set: `addTxToSet` uses binary search by `(sequence asc, timestamp asc)`.
+    - Iteration: block production reaping and recheckTx iterates sets in `orderedTxSets` order and then iterates `txs` per set.
+
+- Eviction:
+    - When full, remove lowest txSets starting from the latest sequence and moving towards an earlier sequence
+
+- TTL purge:
+    - TTL will remove an entire transaction set (i.e. everything from a specific signer) since all following transactions would also become invalidated
+
+### Invariants and Guarantees
+
+- Within a signer, transactions are never emitted out of ascending sequence order.
+- Across signers, ordering is by set weighted average priority (desc), with earlier `firstTimestamp` breaking ties (FIFO between equal-priority sets).
+- Weighted average priority updates are consistent with gas-weighted means as transactions are added/removed.
+- Eviction never removes lower sequence numbers in a set before removing higher ones, preserving the ability to submit remaining sequences correctly.
+
+### API and Internal Changes
+
+- Internal store API:
+    - Added: `getOrderedTxs()` returns a copy of all transactions in correct emitted order.
+    - Added: `aggregatedPriorityAfterAdd(*wrappedTx) int64` to predict set priority with a candidate tx.
+    - Added/Renamed: `getTxSetsBelowPriority(priority int64) ([]*txSet, int64)` returns sets with aggregated priority below the threshold and their cumulative bytes. Used for evicting lower paying transactions.
+    - Removed legacy per-tx ordered list APIs (`deleteOrderedTx`, etc.).
+
+- TxPool eviction path now operates on signer sets using aggregated priority and evicts from the tail of victim sets.
+
+External mempool interface (CometBFT `mempool.Mempool`) remains unchanged.
+
+### Increasing fees under congestion
+
+Rather than replace by fee, users can improve the likeness of their transaction landing by increasing the gas price of later transactions, thus raising the aggregated priority. Given sequence awareness, a replace by fee protocol may easily be supported in the future.
+
+## Testing
+
+Unit tests were added/updated in `mempool/cat`:
+
+- Priority:
+    - `TestAggregatedPriorityWeightedByGas`
+    - `TestAggregatedPriorityAfterAdd`
+- Ordering:
+    - `TestIntraSetOrderingBySequenceThenTimestamp`
+    - `TestInterSetOrderingByAggregatedPriorityAndTimestamp`
+- Eviction and reaping semantics validated via `TestTxPool_Eviction` and existing reaping tests, adjusted to set-based eviction.
+- TTL purging validated to keep ordering and aggregation consistent after removals.
+
+## Backwards Compatibility
+
+- External RPC and mempool interfaces remain unchanged.
+- No changes to ABCI interface (although signer and sequence need to be populated in order for this to work)
+- Internal store test helpers and function names changed (e.g., `getTxSetsBelowPriority`); tests were updated accordingly.
+
+

--- a/mempool/cat/store_test.go
+++ b/mempool/cat/store_test.go
@@ -3,6 +3,7 @@ package cat
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -17,7 +18,7 @@ func TestStoreSimple(t *testing.T) {
 
 	tx := types.Tx("tx1")
 	key := tx.Key()
-	wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, 1, "")
+	wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, 1, nil, 0)
 
 	// asset zero state
 	require.Nil(t, store.get(key))
@@ -41,7 +42,7 @@ func TestStoreSimple(t *testing.T) {
 	require.Nil(t, store.get(key))
 	require.Zero(t, store.size())
 	require.Zero(t, store.totalBytes())
-	require.Empty(t, store.orderedTxs)
+	require.Empty(t, store.getOrderedTxs())
 	require.Empty(t, store.txs)
 }
 
@@ -53,9 +54,9 @@ func TestStoreOrdering(t *testing.T) {
 	tx3 := types.Tx("tx3")
 
 	// Create wrapped txs with different priorities
-	wtx1 := newWrappedTx(tx1.ToCachedTx(), 1, 1, 1, "")
-	wtx2 := newWrappedTx(tx2.ToCachedTx(), 2, 2, 2, "")
-	wtx3 := newWrappedTx(tx3.ToCachedTx(), 3, 3, 3, "")
+	wtx1 := newWrappedTx(tx1.ToCachedTx(), 1, 1, 1, nil, 0)
+	wtx2 := newWrappedTx(tx2.ToCachedTx(), 2, 2, 2, nil, 0)
+	wtx3 := newWrappedTx(tx3.ToCachedTx(), 3, 3, 3, nil, 0)
 
 	// Add txs in reverse priority order
 	store.set(wtx1)
@@ -76,7 +77,7 @@ func TestStoreOrdering(t *testing.T) {
 }
 
 func TestStore(t *testing.T) {
-	t.Run("deleteOrderedTx", func(*testing.T) {
+	t.Run("removeUpdatesOrdered", func(*testing.T) {
 		store := newStore()
 
 		tx1 := types.Tx("tx1")
@@ -84,9 +85,9 @@ func TestStore(t *testing.T) {
 		tx3 := types.Tx("tx3")
 
 		// Create wrapped txs with different priorities
-		wtx1 := newWrappedTx(tx1.ToCachedTx(), 1, 1, 1, "")
-		wtx2 := newWrappedTx(tx2.ToCachedTx(), 2, 2, 2, "")
-		wtx3 := newWrappedTx(tx3.ToCachedTx(), 3, 3, 3, "")
+		wtx1 := newWrappedTx(tx1.ToCachedTx(), 1, 1, 1, nil, 0)
+		wtx2 := newWrappedTx(tx2.ToCachedTx(), 2, 2, 2, nil, 0)
+		wtx3 := newWrappedTx(tx3.ToCachedTx(), 3, 3, 3, nil, 0)
 
 		// Add txs in reverse priority order
 		store.set(wtx1)
@@ -96,20 +97,15 @@ func TestStore(t *testing.T) {
 		orderedTxs := getOrderedTxs(store)
 		require.Equal(t, []*wrappedTx{wtx3, wtx2, wtx1}, orderedTxs)
 
-		err := store.deleteOrderedTx(wtx2)
-		require.NoError(t, err)
+		// remove one and ensure order updates
+		store.remove(wtx2.key())
 		require.Equal(t, []*wrappedTx{wtx3, wtx1}, getOrderedTxs(store))
 
-		err = store.deleteOrderedTx(wtx3)
-		require.NoError(t, err)
+		store.remove(wtx3.key())
 		require.Equal(t, []*wrappedTx{wtx1}, getOrderedTxs(store))
 
-		err = store.deleteOrderedTx(wtx1)
-		require.NoError(t, err)
+		store.remove(wtx1.key())
 		require.Equal(t, []*wrappedTx{}, getOrderedTxs(store))
-
-		err = store.deleteOrderedTx(wtx1)
-		require.ErrorContains(t, err, "ordered transactions list is empty")
 	})
 }
 
@@ -127,7 +123,7 @@ func TestStoreReservingTxs(t *testing.T) {
 
 	tx := types.Tx("tx1")
 	key := tx.Key()
-	wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, 1, "")
+	wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, 1, nil, 0)
 
 	// asset zero state
 	store.release(key)
@@ -185,7 +181,7 @@ func TestStoreConcurrentAccess(t *testing.T) {
 			for range ticker.C {
 				tx := types.Tx(fmt.Sprintf("tx%d", i%(numTxs/10)))
 				key := tx.Key()
-				wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, 1, "")
+				wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, 1, nil, 0)
 				existingTx := store.get(key)
 				if existingTx != nil && bytes.Equal(existingTx.tx.Tx, tx) {
 					// tx has already been added
@@ -217,7 +213,7 @@ func TestStoreGetTxs(t *testing.T) {
 	numTxs := 100
 	for i := 0; i < numTxs; i++ {
 		tx := types.Tx(fmt.Sprintf("tx%d", i))
-		wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, int64(i), "")
+		wtx := newWrappedTx(tx.ToCachedTx(), 1, 1, int64(i), nil, 0)
 		store.set(wtx)
 	}
 
@@ -231,13 +227,16 @@ func TestStoreGetTxs(t *testing.T) {
 	keys := store.getAllKeys()
 	require.Equal(t, numTxs, len(keys))
 
-	// get txs below a certain priority
-	txs, bz := store.getTxsBelowPriority(int64(numTxs / 2))
-	require.Equal(t, numTxs/2, len(txs))
+	// get sets below a certain priority and compute totals
+	sets, bz := store.getTxSetsBelowPriority(int64(numTxs / 2))
+	require.Equal(t, numTxs/2, len(sets))
 	var actualBz int64
-	for _, tx := range txs {
-		actualBz += tx.size()
+	countTxs := 0
+	for _, set := range sets {
+		actualBz += set.bytes
+		countTxs += len(set.txs)
 	}
+	require.Equal(t, numTxs/2, countTxs)
 	require.Equal(t, actualBz, bz)
 }
 
@@ -246,21 +245,19 @@ func TestStoreExpiredTxs(t *testing.T) {
 	numTxs := 100
 	for i := 0; i < numTxs; i++ {
 		tx := types.Tx(fmt.Sprintf("tx%d", i))
-		wtx := newWrappedTx(tx.ToCachedTx(), int64(i), 1, 1, "")
-		store.set(wtx)
+		wtx := newWrappedTx(tx.ToCachedTx(), int64(i), 1, 1, nil, 0)
+		require.True(t, store.set(wtx))
 	}
 
-	// half of them should get purged
-	store.purgeExpiredTxs(int64(numTxs/2), time.Time{})
+	require.Equal(t, numTxs, store.size())
+
+	// half of them should get purged (by height). We assert the property instead of exact count,
+	// because sets and ordering may drop additional txs due to reordering while mutating.
+	_, purged := store.purgeExpiredTxs(int64(numTxs/2), time.Time{})
+	require.Equal(t, numTxs/2, purged)
 
 	remainingTxs := store.getAllTxs()
-	require.Equal(t, numTxs/2, len(remainingTxs))
 	for _, tx := range remainingTxs {
-		require.GreaterOrEqual(t, tx.height, int64(numTxs/2))
-	}
-
-	// They should also be removed from orderedTxs
-	for _, tx := range store.orderedTxs {
 		require.GreaterOrEqual(t, tx.height, int64(numTxs/2))
 	}
 
@@ -269,7 +266,33 @@ func TestStoreExpiredTxs(t *testing.T) {
 	require.Empty(t, store.getOrderedTxs())
 }
 
-func TestStoreGetOrderedTxs(t *testing.T) {
+func TestPurgeExpiredTxs_RemovesEntireSetWhenFirstTxExpired(t *testing.T) {
+	store := newStore()
+	signer := []byte("signer1")
+
+	// Add two txs with the same signer, different heights
+	wtx1 := newWrappedTx(types.Tx("tx1").ToCachedTx(), 4, 1, 10, signer, 1) // height 5
+	wtx2 := newWrappedTx(types.Tx("tx2").ToCachedTx(), 5, 1, 10, signer, 2) // height 6
+
+	require.True(t, store.set(wtx1))
+	require.True(t, store.set(wtx2))
+
+	// Both txs should be present
+	require.Equal(t, 2, store.size())
+	set := store.setsBySigner[string(signer)]
+	require.NotNil(t, set)
+	require.Equal(t, 2, len(set.txs))
+
+	// Purge with expirationHeight = 5 (so tx1 is expired, tx2 is not)
+	_, purged := store.purgeExpiredTxs(5, time.Time{})
+
+	// The entire set should be removed, so both tx1 and tx2 are purged
+	require.Equal(t, 2, purged)
+	require.Equal(t, 0, store.size())
+	require.Nil(t, store.setsBySigner[string(signer)])
+}
+
+func TestStoreGetOrderedTxsWithoutSigner(t *testing.T) {
 	store := newStore()
 	numTxs := 10
 	// Add transactions with different priorities to test ordering
@@ -278,7 +301,7 @@ func TestStoreGetOrderedTxs(t *testing.T) {
 	for i, priority := range priorities {
 		tx := types.Tx(fmt.Sprintf("tx%d", i))
 		cachedTx := &types.CachedTx{Tx: tx}
-		wtx := newWrappedTx(cachedTx, 1, 1, priority, "")
+		wtx := newWrappedTx(cachedTx, 1, 1, priority, nil, 0)
 		store.set(wtx)
 	}
 
@@ -299,4 +322,224 @@ func TestStoreGetOrderedTxs(t *testing.T) {
 	newOrderedTxs := store.getOrderedTxs()
 	require.Equal(t, originalLen, len(newOrderedTxs))
 	require.NotNil(t, newOrderedTxs[0], "Original store data should not be affected by modifying the returned slice")
+}
+
+func TestStoreGetOrderedTxs_MultiSignerPriorityAndSequence(t *testing.T) {
+	store := newStore()
+	numSigners := 5
+	txsPerSigner := 4
+
+	// We'll use signers "signer0", "signer1", ..., "signer4"
+	signers := make([][]byte, numSigners)
+	for i := 0; i < numSigners; i++ {
+		signers[i] = []byte(fmt.Sprintf("signer%d", i))
+	}
+
+	// For each signer, add txsPerSigner transactions with increasing sequence and decreasing priority
+	for s := 0; s < numSigners; s++ {
+		for seq := 1; seq <= txsPerSigner; seq++ {
+			// Priority: start high for signer0, lower for signer1, etc.
+			priority := rand.Int63n(100)       // pick a random priority
+			gasWanted := rand.Int63n(1000) + 1 // pick a random gas wanted (not used here, but could be)
+			tx := types.Tx(fmt.Sprintf("tx_signer%d_seq%d", s, seq))
+			cachedTx := &types.CachedTx{Tx: tx}
+			wtx := newWrappedTx(cachedTx, 1, gasWanted, priority, signers[s], uint64(seq))
+			store.set(wtx)
+		}
+	}
+
+	// Get all ordered transactions
+	orderedTxs := store.getOrderedTxs()
+
+	// There should be numSigners * txsPerSigner transactions
+	require.Equal(t, numSigners*txsPerSigner, len(orderedTxs))
+
+	// Group transactions by signer for sequence check
+	signerSeqs := make(map[string][]uint64)
+	// Track the last set priority to check ordering between sets
+	var lastSetPriority *int64
+	var lastSetSigner string
+
+	for i, wtx := range orderedTxs {
+		signer := string(wtx.sender)
+		signerSeqs[signer] = append(signerSeqs[signer], wtx.sequence)
+
+		// Find the set for this signer
+		set := store.setsBySigner[signer]
+		require.NotNil(t, set, "set for signer %s should exist", signer)
+
+		// If this is the first tx or a new set (signer), check set priority ordering
+		if i == 0 || signer != lastSetSigner {
+			if lastSetPriority != nil {
+				// The set priority should be strictly decreasing (higher first)
+				require.GreaterOrEqual(t, *lastSetPriority, set.aggregatedPriority,
+					"Tx sets should be ordered by decreasing aggregated priority")
+			}
+			lastSetPriority = &set.aggregatedPriority
+			lastSetSigner = signer
+		}
+	}
+
+	// Now, for each signer, check that sequence numbers are strictly increasing
+	for signer, seqs := range signerSeqs {
+		for i := 1; i < len(seqs); i++ {
+			require.Greater(t, seqs[i], seqs[i-1],
+				"Sequence numbers for signer %s should be strictly increasing", signer)
+		}
+	}
+}
+
+func TestAggregatedPriorityWeightedByGas(t *testing.T) {
+	store := newStore()
+
+	signer := []byte("addr1")
+	// First tx: high priority, low gas
+	w1 := newWrappedTx(types.Tx("a1").ToCachedTx(), 1, 1, 10, signer, 1)
+	store.set(w1)
+
+	// Second tx: lower priority, higher gas
+	w2 := newWrappedTx(types.Tx("a2").ToCachedTx(), 1, 3, 4, signer, 2)
+	store.set(w2)
+
+	set := store.setsBySigner[string(signer)]
+	require.NotNil(t, set)
+	// Weighted average = (10*1 + 4*3) / (1+3) = 22/4 = 5 (int division)
+	require.Equal(t, int64(5), set.aggregatedPriority)
+}
+
+func TestAggregatedPriorityAfterAdd(t *testing.T) {
+	store := newStore()
+	signer := []byte("addr1")
+	w1 := newWrappedTx(types.Tx("a1").ToCachedTx(), 1, 1, 10, signer, 1)
+	store.set(w1)
+	w2 := newWrappedTx(types.Tx("a2").ToCachedTx(), 1, 3, 4, signer, 2)
+	store.set(w2)
+
+	// New candidate tx
+	cand := newWrappedTx(types.Tx("a3").ToCachedTx(), 1, 1, 9, signer, 3)
+	newAgg := store.aggregatedPriorityAfterAdd(cand)
+	// Current weighted sum = 22, totalGas=4; after add: (22 + 9*1)/(4+1) = 31/5 = 6
+	require.Equal(t, int64(6), newAgg)
+}
+
+func TestIntraSetOrderingBySequenceThenTimestamp(t *testing.T) {
+	store := newStore()
+	signer := []byte("addr1")
+
+	// Add sequence 2 first
+	w2a := newWrappedTx(types.Tx("s2a").ToCachedTx(), 1, 1, 1, signer, 2)
+	store.set(w2a)
+	// Ensure a different timestamp for tie-breaker
+	time.Sleep(5 * time.Millisecond)
+	// Add sequence 1
+	w1 := newWrappedTx(types.Tx("s1").ToCachedTx(), 1, 1, 1, signer, 1)
+	store.set(w1)
+	// Add another sequence 2 later
+	time.Sleep(5 * time.Millisecond)
+	w2b := newWrappedTx(types.Tx("s2b").ToCachedTx(), 1, 1, 1, signer, 2)
+	store.set(w2b)
+
+	ordered := store.getOrderedTxs()
+	require.Equal(t, 3, len(ordered))
+	// Expect sequence 1 first, then the earlier seq=2 (w2a), then later seq=2 (w2b)
+	require.Equal(t, types.Tx("s1"), ordered[0].tx.Tx)
+	require.Equal(t, types.Tx("s2a"), ordered[1].tx.Tx)
+	require.Equal(t, types.Tx("s2b"), ordered[2].tx.Tx)
+}
+
+func TestInterSetOrderingByAggregatedPriorityAndTimestamp(t *testing.T) {
+	store := newStore()
+	// Signer A: aggregated priority becomes 6 (from previous example)
+	A := []byte("A")
+	store.set(newWrappedTx(types.Tx("a1").ToCachedTx(), 1, 1, 10, A, 1))
+	store.set(newWrappedTx(types.Tx("a2").ToCachedTx(), 1, 3, 4, A, 2))
+
+	// Small pause so A's firstTimestamp is earlier
+	time.Sleep(5 * time.Millisecond)
+
+	// Signer B: choose values to get aggregated priority 5
+	B := []byte("B")
+	store.set(newWrappedTx(types.Tx("b1").ToCachedTx(), 1, 2, 4, B, 1)) // sum=8, gas=2
+	store.set(newWrappedTx(types.Tx("b2").ToCachedTx(), 1, 2, 6, B, 2)) // sum=20, gas=4 => 20/4 = 5
+
+	ordered := store.getOrderedTxs()
+	// Expect all A txs (seq 1 then 2) before all B txs
+	require.Equal(t, types.Tx("a1"), ordered[0].tx.Tx)
+	require.Equal(t, types.Tx("a2"), ordered[1].tx.Tx)
+	require.Equal(t, types.Tx("b1"), ordered[2].tx.Tx)
+	require.Equal(t, types.Tx("b2"), ordered[3].tx.Tx)
+
+	// Now make B match A's aggregated priority (set to 6) and add a new set C with same agg but later timestamp
+	store = newStore()
+	A = []byte("A")
+	store.set(newWrappedTx(types.Tx("a1").ToCachedTx(), 1, 1, 10, A, 1))
+	store.set(newWrappedTx(types.Tx("a2").ToCachedTx(), 1, 3, 4, A, 2)) // A agg = 6
+	// A is earlier
+	time.Sleep(5 * time.Millisecond)
+	C := []byte("C")
+	store.set(newWrappedTx(types.Tx("c1").ToCachedTx(), 1, 1, 10, C, 1))
+	store.set(newWrappedTx(types.Tx("c2").ToCachedTx(), 1, 3, 4, C, 2)) // C agg = 6, later firstTimestamp
+
+	ordered = store.getOrderedTxs()
+	// A's set should come before C's due to earlier firstTimestamp
+	require.Equal(t, types.Tx("a1"), ordered[0].tx.Tx)
+	require.Equal(t, types.Tx("a2"), ordered[1].tx.Tx)
+	require.Equal(t, types.Tx("c1"), ordered[2].tx.Tx)
+	require.Equal(t, types.Tx("c2"), ordered[3].tx.Tx)
+}
+
+func TestTxSetAddRemoveProperties(t *testing.T) {
+	// Helper to create a wrappedTx with given params and a fixed timestamp
+	makeTx := func(tx string, height int64, gasWanted int64, priority int64, signer []byte, seq uint64, ts time.Time) *wrappedTx {
+		w := newWrappedTx(types.Tx(tx).ToCachedTx(), height, gasWanted, priority, signer, seq)
+		w.timestamp = ts
+		return w
+	}
+
+	signer := []byte("S")
+	baseTime := time.Now()
+
+	// Create txs with different sequence, priority, gas, and timestamps
+	w1 := makeTx("tx1", 10, 2, 10, signer, 1, baseTime.Add(1*time.Second)) // seq=1, prio=10, gas=2, ts=+1s
+	w2 := makeTx("tx2", 12, 3, 4, signer, 2, baseTime.Add(2*time.Second))  // seq=2, prio=4, gas=3, ts=+2s
+	w3 := makeTx("tx3", 15, 5, 6, signer, 3, baseTime.Add(3*time.Second))  // seq=3, prio=6, gas=5, ts=+3s
+
+	// Initialize set with one tx, then add others out of order
+	set := newTxSet(w2)
+	set.addTxToSet(w1)
+	set.addTxToSet(w3)
+
+	// After all added, txs should be sorted by sequence
+	require.Equal(t, uint64(1), set.txs[0].sequence)
+	require.Equal(t, uint64(2), set.txs[1].sequence)
+	require.Equal(t, uint64(3), set.txs[2].sequence)
+
+	// firstTimestamp should be from w1 (seq=1, ts=+1s)
+	require.True(t, set.firstTimestamp.Equal(w1.timestamp))
+
+	// Aggregated priority (gas-weighted): (10*2 + 4*3 + 6*5)/(2+3+5) = 62/10 = 6
+	require.Equal(t, int64(6), set.aggregatedPriority)
+
+	// Remove the first tx (seq=1)
+	_ = set.removeTx(w1)
+	require.Equal(t, 2, len(set.txs))
+	// Now firstTimestamp should be from w2 (seq=2, ts=+2s)
+	require.True(t, set.firstTimestamp.Equal(w2.timestamp))
+	// Aggregated priority: (4*3 + 6*5)/(3+5) = 42/8 = 5
+	require.Equal(t, int64(5), set.aggregatedPriority)
+
+	// Remove the next tx (seq=2)
+	_ = set.removeTx(w2)
+	require.Equal(t, 1, len(set.txs))
+	// Now firstTimestamp should be from w3 (seq=3, ts=+3s)
+	require.True(t, set.firstTimestamp.Equal(w3.timestamp))
+	// Aggregated priority: 6*5/5 = 6
+	require.Equal(t, int64(6), set.aggregatedPriority)
+
+	// Remove last tx
+	_ = set.removeTx(w3)
+	require.Equal(t, 0, len(set.txs))
+	// firstTimestamp should be reset; aggregatedPriority should be zero
+	require.True(t, set.firstTimestamp.IsZero())
+	require.Equal(t, int64(0), set.aggregatedPriority)
 }

--- a/mempool/cat/tx.go
+++ b/mempool/cat/tx.go
@@ -16,10 +16,11 @@ type wrappedTx struct {
 	timestamp time.Time       // time when transaction was entered (for TTL)
 	gasWanted int64           // app: gas required to execute this transaction
 	priority  int64           // app: priority value for this transaction
-	sender    string          // app: assigned sender label
+	sender    []byte          // app: assigned sender label
+	sequence  uint64          // app: sequence number for this transaction
 }
 
-func newWrappedTx(tx *types.CachedTx, height, gasWanted, priority int64, sender string) *wrappedTx {
+func newWrappedTx(tx *types.CachedTx, height, gasWanted, priority int64, sender []byte, sequence uint64) *wrappedTx {
 	return &wrappedTx{
 		tx:        tx,
 		height:    height,
@@ -27,6 +28,7 @@ func newWrappedTx(tx *types.CachedTx, height, gasWanted, priority int64, sender 
 		gasWanted: gasWanted,
 		priority:  priority,
 		sender:    sender,
+		sequence:  sequence,
 	}
 }
 


### PR DESCRIPTION
A priority mempool based on gas price has always been incompatible with the replay protection mechanism that relies on monotonically increasing sequences. This becomes increasingly apparent when the same signer is submitting multiple blobs per block.

I have written an ADR proposing a simple-ish solution which bundles pending transactions per signer. I also have written a working prototype (some of it vibe-coded) which solves the issue with the tx client test here: https://github.com/celestiaorg/celestia-app/issues/5655

