### PR TITLE
chore: increase the propagation and consensus reactors channel priorities

### DIFF
--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -152,14 +152,14 @@ func (blockProp *Reactor) GetChannels() []*conn.ChannelDescriptor {
 	return []*p2p.ChannelDescriptor{
 		{
 			ID:                  WantChannel,
-			Priority:            45,
+			Priority:            145,
 			SendQueueCapacity:   20000,
 			RecvMessageCapacity: maxMsgSize,
 			MessageType:         &propproto.Message{},
 		},
 		{
 			ID:                  DataChannel,
-			Priority:            40,
+			Priority:            140,
 			SendQueueCapacity:   20000,
 			RecvMessageCapacity: maxMsgSize,
 			MessageType:         &propproto.Message{},

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -177,7 +177,7 @@ func (conR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 	return []*p2p.ChannelDescriptor{
 		{
 			ID:                  StateChannel,
-			Priority:            30,
+			Priority:            230,
 			SendQueueCapacity:   100,
 			RecvMessageCapacity: maxMsgSize,
 			MessageType:         &cmtcons.Message{},
@@ -193,7 +193,7 @@ func (conR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		},
 		{
 			ID:                  VoteChannel,
-			Priority:            35,
+			Priority:            235,
 			SendQueueCapacity:   100,
 			RecvBufferCapacity:  100 * 100,
 			RecvMessageCapacity: maxMsgSize,
@@ -201,7 +201,7 @@ func (conR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		},
 		{
 			ID:                  VoteSetBitsChannel,
-			Priority:            6,
+			Priority:            206,
 			SendQueueCapacity:   10,
 			RecvBufferCapacity:  1024,
 			RecvMessageCapacity: maxMsgSize,


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/2213

This PR just bumps the priorities of some channels to make sure their messages are heavily prioritized. The next step might be absolute vote priorities, but we still need to decide we need it after we implement all the performance improvements we have planned.