### PR TITLE
fix: replace string literals with constants in test/e2e/node to resolve goconst linter error

### DIFF
--- a/test/e2e/node/config.go
+++ b/test/e2e/node/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/cometbft/cometbft/test/e2e/app"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
 // Config is the application configuration.
@@ -62,7 +63,7 @@ func (cfg Config) Validate() error {
 	switch {
 	case cfg.ChainID == "":
 		return errors.New("chain_id parameter is required")
-	case cfg.Listen == "" && cfg.Protocol != "builtin" && cfg.Protocol != "builtin_connsync":
+	case cfg.Listen == "" && cfg.Protocol != string(e2e.ProtocolBuiltin) && cfg.Protocol != string(e2e.ProtocolBuiltinConnSync):
 		return errors.New("listen parameter is required")
 	default:
 		return nil

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -64,7 +64,7 @@ func run(configFile string) error {
 		if err = startSigner(cfg); err != nil {
 			return err
 		}
-		if cfg.Protocol == "builtin" || cfg.Protocol == "builtin_connsync" { //nolint:goconst
+		if cfg.Protocol == string(e2e.ProtocolBuiltin) || cfg.Protocol == string(e2e.ProtocolBuiltinConnSync) {
 			time.Sleep(1 * time.Second)
 		}
 	}
@@ -73,7 +73,7 @@ func run(configFile string) error {
 	switch cfg.Protocol {
 	case "socket", "grpc":
 		err = startApp(cfg)
-	case "builtin", "builtin_connsync":
+	case string(e2e.ProtocolBuiltin), string(e2e.ProtocolBuiltinConnSync):
 		if cfg.Mode == string(e2e.ModeLight) {
 			err = startLightClient(cfg)
 		} else {


### PR DESCRIPTION
fix ##2456