### PR TITLE
fix: set MaxBlockSizeBytes to 128MiB

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -905,7 +905,7 @@ func TestNewValidBlockMessageValidateBasic(t *testing.T) {
 		},
 		{
 			func(msg *NewValidBlockMessage) { msg.BlockParts = bits.NewBitArray(int(types.MaxBlockPartsCount) + 1) },
-			"blockParts bit array size 1998 not equal to BlockPartSetHeader.Total 1",
+			fmt.Sprintf("blockParts bit array size %d not equal to BlockPartSetHeader.Total 1", types.MaxBlockPartsCount+1),
 		},
 	}
 

--- a/types/params.go
+++ b/types/params.go
@@ -15,7 +15,7 @@ const (
 	// MaxBlockSizeBytes is the maximum permitted size of the blocks.
 	//
 	// todo: revert the technically consensus breaking change to > 100MB
-	MaxBlockSizeBytes = 130857600
+	MaxBlockSizeBytes = 128 * 1024 * 1024
 
 	// BlockPartSizeBytes is the size of one block part.
 	BlockPartSizeBytes uint32 = 65536 // 64kB

--- a/types/params.go
+++ b/types/params.go
@@ -13,8 +13,6 @@ import (
 
 const (
 	// MaxBlockSizeBytes is the maximum permitted size of the blocks.
-	//
-	// todo: revert the technically consensus breaking change to > 100MB
 	MaxBlockSizeBytes = 128 * 1024 * 1024
 
 	// BlockPartSizeBytes is the size of one block part.


### PR DESCRIPTION
`MaxBlockSizeBytes` was set to very strange value, this PR changes it to 128 MiB (and makes this more explicit).