### PR TITLE
chore: change compact block error to debug level

### DIFF
--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -206,7 +206,7 @@ func (blockProp *Reactor) AddPeer(peer p2p.Peer) {
 
 	cb, _, found := blockProp.GetCurrentCompactBlock()
 	if !found {
-		blockProp.Logger.Error("failed to get current compact block", "peer", peer.ID())
+		blockProp.Logger.Debug("failed to get current compact block", "peer", peer.ID())
 		return
 	}
 	if len(cb.PartsHashes) == 0 {


### PR DESCRIPTION
When the chain starts, all the peers we connect to don't yet have a compact block and it shows unnecessary noise

Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contribution guidelines.

