### PR TITLE
fix: limit the number of SeenTx broadcast for new txs

### DIFF
--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -340,46 +340,10 @@ type PeerState interface {
 	GetHeight() int64
 }
 
-// broadcastSeenTx broadcasts a SeenTx message to all peers unless we
+// broadcastSeenTx broadcasts a SeenTx message to limited peers unless we
 // know they have already seen the transaction
 func (memR *Reactor) broadcastSeenTx(txKey types.TxKey) {
-	memR.Logger.Debug("broadcasting seen tx to all peers", "tx_key", string(txKey[:]))
-	msg := &protomem.Message{
-		Sum: &protomem.Message_SeenTx{
-			SeenTx: &protomem.SeenTx{
-				TxKey: txKey[:],
-			},
-		},
-	}
-
-	count := 0
-	for id, peer := range ShufflePeers(memR.ids.GetAll()) {
-		if count >= maxSeenTxBroadcast {
-			break
-		}
-		if p, ok := peer.Get(types.PeerStateKey).(PeerState); ok {
-			// make sure peer isn't too far behind. This can happen
-			// if the peer is blocksyncing still and catching up
-			// in which case we just skip sending the transaction
-			if p.GetHeight() < memR.mempool.Height()-peerHeightDiff {
-				memR.Logger.Debug("peer is too far behind us. Skipping broadcast of seen tx")
-				continue
-			}
-		}
-		// no need to send a seen tx message to a peer that already
-		// has that tx.
-		if memR.mempool.seenByPeersSet.Has(txKey, id) {
-			continue
-		}
-
-		peer.Send(
-			p2p.Envelope{
-				ChannelID: MempoolDataChannel,
-				Message:   msg,
-			},
-		)
-		count++
-	}
+	memR.broadcastSeenTxWithHeight(txKey, memR.mempool.Height())
 }
 
 // ShufflePeers shuffles the peers map from GetAll() and returns a new shuffled map.
@@ -411,28 +375,38 @@ func ShufflePeers(peers map[uint16]p2p.Peer) map[uint16]p2p.Peer {
 	return result
 }
 
-// broadcastNewTx broadcast new transaction to all peers unless we are already sure they have seen the tx.
+// broadcastNewTx broadcast new transaction to limited peers unless we are already sure they have seen the tx.
 func (memR *Reactor) broadcastNewTx(wtx *wrappedTx) {
+	memR.broadcastSeenTxWithHeight(wtx.key(), wtx.height)
+}
+
+// broadcastSeenTxWithHeight is a helper that broadcasts a SeenTx message with height checking.
+func (memR *Reactor) broadcastSeenTxWithHeight(txKey types.TxKey, height int64) {
+	memR.Logger.Debug("broadcasting seen tx to limited peers", "tx_key", string(txKey[:]))
 	msg := &protomem.Message{
 		Sum: &protomem.Message_SeenTx{
 			SeenTx: &protomem.SeenTx{
-				TxKey: wtx.tx.Hash(),
+				TxKey: txKey[:],
 			},
 		},
 	}
 
-	for id, peer := range memR.ids.GetAll() {
+	count := 0
+	for id, peer := range ShufflePeers(memR.ids.GetAll()) {
+		if count >= maxSeenTxBroadcast {
+			break
+		}
 		if p, ok := peer.Get(types.PeerStateKey).(PeerState); ok {
 			// make sure peer isn't too far behind. This can happen
 			// if the peer is blocksyncing still and catching up
 			// in which case we just skip sending the transaction
-			if p.GetHeight() < wtx.height-peerHeightDiff {
+			if p.GetHeight() < height-peerHeightDiff {
 				memR.Logger.Debug("peer is too far behind us. Skipping broadcast of seen tx")
 				continue
 			}
 		}
 
-		if memR.mempool.seenByPeersSet.Has(wtx.key(), id) {
+		if memR.mempool.seenByPeersSet.Has(txKey, id) {
 			continue
 		}
 
@@ -442,8 +416,9 @@ func (memR *Reactor) broadcastNewTx(wtx *wrappedTx) {
 				Message:   msg,
 			},
 		) {
-			memR.mempool.PeerHasTx(id, wtx.key())
+			memR.mempool.PeerHasTx(id, txKey)
 		}
+		count++
 	}
 }
 


### PR DESCRIPTION
One thing that I noticed during our recent traces was that often the original node operator was uploading the new transactions too much, which ended up slowing distribution.

We can reduce this and try to force the higher throughput case by doing the same thing we do when we normally broadcast a seenTx, which is to limit the number of peers that we send them to.

Here's a trace of the problematic case, where under congestion the broadcaster is uploading the transaction too much
<img width="1436" height="1069" alt="Screenshot_20251001_155639-1" src="https://github.com/user-attachments/assets/9015321c-2187-4cef-abf9-d0b757d9ed20" />

We want more cases that look like this trace, where we  peers of the broadcaster are doing a lot of work.
<img width="1433" height="849" alt="Screenshot_20251001_155506-1" src="https://github.com/user-attachments/assets/5784ed52-a0d1-498e-9180-383dcc3f99b6" />

for posterity, I'll also link the 
[graph.py](https://github.com/user-attachments/files/22649363/graph.py)
python script to generate these traces here. 
