### PR TITLE
chore: increase pex message size

### DIFF
--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -339,7 +339,7 @@ func (blockProp *Reactor) broadcastHaves(haves *proptypes.HaveParts, from p2p.ID
 		// for data, they must already have the proposal.
 		// TODO: use retry and logs
 		if !peer.peer.TrySend(e) {
-			blockProp.Logger.Error("failed to send haves to peer", "peer", peer.peer.ID())
+			blockProp.Logger.Debug("failed to send haves to peer", "peer", peer.peer.ID())
 			continue
 		}
 		hb := haves.BitArray(partSetSize)

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -23,7 +23,7 @@ const (
 	// over-estimate of max NetAddress size
 	// hexID (40) + IP (16) + Port (2) + Name (100) ...
 	// NOTE: dont use massive DNS name ..
-	maxAddressSize = 256
+	maxAddressSize = 512
 
 	// NOTE: amplificaiton factor!
 	// small request results in up to maxMsgSize response

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -23,7 +23,7 @@ const (
 	// over-estimate of max NetAddress size
 	// hexID (40) + IP (16) + Port (2) + Name (100) ...
 	// NOTE: dont use massive DNS name ..
-	maxAddressSize = 512
+	maxAddressSize = 1024
 
 	// NOTE: amplificaiton factor!
 	// small request results in up to maxMsgSize response


### PR DESCRIPTION
This fixes one of the issues sees currently on mocha:
```
9:59AM ERR Stopping peer for error err="received message exceeds available capacity: 64000 < 64512" module=p2p peer="Peer{MConn{183.83.177.95:11656} 179e9dc18073fa4f979c7e58917ef716115831de out}" reactor=p2p
```

for some reason, 64kb is not enough for pex messages.

Closes https://github.com/celestiaorg/celestia-core/issues/2524