### PR TITLE
feat: dynamically set the start time to pace the network

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2105,19 +2105,6 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
 }
 
-// isReadyToPrecommit calculates if the process has waited at least a certain number of seconds
-// from their start time before they can vote
-// If the application's DelayedPrecommitTimeout is set to 0, no precommit wait is done.
-func (cs *State) isReadyToPrecommit() (bool, time.Duration) {
-	if cs.state.Timeouts.DelayedPrecommitTimeout == 0 {
-		// setting 0 as a special case not to reschedule the pre-commit
-		return true, 0
-	}
-	precommitVoteTime := cs.rs.StartTime.Add(cs.state.Timeouts.DelayedPrecommitTimeout)
-	waitTime := time.Until(precommitVoteTime)
-	return waitTime <= 0, waitTime
-}
-
 //-----------------------------------------------------------------------------
 
 func (cs *State) defaultSetProposal(proposal *types.Proposal) error {


### PR DESCRIPTION
closes: https://github.com/celestiaorg/celestia-core/issues/2538

This PR dynamically sets the next block's start time to be at least 6s. This ensures consistent block time. 

Currently, we use the precommit delay timeout for that, that's why the block times are set to 5.8s in the plots below.

We could rename the `DelayedPrecommitTimeout` to a more accurate name. However, that would require a breaking change. Same for updating its value.

I'm not sure if introducing a new timeout and deprecating `DelayedPrecommitTimeout` would be fine to do. But if we don't want to touch that, 5.8s block time is good enough.

### Experiment

95 validator running 32mb/6s blocks:

- block size:
<img width="1134" height="545" alt="image" src="https://github.com/user-attachments/assets/70b5d1dc-0786-4ebb-9983-7f9f7c79217e" />

- block time: 
<img width="1182" height="567" alt="image" src="https://github.com/user-attachments/assets/4bf5b842-c48f-4790-9b8e-95653b0d86e4" />

The issue with this approach is that if a block takes multiple rounds, the timeout is reduced for the next one (as seen in the plot). If we're fine with this, we can ship.

Here is an experiment with 10 validators network where I stopped 2 validators to simulate multiple rounds:

<img width="1158" height="558" alt="image" src="https://github.com/user-attachments/assets/0f4e7185-772d-4896-8635-71b0267d8256" />

and the block times: 

<img width="493" height="319" alt="image" src="https://github.com/user-attachments/assets/fab41d95-d5c3-4624-b768-7820bcb89ba2" />

We could play the time even more but I'm not sure if it's worth it. 

The alternative would be to reduce the delayed precommit time by a constant to give more time for KMS to sign: https://github.com/celestiaorg/celestia-core/pull/2541
