### PR TITLE
feat: account for KMS signing delay in the delayed precommit timeout

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2102,7 +2102,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
 }
 
-// KMSSigningDelay is a constant representing a delay of one second, used primarily to adjust for KMS signing latencies.
+// KMSSigningDelay is a constant representing a delay used primarily to adjust for KMS signing latencies.
 const KMSSigningDelay = 200 * time.Millisecond
 
 // isReadyToPrecommit calculates if the process has waited at least a certain number of seconds


### PR DESCRIPTION
A second option to close: https://github.com/celestiaorg/celestia-core/issues/2538

First option: https://github.com/celestiaorg/celestia-core/pull/2540

I couldn't test this in a realistic network, given how hard it is to simulate a realistic environment with KMS. However, if we agree on this approach, we can ask POPS to use it and see if this gives them enough time to include their KMS signatures.

The potential issue with this approach is not knowing exactly how much latency to expect. For example, if validators are running geographically distributed KMS, it might take up to a second if we have 5 signers on different continents. 
The other issue is if most validators are using KMS, then they will all share pre-commit signatures pre-maturely and the network would advance at 5s blocks. And given most of them will fire faster and the network advances at a faster block time, it means that we will go back to the original problem and have validators not able to include their own signatures in time.

So, this approach depends on the validators running KMS to be low.