### PR TITLE
fix: receiving have on catchup block due to congestion

### DIFF
--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -2,7 +2,6 @@ package propagation
 
 import (
 	"bytes"
-	"fmt"
 	"math/rand"
 
 	proptypes "github.com/cometbft/cometbft/consensus/propagation/types"
@@ -122,7 +121,6 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 	}
 	blockProp.Logger.Info("added commitment", "height", height, "round", round)
 
-	fmt.Println("added cb without parts: ", height, " ", round)
 	// increment the local copies of the height and round
 	blockProp.height = height
 	blockProp.round = 0

--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -56,7 +56,6 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts) {
 	err := haves.ValidatePartHashes(cb.PartsHashes)
 	if err != nil {
 		blockProp.Logger.Error("received invalid have part", "height", haves.Height, "round", haves.Round, "err", err)
-		fmt.Println("cb: ", cb.ToProto())
 		blockProp.Switch.StopPeerForError(p.peer, err, blockProp.String())
 		return
 	}


### PR DESCRIPTION
Closes: https://github.com/celestiaorg/celestia-core/issues/2211

This is issue happens because we receive the votes using the consensus queues. Then we use those votes to add commitments for catchup blocks.

So, if the node is congested, and it received a `have` for a certain block, but that `have` wasn't processed in time until a commitment was added, then this `have` was causing that error. 

