### PR TITLE
chore(libs): add message stats table

### DIFF
--- a/libs/trace/schema/message_stats.go
+++ b/libs/trace/schema/message_stats.go
@@ -1,0 +1,40 @@
+package schema
+
+import (
+	"github.com/cometbft/cometbft/libs/trace"
+)
+
+// MessageStatsTables returns the list of tables that are used for the message stats
+// tracing.
+func MessageStatsTables() []string {
+	return []string{
+		MessageStatsTable,
+	}
+}
+
+const (
+	// MessageStatsTable tracks all the messages received by any reactor and traces their processing time.
+	MessageStatsTable = "message_stats"
+)
+
+// MessageStat describes schema for the "message_stats" table.
+type MessageStat struct {
+	Reactor        string `json:"reactor"`
+	MessageType    string `json:"message_type"`
+	ProcessingTime int64  `json:"processing_time"`
+	Details        string `json:"details"`
+}
+
+// Table returns the table name for the MessageStat struct.
+func (MessageStat) Table() string {
+	return MessageStatsTable
+}
+
+func WriteMessageStats(client trace.Tracer, reactor string, messageType string, processingTime int64, details string) {
+	client.Write(MessageStat{
+		Reactor:        reactor,
+		MessageType:    messageType,
+		ProcessingTime: processingTime,
+		Details:        details,
+	})
+}

--- a/libs/trace/schema/schema.go
+++ b/libs/trace/schema/schema.go
@@ -17,6 +17,7 @@ func AllTables() []string {
 	tables = append(tables, P2PTables()...)
 	tables = append(tables, ABCITable)
 	tables = append(tables, RecoveryTables()...)
+	tables = append(tables, MessageStatsTables()...)
 	return tables
 }
 


### PR DESCRIPTION
Adds the message stats table that I always add to measure times. It's not outputing any traces because they're too much. But I prefer to leave it always here so that if anyone wants to use it, they can just call:

```
schema.WriteMessageStats(cs.traceClient, "consensus", "proposeBlock", time.Since(start).Nanoseconds(), "")
```

