### PR TITLE
V0.38.x celestia fixed Issue #2571 (adding invalid-tx-format) line to expected output

### DIFF
--- a/abci/tests/test_cli/ex2.abci.out
+++ b/abci/tests/test_cli/ex2.abci.out
@@ -2,7 +2,6 @@
 -> code: 2
 -> log: invalid-tx-format
 
-
 > check_tx "def=567"
 -> code: OK
 


### PR DESCRIPTION


Add missing '-> log: invalid-tx-format' line, for check_tx command with invalid transaction format.