### PR TITLE
feat: track validator missed proposals

### DIFF
--- a/consensus/metrics.gen.go
+++ b/consensus/metrics.gen.go
@@ -222,6 +222,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "timed_out_proposals",
 			Help:      "TimedOutProposals is the number of proposals that failed to be received in time.",
 		}, labels).With(labelsAndValues...),
+		ProposerMissedProposals: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "proposer_missed_proposals",
+			Help:      "ProposerMissedProposals is the number of proposals missed by each proposer.",
+		}, append(labels, "proposer_address")).With(labelsAndValues...),
 	}
 }
 
@@ -261,5 +267,6 @@ func NopMetrics() *Metrics {
 		BlockTimeSeconds:             discard.NewGauge(),
 		ApplicationRejectedProposals: discard.NewCounter(),
 		TimedOutProposals:            discard.NewCounter(),
+		ProposerMissedProposals:      discard.NewCounter(),
 	}
 }

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -134,6 +134,9 @@ type Metrics struct {
 	ApplicationRejectedProposals metrics.Counter
 	// TimedOutProposals is the number of proposals that failed to be received in time.
 	TimedOutProposals metrics.Counter
+
+	// ProposerMissedProposals is the number of proposals missed by each proposer.
+	ProposerMissedProposals metrics.Counter `metrics_labels:"proposer_address"`
 }
 
 func (m *Metrics) MarkProposalProcessed(accepted bool) {

--- a/libs/trace/schema/consensus.go
+++ b/libs/trace/schema/consensus.go
@@ -21,6 +21,7 @@ func ConsensusTables() []string {
 		GapTable,
 		RetriesTable,
 		CatchupRequestsTable,
+		MissedProposalsTable,
 	}
 }
 
@@ -422,5 +423,32 @@ func WriteGap(
 	client.Write(Gap{
 		Height: height,
 		Round:  round,
+	})
+}
+
+const (
+	MissedProposalsTable = "missed_proposals"
+)
+
+type MissedProposal struct {
+	Height   int64  `json:"height"`
+	Round    int32  `json:"round"`
+	Proposer string `json:"proposer"`
+}
+
+func (b MissedProposal) Table() string {
+	return MissedProposalsTable
+}
+
+func WriteMissedProposal(
+	client trace.Tracer,
+	height int64,
+	round int32,
+	proposerAddress string,
+) {
+	client.Write(MissedProposal{
+		Height:   height,
+		Round:    round,
+		Proposer: proposerAddress,
 	})
 }


### PR DESCRIPTION
Adds tracking for when validators miss their proposal slots.

Added ProposerMissedProposals metric and missed_proposals trace table to track when validators fail to send proposals during their assigned rounds. Only counts as a miss when Proposal == nil (proposal never received).

Closes #2520 