### PR TITLE
fix(log): Safe colorFn for NewTMLogger, no more panics

### DIFF
--- a/libs/log/tm_logger.go
+++ b/libs/log/tm_logger.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"fmt"
+//	"fmt"
 	"io"
 
 	kitlog "github.com/go-kit/log"
@@ -26,37 +26,49 @@ var _ Logger = (*tmLogger)(nil)
 // using go-kit's log as an underlying logger and our custom formatter. Note
 // that underlying logger could be swapped with something else.
 func NewTMLogger(w io.Writer) Logger {
-	// Color by level value
-	colorFn := func(keyvals ...interface{}) term.FgBgColor {
-		// keyvals can start with either levelKey (for trace) or kitlevel.Key() (for debug/info/error)
-		if len(keyvals) < 2 {
-			return term.FgBgColor{}
-		}
+    colorFn := func(keyvals ...interface{}) term.FgBgColor {
+        if len(keyvals) < 2 {
+            return term.FgBgColor{}
+        }
 
-		var levelStr string
-		if keyvals[0] == levelKey {
-			// Custom trace level
-			levelStr = keyvals[1].(string)
-		} else if keyvals[0] == kitlevel.Key() {
-			// Standard go-kit levels
-			levelStr = keyvals[1].(kitlevel.Value).String()
-		} else {
-			panic(fmt.Sprintf("expected level key to be first, got %v", keyvals[0]))
-		}
+        var levelStr string
 
-		switch levelStr {
-		case "trace":
-			return term.FgBgColor{Fg: term.DarkGray}
-		case "debug":
-			return term.FgBgColor{Fg: term.Gray}
-		case "error":
-			return term.FgBgColor{Fg: term.Red}
-		default:
-			return term.FgBgColor{}
-		}
-	}
+        // Handle custom trace level
+        if keyvals[0] == levelKey {
+            // Safely handle this case
+            if strVal, ok := keyvals[1].(string); ok {
+                levelStr = strVal
+            } else {
+                return term.FgBgColor{}
+            }
+        // Handle standard go-kit levels
+        } else if keyvals[0] == kitlevel.Key() {
+            // Type-safe extraction for current go-kit/log (pointer and value types)
+            if stringer, ok := keyvals[1].(interface{ String() string }); ok {
+                levelStr = stringer.String()
+            } else if strVal, ok := keyvals[1].(string); ok {
+                levelStr = strVal
+            } else {
+                return term.FgBgColor{}
+            }
+        } else {
+            // Never panic: just return default color for unknown key types
+            return term.FgBgColor{}
+        }
 
-	return &tmLogger{term.NewLogger(w, NewTMFmtLogger, colorFn)}
+        switch levelStr {
+        case "trace":
+            return term.FgBgColor{Fg: term.DarkGray}
+        case "debug":
+            return term.FgBgColor{Fg: term.Gray}
+        case "error":
+            return term.FgBgColor{Fg: term.Red}
+        default:
+            return term.FgBgColor{}
+        }
+    }
+
+    return &tmLogger{term.NewLogger(w, NewTMFmtLogger, colorFn)}
 }
 
 // NewTMLoggerWithColorFn allows you to provide your own color function. See


### PR DESCRIPTION
### Problem

When running `celestia-appd comet unsafe-reset-all` or related commands with go-kit/log v0.2.1, the logger colorFn panics:  
`interface conversion: interface {} is *level.levelValue, not string`

### Solution

This patch updates colorFn to use type assertion against any type implementing String(), enabling compatibility with both *level.levelValue and other log level types. Safe fallback returns the default color.

### Testing

- Built against v0.39.12 with Go 1.24.6 (Initially tested against v0.39.10, also works)
- All previous panics now eliminated
- Node commands and logging verified functional

---

Let me know if more info or unit tests are needed.
