### PR TITLE
chore: pin buf version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,7 @@ mockery:
 
 #? check-proto-deps: Check protobuf deps
 check-proto-deps:
-ifeq (,$(shell which protoc-gen-gogofaster))
-	@go install github.com/cosmos/gogoproto/protoc-gen-gogofaster@latest
-endif
+	@go install github.com/cosmos/gogoproto/protoc-gen-gogofaster@v1.7.2
 .PHONY: check-proto-deps
 
 #? check-proto-format-deps: Check protobuf format deps
@@ -135,7 +133,7 @@ endif
 #? proto-gen: Generate protobuf files
 proto-gen: check-proto-deps
 	@echo "Generating Protobuf files"
-	@go run github.com/bufbuild/buf/cmd/buf@latest generate
+	@go run github.com/bufbuild/buf/cmd/buf@v1.28.1 generate
 	@mv ./proto/tendermint/abci/types.pb.go ./abci/types/
 	@cp ./proto/tendermint/rpc/grpc/types.pb.go ./rpc/grpc
 .PHONY: proto-gen
@@ -145,7 +143,7 @@ proto-gen: check-proto-deps
 #? proto-lint: Lint protobuf files
 proto-lint: check-proto-deps
 	@echo "Linting Protobuf files"
-	@go run github.com/bufbuild/buf/cmd/buf@latest lint
+	@go run github.com/bufbuild/buf/cmd/buf@v1.28.1 lint
 .PHONY: proto-lint
 
 #? proto-format: Format protobuf files
@@ -160,11 +158,11 @@ proto-check-breaking: check-proto-deps
 	@echo "Note: This is only useful if your changes have not yet been committed."
 	@echo "      Otherwise read up on buf's \"breaking\" command usage:"
 	@echo "      https://docs.buf.build/breaking/usage"
-	@go run github.com/bufbuild/buf/cmd/buf@latest breaking --against ".git"
+	@go run github.com/bufbuild/buf/cmd/buf@v1.28.1 breaking --against ".git"
 .PHONY: proto-check-breaking
 
 proto-check-breaking-ci:
-	@go run github.com/bufbuild/buf/cmd/buf@latest breaking --against $(HTTPS_GIT)#branch=v0.34.x
+	@go run github.com/bufbuild/buf/cmd/buf@v1.28.1 breaking --against $(HTTPS_GIT)#branch=v0.34.x
 .PHONY: proto-check-breaking-ci
 
 ###############################################################################


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/2647

Pins the buf and protoc-gen-gogofaster versions so that `make proto-gen` doesn't cause a huge diff

Unblocks https://github.com/celestiaorg/celestia-core/pull/2646

## Testing

```
make proto-gen
```

causes no git diff