### PR TITLE
feat: optionally skip processProposal while blocksyncing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1035,13 +1035,15 @@ func (cfg *StateSyncConfig) ValidateBasic() error {
 
 // BlockSyncConfig (formerly known as FastSync) defines the configuration for the CometBFT block sync service
 type BlockSyncConfig struct {
-	Version string `mapstructure:"version"`
+	Version    string `mapstructure:"version"`
+	VerifyData bool   `mapstructure:"verify_data"`
 }
 
 // DefaultBlockSyncConfig returns a default configuration for the block sync service
 func DefaultBlockSyncConfig() *BlockSyncConfig {
 	return &BlockSyncConfig{
-		Version: "v0",
+		Version:    "v0",
+		VerifyData: true,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -499,6 +499,11 @@ chunk_fetchers = "{{ .StateSync.ChunkFetchers }}"
 #   1) "v0" - the default block sync implementation
 version = "{{ .BlockSync.Version }}"
 
+# If true, the node will verify the application data in the block via ProcessProposal
+# during block sync. If false, this verification is skipped.
+# Default: true
+verify_data = {{ .BlockSync.VerifyData }}
+
 #######################################################
 ###         Consensus Configuration Options         ###
 #######################################################

--- a/node/setup.go
+++ b/node/setup.go
@@ -352,7 +352,7 @@ func createBlocksyncReactor(config *cfg.Config,
 ) (bcReactor p2p.Reactor, err error) {
 	switch config.BlockSync.Version {
 	case "v0":
-		bcReactor = blocksync.NewReactorWithAddr(state.Copy(), blockExec, blockStore, blockSync, localAddr, metrics, offlineStateSyncHeight, tracer)
+		bcReactor = blocksync.NewReactorWithAddr(state.Copy(), blockExec, blockStore, blockSync, localAddr, metrics, offlineStateSyncHeight, tracer, blocksync.ReactorVerifyData(config.BlockSync.VerifyData))
 	case "v1", "v2":
 		return nil, fmt.Errorf("block sync version %s has been deprecated. Please use v0", config.BlockSync.Version)
 	default:


### PR DESCRIPTION
first part of #2657

adds a config and flag to the blocksync config that enables a user to select if they call ProcessProposal while blocksyncing or not. This can significantly increase syncing rate, especially with large blocks. When state syncing, users also suffer from a minimal security decrease.

when verifying is disabled, we are only comparing the partsetheader, not the data root.
