### PR TITLE
refactor(propagation): async block decoding in handleRecoveryPart

### DIFF
--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -69,7 +69,7 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts) {
 		p.consensusPeerState.SetHasProposalBlockPart(height, round, int(pmd.Index))
 	}
 
-	if parts.Original().IsComplete() {
+	if parts.Original().IsComplete() || parts.IsDecoding.Load() {
 		return
 	}
 


### PR DESCRIPTION
converts block decoding to not block but also stops requesting parts

the latter might cause problems if we're not careful so we should add a flup to try and provide a stronger guarantee this never gets turned on or off when its not supposed to. idk what that would look like, but worth thinking about

