### PR TITLE
refactor(propagation): async mempool recovery with batched have broadcast

### DIFF
--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -224,7 +224,7 @@ func (blockProp *Reactor) handleCompactBlock(cb *proptypes.CompactBlock, peer p2
 
 	if !proposer {
 		// check if we have any transactions that are in the compact block
-		blockProp.recoverPartsFromMempool(cb)
+		go blockProp.recoverPartsFromMempool(cb)
 	}
 
 	blockProp.broadcastCompactBlock(cb, peer)


### PR DESCRIPTION
just makes recovery from the mempool async, by itself, this has the consequence of downloading a lot of extra data since often we end up getting a Have message before we can recover the tx4
