### PR TITLE
test: fix `TestStateOversizedBlock` flake

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -257,7 +257,11 @@ func TestStateBadProposal(t *testing.T) {
 }
 
 func TestStateOversizedBlock(t *testing.T) {
-	ensureTimeout = 500 * time.Millisecond
+	// Save and restore the original ensureTimeout value
+	origEnsureTimeout := ensureTimeout
+	ensureTimeout = 2 * time.Second
+	t.Cleanup(func() { ensureTimeout = origEnsureTimeout })
+
 	const maxBytes = int64(types.BlockPartSizeBytes)
 
 	for _, testCase := range []struct {


### PR DESCRIPTION
Attempts to fix another flake

This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-8ea6334b-5572-4b60-858f-4923b5873222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ea6334b-5572-4b60-858f-4923b5873222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

