### PR TITLE
Updated actions/upload-artifact from v5 to v6

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -49,14 +49,14 @@ jobs:
         continue-on-error: true
 
       - name: Archive crashers
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: crashers
           path: test/fuzz/**/crashers
           retention-days: 3
 
       - name: Archive suppressions
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: suppressions
           path: test/fuzz/**/suppressions


### PR DESCRIPTION
Updated actions/upload-artifact from v5 to v6 in fuzz-nightly workflow.
