### PR TITLE
feat: add the ability to halt via rpc upon configuration

### DIFF
--- a/consensus/debug_halt_test.go
+++ b/consensus/debug_halt_test.go
@@ -1,0 +1,105 @@
+package consensus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cometbft/cometbft/types"
+)
+
+// TestDebugHaltUnlock tests the debug halt and unlock functionality.
+// It verifies that:
+// 1. DebugHalt returns the current height
+// 2. IsDebugHalted returns true after halt
+// 3. DebugUnlock returns correct halt duration and heights
+// 4. IsDebugHalted returns false after unlock
+func TestDebugHaltUnlock(t *testing.T) {
+	cs1, _ := randState(4)
+	height, round := cs1.rs.Height, cs1.rs.Round
+
+	// Start the consensus state
+	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
+	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
+
+	startTestRound(cs1, height, round)
+
+	// Wait for first round
+	ensureNewRound(newRoundCh, height, round)
+	ensureNewProposal(proposalCh, height, round)
+
+	// Verify not halted initially
+	require.False(t, cs1.IsDebugHalted(), "should not be halted initially")
+
+	// Halt consensus
+	haltHeight := cs1.DebugHalt()
+	require.Equal(t, height, haltHeight, "halt height should match current height")
+	require.True(t, cs1.IsDebugHalted(), "should be halted after DebugHalt")
+
+	// Calling halt again should be idempotent and return the original halt height
+	haltHeight2 := cs1.DebugHalt()
+	require.Equal(t, haltHeight, haltHeight2, "second halt should return same height")
+
+	// Wait a bit to simulate time passing
+	time.Sleep(50 * time.Millisecond)
+
+	// Unlock consensus
+	duration, unlockHaltHeight, currentHeight := cs1.DebugUnlock()
+	require.Equal(t, haltHeight, unlockHaltHeight, "unlock should return original halt height")
+	require.GreaterOrEqual(t, duration.Milliseconds(), int64(50), "duration should be at least 50ms")
+	require.Equal(t, height, currentHeight, "current height should still be the same")
+	require.False(t, cs1.IsDebugHalted(), "should not be halted after unlock")
+
+	// Calling unlock again when not halted should return zeros
+	duration2, haltHeight3, currentHeight2 := cs1.DebugUnlock()
+	require.Equal(t, time.Duration(0), duration2, "duration should be 0 when not halted")
+	require.Equal(t, int64(0), haltHeight3, "halt height should be 0 when not halted")
+	require.Equal(t, height, currentHeight2, "current height should still be returned")
+}
+
+// TestDebugHaltBlocksCommit tests that debug halt actually blocks block commits
+// while allowing message processing to continue.
+func TestDebugHaltBlocksCommit(t *testing.T) {
+	cs1, vss := randState(4)
+	height, round := cs1.rs.Height, cs1.rs.Round
+
+	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
+	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
+	newBlockCh := subscribe(cs1.eventBus, types.EventQueryNewBlock)
+
+	startTestRound(cs1, height, round)
+
+	// Wait for first round and proposal
+	ensureNewRound(newRoundCh, height, round)
+	ensureNewProposal(proposalCh, height, round)
+
+	rs := cs1.GetRoundState()
+
+	// Halt before precommits
+	haltHeight := cs1.DebugHalt()
+	require.Equal(t, height, haltHeight)
+	require.True(t, cs1.IsDebugHalted())
+
+	// Sign precommit votes - this should trigger commit attempt which will block
+	signAddVotes(cs1, cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:]...)
+
+	// Give time for the commit to be attempted (it should block)
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify we're still at the same height (commit is blocked)
+	rs = cs1.GetRoundState()
+	require.Equal(t, height, rs.Height, "height should not have advanced while halted")
+
+	// Now unlock
+	cs1.DebugUnlock()
+
+	// The commit should now proceed - wait for new block
+	ensureNewBlock(newBlockCh, height)
+
+	// Verify we advanced to the next height
+	ensureNewRound(newRoundCh, height+1, 0)
+	rs = cs1.GetRoundState()
+	require.Equal(t, height+1, rs.Height, "height should advance after unlock")
+}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -172,6 +172,15 @@ type State struct {
 
 	// gossipDataEnabled controls whether the gossipDataRoutine should run
 	gossipDataEnabled atomic.Bool
+
+	// debugHalt is used to pause block commits for debugging catchup behavior.
+	// When unlockCh is non-nil, the consensus state will wait on it before
+	// committing blocks, allowing peers to get ahead.
+	debugHaltMtx    sync.Mutex
+	debugHaltCh     chan struct{} // signals when to halt (close to halt)
+	debugUnlockCh   chan struct{} // signals when to unlock (close to unlock)
+	debugHaltStart  time.Time     // when the halt started
+	debugHaltHeight int64         // the height at which the halt was initiated
 }
 
 // StateOption sets an optional parameter on the State.
@@ -1958,6 +1967,12 @@ func (cs *State) finalizeCommit(height int64) {
 		seenExtendedCommit := cs.rs.Votes.Precommits(cs.rs.CommitRound).MakeExtendedCommit(cs.state.ConsensusParams.ABCI)
 		seenCommit = seenExtendedCommit.ToCommit()
 		cs.unlockAll()
+
+		// Debug halt: wait for unlock signal before saving block.
+		// This allows forcing the node into catchup mode for debugging.
+		// Message processing continues while waiting because locks are released.
+		cs.waitForDebugUnlock()
+
 		if cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(block.Height) {
 			cs.blockStore.SaveBlockWithExtendedCommit(block, blockParts, seenExtendedCommit)
 		} else {
@@ -2944,4 +2959,92 @@ func (cs *State) unlockAll() {
 	cs.rsMtx.Unlock()
 	cs.stateMtx.Unlock()
 	cs.mtx.Unlock()
+}
+
+// DebugHalt pauses the consensus state before committing blocks.
+// This is an unsafe debugging operation that allows forcing a node into catchup mode.
+// Message processing continues while halted, but block commits are delayed.
+// Returns the height at which the halt was initiated.
+func (cs *State) DebugHalt() int64 {
+	cs.debugHaltMtx.Lock()
+	defer cs.debugHaltMtx.Unlock()
+
+	cs.rsMtx.RLock()
+	height := cs.rs.Height
+	round := cs.rs.Round
+	cs.rsMtx.RUnlock()
+
+	// Already halted
+	if cs.debugHaltCh != nil {
+		cs.Logger.Info("DebugHalt called but already halted", "height", height)
+		return cs.debugHaltHeight
+	}
+
+	cs.debugHaltCh = make(chan struct{})
+	cs.debugUnlockCh = make(chan struct{})
+	cs.debugHaltStart = time.Now()
+	cs.debugHaltHeight = height
+
+	cs.Logger.Info("DebugHalt: consensus halted, waiting for unlock", "height", height, "round", round)
+
+	return height
+}
+
+// DebugUnlock resumes the consensus state after a DebugHalt.
+// Returns the duration the node was halted and the height at which it will resume catchup.
+func (cs *State) DebugUnlock() (haltDuration time.Duration, haltHeight int64, currentHeight int64) {
+	cs.debugHaltMtx.Lock()
+	defer cs.debugHaltMtx.Unlock()
+
+	cs.rsMtx.RLock()
+	currentHeight = cs.rs.Height
+	cs.rsMtx.RUnlock()
+
+	// Not halted
+	if cs.debugUnlockCh == nil {
+		cs.Logger.Info("DebugUnlock called but not halted")
+		return 0, 0, currentHeight
+	}
+
+	haltDuration = time.Since(cs.debugHaltStart)
+	haltHeight = cs.debugHaltHeight
+
+	// Signal unlock to any waiting goroutine
+	close(cs.debugUnlockCh)
+	cs.debugHaltCh = nil
+	cs.debugUnlockCh = nil
+
+	cs.Logger.Info("DebugUnlock: consensus resumed",
+		"halt_duration", haltDuration,
+		"halt_height", haltHeight,
+		"current_height", currentHeight)
+
+	return haltDuration, haltHeight, currentHeight
+}
+
+// IsDebugHalted returns true if the consensus state is currently halted for debugging.
+func (cs *State) IsDebugHalted() bool {
+	cs.debugHaltMtx.Lock()
+	defer cs.debugHaltMtx.Unlock()
+	return cs.debugHaltCh != nil
+}
+
+// waitForDebugUnlock blocks until debug unlock is signaled, if a halt is active.
+// This should be called in finalizeCommit before actually committing the block.
+// It releases all locks while waiting to allow message processing to continue.
+func (cs *State) waitForDebugUnlock() {
+	cs.debugHaltMtx.Lock()
+	unlockCh := cs.debugUnlockCh
+	cs.debugHaltMtx.Unlock()
+
+	if unlockCh == nil {
+		return
+	}
+
+	cs.Logger.Info("waitForDebugUnlock: waiting for unlock signal before committing block")
+
+	// Wait for unlock signal
+	<-unlockCh
+
+	cs.Logger.Info("waitForDebugUnlock: unlock signal received, proceeding with commit")
 }

--- a/rpc/client/debug.go
+++ b/rpc/client/debug.go
@@ -1,0 +1,130 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+)
+
+// DebugHalt calls the unsafe_debug_halt RPC endpoint to halt consensus.
+// This pauses block commits while allowing message processing to continue,
+// which forces the node into catchup mode when unlocked.
+//
+// The endpoint parameter should be the RPC endpoint URL (e.g., "http://localhost:26657").
+// Returns the height at which the halt was initiated.
+func DebugHalt(endpoint string) (*ctypes.ResultUnsafeDebugHalt, error) {
+	url := fmt.Sprintf("%s/unsafe_debug_halt", endpoint)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call unsafe_debug_halt: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unsafe_debug_halt returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse JSON-RPC response
+	var rpcResp struct {
+		Result *ctypes.ResultUnsafeDebugHalt `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    string `json:"data"`
+		} `json:"error"`
+	}
+
+	if err := cmtjson.Unmarshal(body, &rpcResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("RPC error %d: %s - %s", rpcResp.Error.Code, rpcResp.Error.Message, rpcResp.Error.Data)
+	}
+
+	return rpcResp.Result, nil
+}
+
+// DebugUnlock calls the unsafe_debug_unlock RPC endpoint to unlock consensus.
+// This resumes block commits after a debug halt, allowing the node to catch up.
+//
+// The endpoint parameter should be the RPC endpoint URL (e.g., "http://localhost:26657").
+// Returns information about the halt duration and heights.
+func DebugUnlock(endpoint string) (*ctypes.ResultUnsafeDebugUnlock, error) {
+	url := fmt.Sprintf("%s/unsafe_debug_unlock", endpoint)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call unsafe_debug_unlock: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unsafe_debug_unlock returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse JSON-RPC response
+	var rpcResp struct {
+		Result *ctypes.ResultUnsafeDebugUnlock `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    string `json:"data"`
+		} `json:"error"`
+	}
+
+	if err := cmtjson.Unmarshal(body, &rpcResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("RPC error %d: %s - %s", rpcResp.Error.Code, rpcResp.Error.Message, rpcResp.Error.Data)
+	}
+
+	return rpcResp.Result, nil
+}
+
+// DebugHaltAndPrint calls DebugHalt and prints the result to stdout.
+func DebugHaltAndPrint(endpoint string) error {
+	result, err := DebugHalt(endpoint)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Debug Halt Result:\n")
+	fmt.Printf("  Height: %d\n", result.Height)
+	fmt.Printf("  Halted: %v\n", result.Halted)
+	return nil
+}
+
+// DebugUnlockAndPrint calls DebugUnlock and prints the result to stdout.
+func DebugUnlockAndPrint(endpoint string) error {
+	result, err := DebugUnlock(endpoint)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Debug Unlock Result:\n")
+	fmt.Printf("  Was Halted: %v\n", result.WasHalted)
+	if result.WasHalted {
+		fmt.Printf("  Halt Height: %d\n", result.HaltHeight)
+		fmt.Printf("  Current Height: %d\n", result.CurrentHeight)
+		fmt.Printf("  Halt Duration: %v\n", time.Duration(result.HaltDurationNs))
+	}
+	return nil
+}

--- a/rpc/core/dev.go
+++ b/rpc/core/dev.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"fmt"
+
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 )
@@ -9,4 +11,56 @@ import (
 func (env *Environment) UnsafeFlushMempool(*rpctypes.Context) (*ctypes.ResultUnsafeFlushMempool, error) {
 	env.Mempool.Flush()
 	return &ctypes.ResultUnsafeFlushMempool{}, nil
+}
+
+// UnsafeDebugHalt halts the consensus state to simulate falling behind for catchup testing.
+// This is an unsafe debugging operation that pauses block commits while allowing
+// message processing to continue. Other nodes will continue to make progress,
+// and this node will need to catch up when unlocked.
+//
+// Use UnsafeDebugUnlock to resume normal operation.
+func (env *Environment) UnsafeDebugHalt(*rpctypes.Context) (*ctypes.ResultUnsafeDebugHalt, error) {
+	debugCS, ok := env.ConsensusState.(debugConsensusState)
+	if !ok {
+		return nil, fmt.Errorf("consensus state does not support debug operations")
+	}
+
+	height := debugCS.DebugHalt()
+
+	env.Logger.Info("UnsafeDebugHalt: consensus halted", "height", height)
+
+	return &ctypes.ResultUnsafeDebugHalt{
+		Height: height,
+		Halted: true,
+	}, nil
+}
+
+// UnsafeDebugUnlock unlocks the consensus state after a debug halt.
+// Returns information about how long the node was halted and the current state.
+// The node will then proceed to catch up to the chain tip.
+func (env *Environment) UnsafeDebugUnlock(*rpctypes.Context) (*ctypes.ResultUnsafeDebugUnlock, error) {
+	debugCS, ok := env.ConsensusState.(debugConsensusState)
+	if !ok {
+		return nil, fmt.Errorf("consensus state does not support debug operations")
+	}
+
+	if !debugCS.IsDebugHalted() {
+		return &ctypes.ResultUnsafeDebugUnlock{
+			WasHalted: false,
+		}, nil
+	}
+
+	haltDuration, haltHeight, currentHeight := debugCS.DebugUnlock()
+
+	env.Logger.Info("UnsafeDebugUnlock: consensus unlocked",
+		"halt_duration_ns", haltDuration.Nanoseconds(),
+		"halt_height", haltHeight,
+		"current_height", currentHeight)
+
+	return &ctypes.ResultUnsafeDebugUnlock{
+		HaltDurationNs: haltDuration.Nanoseconds(),
+		HaltHeight:     haltHeight,
+		CurrentHeight:  currentHeight,
+		WasHalted:      true,
+	}, nil
 }

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -61,6 +61,14 @@ type consensusReactor interface {
 	WaitSync() bool
 }
 
+// debugConsensusState is an optional interface for debug operations on consensus state.
+// It's separate from the main interface to avoid requiring it in production code.
+type debugConsensusState interface {
+	DebugHalt() int64
+	DebugUnlock() (haltDuration time.Duration, haltHeight int64, currentHeight int64)
+	IsDebugHalted() bool
+}
+
 // ----------------------------------------------
 // Environment contains objects and interfaces used by the RPC. It is expected
 // to be setup once during startup.

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -69,4 +69,8 @@ func (env *Environment) AddUnsafeRoutes(routes RoutesMap) {
 	routes["dial_seeds"] = rpc.NewRPCFunc(env.UnsafeDialSeeds, "seeds")
 	routes["dial_peers"] = rpc.NewRPCFunc(env.UnsafeDialPeers, "peers,persistent,unconditional,private")
 	routes["unsafe_flush_mempool"] = rpc.NewRPCFunc(env.UnsafeFlushMempool, "")
+
+	// debug consensus API - for testing catchup behavior
+	routes["unsafe_debug_halt"] = rpc.NewRPCFunc(env.UnsafeDebugHalt, "")
+	routes["unsafe_debug_unlock"] = rpc.NewRPCFunc(env.UnsafeDebugUnlock, "")
 }

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -249,6 +249,26 @@ type (
 	ResultHealth             struct{}
 )
 
+// ResultUnsafeDebugHalt is returned when the consensus is halted for debugging.
+type ResultUnsafeDebugHalt struct {
+	// Height is the height at which the halt was initiated
+	Height int64 `json:"height"`
+	// Halted indicates if the node is now halted
+	Halted bool `json:"halted"`
+}
+
+// ResultUnsafeDebugUnlock is returned when the consensus is unlocked after a debug halt.
+type ResultUnsafeDebugUnlock struct {
+	// HaltDurationNs is how long the node was halted in nanoseconds
+	HaltDurationNs int64 `json:"halt_duration_ns"`
+	// HaltHeight is the height at which the node was halted
+	HaltHeight int64 `json:"halt_height"`
+	// CurrentHeight is the current height when unlocked
+	CurrentHeight int64 `json:"current_height"`
+	// WasHalted indicates if the node was actually halted before unlocking
+	WasHalted bool `json:"was_halted"`
+}
+
 // Event data from a subscription
 type ResultEvent struct {
 	Query  string              `json:"query"`


### PR DESCRIPTION
adds the ability to halt via rpc 

the endpoints are only added if the config is set to true

this is insanely useful if there ever is a bug in catchup and we need to replicate the issue.