### PR TITLE
fix: nil pointer dereference in BlockStore.PruneBlocks

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -402,7 +402,7 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 
 		meta := bs.LoadBlockMeta(h)
 		block := bs.LoadBlock(h)
-		if meta == nil { // assume already deleted
+		if meta == nil || block == nil { // assume already deleted
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Add nil check for `block` in `PruneBlocks`. `LoadBlock()` can return `nil` even when `LoadBlockMeta()` returns non-nil (e.g., when block parts are missing). This was causing a panic when accessing `block.Txs`.

## Bug

```go
meta := bs.LoadBlockMeta(h)
block := bs.LoadBlock(h)
if meta == nil { // assume already deleted
    continue
}

for _, tx := range block.Txs {  // PANIC: block can be nil!
```

`LoadBlock()` returns `nil` when block parts are missing:

```go
func (bs *BlockStore) LoadBlock(height int64) *types.Block {
    blockMeta := bs.LoadBlockMeta(height)
    if blockMeta == nil {
        return nil
    }
    ...
    part := bs.LoadBlockPart(height, i)
    if part == nil {
        return nil  // Returns nil even if meta exists!
    }
```

## Fix

```diff
 meta := bs.LoadBlockMeta(h)
 block := bs.LoadBlock(h)
-if meta == nil { // assume already deleted
+if meta == nil || block == nil { // assume already deleted
     continue
 }
```

Closes #2772

## Related

- https://github.com/celestiaorg/celestia-app/issues/6476