### PR TITLE
chore: bump Go toolchain to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.25.6
+FROM golang:1.25.7
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION
## Summary
- Bumps Go from 1.25.6 to 1.25.7 to fix [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337) (unexpected session resumption in `crypto/tls`)
- Updates `go.mod` and `test/e2e/docker/Dockerfile`

## Test plan
- [ ] CI passes `make vulncheck` without GO-2026-4337

🤖 Generated with [Claude Code](https://claude.com/claude-code)