### PR TITLE
fix: correct buffer offset bug in ProposerPriorityHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### BUG FIXES
 
+- `[types]` Fix buffer offset bug in `ProposerPriorityHash` where only the
+  last validator's priority was included in the hash
+  ([#2790](https://github.com/celestiaorg/celestia-core/issues/2790))
+
 ### IMPROVEMENTS
 
 - `[statesync]` Add configurable `max-snapshot-chunks` parameter to validate max amount of chunks in a `SnapshotResponse`.

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -391,12 +391,12 @@ func (vals *ValidatorSet) ProposerPriorityHash() []byte {
 	}
 
 	buf := make([]byte, binary.MaxVarintLen64*len(vals.Validators))
-	total := 0
+	offset := 0
 	for _, val := range vals.Validators {
-		n := binary.PutVarint(buf, val.ProposerPriority)
-		total += n
+		n := binary.PutVarint(buf[offset:], val.ProposerPriority)
+		offset += n
 	}
-	return tmhash.Sum(buf[:total])
+	return tmhash.Sum(buf[:offset])
 }
 
 // Iterate will run the given function over the set.

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -183,6 +183,15 @@ func TestValidatorSet_ProposerPriorityHash(t *testing.T) {
 	vset.IncrementProposerPriority(1)
 	assert.Equal(t, vset.Hash(), vsetCopy.Hash())
 	assert.NotEqual(t, vset.ProposerPriorityHash(), vsetCopy.ProposerPriorityHash())
+
+	// Regression test: modifying a single validator's priority must change
+	// ProposerPriorityHash. Before the buffer offset fix, all priorities were
+	// written to buf[0:] so only the last value was reflected in the hash.
+	vsetA := randValidatorSet(3)
+	vsetB := vsetA.Copy()
+	vsetB.Validators[0].ProposerPriority = vsetA.Validators[0].ProposerPriority + 1
+	assert.NotEqual(t, vsetA.ProposerPriorityHash(), vsetB.ProposerPriorityHash(),
+		"ProposerPriorityHash should differ when a non-last validator's priority changes")
 }
 
 // Test that IncrementProposerPriority requires positive times.


### PR DESCRIPTION
## Summary

- Fix buffer offset bug in `ProposerPriorityHash` where `binary.PutVarint(buf, ...)` always wrote to `buf[0:]` instead of `buf[offset:]`, causing each iteration to overwrite the same position so only the last validator's priority was reflected in the hash
- Add regression test that modifies a non-last validator's priority and asserts the hash changes
- Add changelog entry

Closes #2790

Upstream references:
- [cometbft/cometbft#5609](https://github.com/cometbft/cometbft/issues/5609)
- [cometbft/cometbft#5613](https://github.com/cometbft/cometbft/pull/5613)

## Test plan

- [x] `go test ./types/ -run TestValidatorSet_ProposerPriorityHash -v -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)