### PR TITLE
fix: make help the default target and include all targets in help output

### DIFF
--- a/tests.mk
+++ b/tests.mk
@@ -6,26 +6,31 @@
 BINDIR ?= $(GOPATH)/bin
 
 ## required to be run first by most tests
+#? build_docker_test_image: Build Docker test image
 build_docker_test_image:
 	docker build -t tester -f ./test/docker/Dockerfile .
 .PHONY: build_docker_test_image
 
 ### coverage, app, persistence, and libs tests
+#? test_cover: Run go unit tests with coverage
 test_cover:
 	# run the go unit tests with coverage
 	bash test/test_cover.sh
 .PHONY: test_cover
 
+#? test_apps: Run app tests using bash
 test_apps:
 	# run the app tests using bash
 	# requires `abci-cli` and `cometbft` binaries installed
 	bash test/app/test.sh
 .PHONY: test_apps
 
+#? test_abci_apps: Run ABCI app tests
 test_abci_apps:
 	bash abci/tests/test_app/test.sh
 .PHONY: test_abci_apps
 
+#? test_abci_cli: Run ABCI CLI tests
 test_abci_cli:
 	# test the cli against the examples in the tutorial at:
 	# ./docs/abci-cli.md
@@ -33,6 +38,7 @@ test_abci_cli:
 	@ bash abci/tests/test_cli/test.sh
 .PHONY: test_abci_cli
 
+#? test_integrations: Run all integration tests
 test_integrations:
 	make build_docker_test_image
 	make tools
@@ -45,30 +51,36 @@ test_integrations:
 	make test_libs
 .PHONY: test_integrations
 
+#? test_release: Run release tests
 test_release:
 	@go test -tags release $(PACKAGES)
 .PHONY: test_release
 
+#? test100: Run tests 100 times
 test100:
 	@for i in {1..100}; do make test; done
 .PHONY: test100
 
+#? vagrant_test: Run integration tests in Vagrant
 vagrant_test:
 	vagrant up
 	vagrant ssh -c 'make test_integrations'
 .PHONY: vagrant_test
 
 ### go tests
+#? test: Run go tests
 test:
 	@echo "--> Running go test"
 	@go test -p 1 $(PACKAGES) -tags deadlock
 .PHONY: test
 
+#? test_race: Run go tests with race detector
 test_race:
 	@echo "--> Running go test --race"
 	@go test -p 1 -v -race $(PACKAGES)
 .PHONY: test_race
 
+#? test_deadlock: Run go tests with deadlock detector
 test_deadlock:
 	@echo "--> Running go test --deadlock"
 	@go test -p 1 -v  $(PACKAGES) -tags deadlock 


### PR DESCRIPTION
## Summary
- Set `.DEFAULT_GOAL := help` so running `make` with no arguments displays help instead of running `all`
- Added `#?` help comments to all targets in both `Makefile` (6 targets) and `tests.mk` (12 targets) that were missing them
- Updated the `help` recipe to read from both `Makefile` and `tests.mk` instead of only `Makefile`
- Fixed the duplicate `lint-typo` label (should have been `lint-fix-typo`) and a typo in the help banner ("comebft" → "cometbft")

Closes https://github.com/celestiaorg/celestia-core/issues/2796

## Test plan
- [ ] Run `make` with no arguments and verify it prints help output
- [ ] Run `make help` and verify all targets from both `Makefile` and `tests.mk` are listed
- [ ] Verify no duplicate or mislabeled entries in help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)