### PR TITLE
fix: prevent GC finalizer from closing TCP conn in p2p switch tests

### DIFF
--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -819,8 +819,9 @@ func TestSwitchInitPeerIsNotCalledBeforeRemovePeer(t *testing.T) {
 	rp := &remotePeer{PrivKey: ed25519.GenPrivKey(), Config: cfg}
 	rp.Start()
 	defer rp.Stop()
-	_, err = rp.Dial(sw.NetAddress())
+	rpConn, err := rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
+	defer rpConn.Close()
 
 	// wait till the switch adds rp to the peer set, then stop the peer asynchronously
 	require.Eventually(t, func() bool {
@@ -832,8 +833,9 @@ func TestSwitchInitPeerIsNotCalledBeforeRemovePeer(t *testing.T) {
 	}, 5*time.Second, 20*time.Millisecond, "peer was never added to switch")
 
 	// simulate peer reconnecting to us
-	_, err = rp.Dial(sw.NetAddress())
+	rpConn2, err := rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
+	defer rpConn2.Close()
 	// wait till the switch adds rp to the peer set
 	time.Sleep(50 * time.Millisecond)
 
@@ -867,8 +869,9 @@ func TestPeerRemovedFromReactorOnStopWithNilReason(t *testing.T) {
 	rp := &remotePeer{PrivKey: ed25519.GenPrivKey(), Config: cfg}
 	rp.Start()
 	defer rp.Stop()
-	_, err = rp.Dial(sw.NetAddress())
+	rpConn, err := rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
+	defer rpConn.Close()
 
 	// wait till the switch adds rp to the peer set
 	var peer Peer


### PR DESCRIPTION
## Summary

- Fix flaky `TestPeerRemovedFromReactorOnStopWithNilReason` and `TestSwitchInitPeerIsNotCalledBeforeRemovePeer` tests by retaining the `net.Conn` returned by `rp.Dial()` instead of discarding it
- When the connection was discarded (`_, err = rp.Dial(...)`), Go's GC finalizer on `netFD` could close the TCP socket, causing the switch's MConnection to receive EOF and immediately remove the peer before the test could observe it
- Reproduced locally: ~2-4% failure rate with `-race`, 0% without `-race`; 0% failure rate after fix across 100+ race-enabled runs

Closes #2804

## Test plan

- [x] `go test -v -race -run "TestPeerRemovedFromReactorOnStopWithNilReason|TestSwitchInitPeerIsNotCalledBeforeRemovePeer" -count=100 -timeout=5m ./p2p/` passes (0 failures out of 200 test runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)