### PR TITLE
chore!: remove mempool type from config.toml template

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -341,17 +341,6 @@ dial_timeout = "{{ .P2P.DialTimeout }}"
 #######################################################
 [mempool]
 
-# The type of mempool for this node to use.
-#
-#  Possible types:
-#  - "flood" : concurrent linked list mempool with flooding gossip protocol
-#  - "nop"   : nop-mempool (short for no operation; the ABCI app is responsible
-#  for storing, disseminating and proposing txs). "create_empty_blocks=false" is
-#  not supported.
-#  - "priority" : concurrent linked list mempool with priority queue (default)
-#  - "cat"   : content addressable mempool
-type = "{{ .Mempool.Type }}"
-
 # Recheck (default: true) defines whether CometBFT should recheck the
 # validity for all remaining transaction in the mempool after a block.
 # Since a block affects the application state, some transactions in the


### PR DESCRIPTION
## Summary

- Remove the mempool `type` field from the config.toml template so newly generated config files no longer expose it
- The `Type` field remains in the `MempoolConfig` struct with `cat` as the default, so existing config files with a `type` field will still parse without error
- Replace `TestMempoolTypeTemplate` with `TestMempoolTypeNotInTemplate` to verify the field is absent from generated configs

## Context

celestia-app only supports the CAT mempool and hardcodes it at startup. Exposing the `type` field in config.toml gives users the false impression that they can configure it. This change removes it from new config files. Existing config files that still have `type = "..."` will continue to parse — celestia-app will warn and override to CAT.

## Test plan

- [x] `go test ./config/ -v` — all config tests pass
- [x] `TestMempoolTypeNotInTemplate` verifies no mempool type appears in generated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)