### PR TITLE
fix: add default case to handleHaves select to prevent reactor halt

### DIFF
--- a/consensus/propagation/have_wants.go
+++ b/consensus/propagation/have_wants.go
@@ -89,6 +89,8 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts) {
 
 	if p := blockProp.getPeer(peer); p != nil {
 		for _, index := range hc.GetTrueIndices() {
+			// avoid blocking if a single peer is backed up. This means that they
+			// are sending us too many haves
 			select {
 			case <-p.ctx.Done():
 				return
@@ -98,6 +100,7 @@ func (blockProp *Reactor) handleHaves(peer p2p.ID, haves *proptypes.HaveParts) {
 				index:  uint32(index),
 			}:
 				p.RequestsReady()
+			default:
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Add a `default` case to the `select` statement in `handleHaves` (`consensus/propagation/have_wants.go`) so that when the per-peer `receivedHaves` channel is full, the message is dropped instead of blocking the propagation reactor's single message-processing goroutine.
- This matches the existing non-blocking pattern already used in `handleRecoveryPart` in the same file.
- Add a regression test `TestHandleHavesDoesNotBlock` that fills the channel to capacity and asserts `handleHaves` returns promptly.

## Test plan
- [x] `go test -v -run TestHandleHavesDoesNotBlock -count=1 ./consensus/propagation/` passes
- [x] Full `go test ./consensus/propagation/...` passes

Closes CELESTIA-185

🤖 Generated with [Claude Code](https://claude.com/claude-code)