### PR TITLE
fix: disconnect peers that send invalid chunks during state sync

### DIFF
--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -275,6 +275,12 @@ func (r *Reactor) Sync(stateProvider StateProvider, discoveryTime time.Duration)
 	}
 	r.metrics.Syncing.Set(1)
 	r.syncer = newSyncer(r.cfg, r.Logger, r.conn, r.connQuery, stateProvider, r.tempDir)
+	r.syncer.setOnPeerRejected(func(peerID p2p.ID) {
+		peer := r.Switch.Peers().Get(peerID)
+		if peer != nil {
+			r.Switch.StopPeerForError(peer, "chunk sender rejected by ABCI application", r.String())
+		}
+	})
 	r.mtx.Unlock()
 
 	hook := func() {


### PR DESCRIPTION
## Summary

- When the ABCI application rejects a chunk sender via `RejectSenders` during state sync, the peer was only blacklisted in the in-memory snapshot pool (`snapshots.RejectPeer`) but remained connected at the P2P layer. A malicious peer could keep sending poisoned `ChunkResponse` messages, creating an infinite retry loop.
- Adds an `onPeerRejected` callback to the syncer that the reactor wires up to call `StopPeerForError`, disconnecting the rejected peer at the P2P layer.
- Adds `TestSyncer_applyChunks_onPeerRejected` to verify the callback is invoked with the correct peer ID.

## Test plan

- [x] `go test -v -run TestSyncer_applyChunks_onPeerRejected ./statesync/`
- [x] `go test -v ./statesync/...` (all 37 tests pass)
- [x] `go test -race ./statesync/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)