### PR TITLE
fix: use assert.Eventually in TestReactorRecordsVotesAndBlockParts

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -458,8 +458,12 @@ func TestReactorRecordsVotesAndBlockParts(t *testing.T) {
 	// Get peer state
 	ps := peer.Get(types.PeerStateKey).(*PeerState)
 
-	assert.Equal(t, true, ps.VotesSent() > 0, "number of votes sent should have increased")
-	assert.Equal(t, true, ps.BlockPartsSent() > 0, "number of votes sent should have increased")
+	assert.Eventually(t, func() bool {
+		return ps.VotesSent() > 0
+	}, 10*time.Second, 100*time.Millisecond, "number of votes sent should have increased")
+	assert.Eventually(t, func() bool {
+		return ps.BlockPartsSent() > 0
+	}, 10*time.Second, 100*time.Millisecond, "number of block parts sent should have increased")
 }
 
 //-------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace one-shot `assert.Equal` assertions with `assert.Eventually` in `TestReactorRecordsVotesAndBlockParts` to fix a flaky test
- The race condition occurs because peer state vote/block-part counters may not be updated by the time assertions run after waiting for the first block
- Also fixes a copy-paste typo in the second assertion message ("number of votes sent" → "number of block parts sent")

## Test plan

- [x] Ran `TestReactorRecordsVotesAndBlockParts` 3 times with `-race` flag — all passed
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)