### PR TITLE
fix: increase ensureVote timeout to fix flaky TestStateOversizedBlock

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -58,7 +58,7 @@ var (
 	consensusReplayConfig *cfg.Config
 	ensureTimeout         = time.Millisecond * 200
 	ensureVoteTimeout     = time.Second * 2   // votes need longer timeout on slow CI with race detector
-	ensureProposalTimeout = ensureTimeout * 5  // proposals can be delayed by TimeoutCommit and scheduling jitter
+	ensureProposalTimeout = ensureTimeout * 5 // proposals can be delayed by TimeoutCommit and scheduling jitter
 )
 
 func ensureDir(dir string, mode os.FileMode) {

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -57,7 +57,8 @@ var (
 	config                *cfg.Config // NOTE: must be reset for each _test.go file
 	consensusReplayConfig *cfg.Config
 	ensureTimeout         = time.Millisecond * 200
-	ensureProposalTimeout = ensureTimeout * 5 // proposals can be delayed by TimeoutCommit and scheduling jitter
+	ensureVoteTimeout     = time.Second * 2   // votes need longer timeout on slow CI with race detector
+	ensureProposalTimeout = ensureTimeout * 5  // proposals can be delayed by TimeoutCommit and scheduling jitter
 )
 
 func ensureDir(dir string, mode os.FileMode) {
@@ -728,7 +729,7 @@ func ensureVote(
 	round int32,
 	voteType cmtproto.SignedMsgType,
 ) {
-	timer := time.NewTimer(ensureTimeout)
+	timer := time.NewTimer(ensureVoteTimeout)
 	defer timer.Stop()
 
 	var lastUnexpected *types.Vote


### PR DESCRIPTION
## Summary

- Introduce a separate `ensureVoteTimeout` (2s) for the `ensureVote` helper, replacing the shared `ensureTimeout` (200ms)
- The 200ms timeout was too tight for CI machines running with the race detector, causing `TestStateOversizedBlock/max_size,_correct_block` to flake when processing prevotes and producing a precommit took longer than expected
- The shorter `ensureTimeout` used by "ensure no event" helpers remains unaffected

## Test plan

- [x] Ran `TestStateOversizedBlock/max_size,_correct_block` 5 times with `-race` — all passed
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)