### PR TITLE
fix: add missing QuerySequence case to socket client resMatchesReq

### DIFF
--- a/.changelog/unreleased/bug-fixes/socket-client-query-sequence.md
+++ b/.changelog/unreleased/bug-fixes/socket-client-query-sequence.md
@@ -1,0 +1,3 @@
+- `[abci/client]` Add missing `QuerySequence` case to `resMatchesReq` in socket
+  client, which caused the client to treat a valid `QuerySequence` response as
+  unexpected and terminate the connection.

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -504,6 +504,8 @@ func resMatchesReq(req *types.Request, res *types.Response) (ok bool) {
 		_, ok = res.Value.(*types.Response_ProcessProposal)
 	case *types.Request_FinalizeBlock:
 		_, ok = res.Value.(*types.Response_FinalizeBlock)
+	case *types.Request_QuerySequence:
+		_, ok = res.Value.(*types.Response_QuerySequence)
 	}
 	return ok
 }

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -195,6 +195,34 @@ func TestCallbackInvokedWhenSetLate(t *testing.T) {
 	require.True(t, called)
 }
 
+// TestQuerySequenceCrashesSocketClient reproduces a vulnerability where calling
+// QuerySequence over the socket ABCI transport causes the client to stop with
+// an error because resMatchesReq is missing the QuerySequence case. When this
+// happens in production, killTMOnClientError terminates the entire node.
+// A remote peer can trigger this by sending a SeenTx message with a non-empty
+// Signer field, which causes the CAT mempool reactor to call QuerySequence
+// before validating the message fields.
+func TestQuerySequenceCrashesSocketClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	app := types.BaseApplication{}
+	_, c := setupClientServer(t, app)
+
+	// Call QuerySequence over the socket transport. If the bug is present,
+	// the socket client will stop itself because resMatchesReq returns false
+	// for Request_QuerySequence <-> Response_QuerySequence.
+	resp, err := c.QuerySequence(ctx, &types.RequestQuerySequence{
+		Signer: []byte("test-signer"),
+	})
+
+	// With the bug: err != nil and c.Error() != nil (client stopped itself).
+	// With the fix: err == nil, resp is valid, client remains running.
+	require.NoError(t, err, "QuerySequence should not cause socket client error")
+	require.NotNil(t, resp, "QuerySequence should return a response")
+	require.NoError(t, c.Error(), "socket client should still be running without error")
+}
+
 type blockedABCIApplication struct {
 	wg *sync.WaitGroup
 	types.BaseApplication


### PR DESCRIPTION
## Summary

- The `resMatchesReq` function in the socket ABCI client (`abci/client/socket_client.go`) was missing a case for `Request_QuerySequence` ↔ `Response_QuerySequence`. When `QuerySequence` was called over the socket transport, the client treated the valid response as "unexpected", stopped itself with an error, and `killTMOnClientError` terminated the node process.
- This was reported via the Hacken bug bounty program as a remote DoS vector: a peer sends a `SeenTx` message with a non-empty `Signer`, the CAT reactor calls `querySequenceFromApplication`, which triggers the bug over the socket transport.
- **Real-world impact is low** because celestia-app (and Cosmos SDK apps in general) use the in-process local ABCI client, not the socket transport. The local client calls `QuerySequence` directly and is unaffected.
- The fix adds the missing case to `resMatchesReq`. A regression test (`TestQuerySequenceCrashesSocketClient`) is included.

## Test plan

- [x] `TestQuerySequenceCrashesSocketClient` — calls `QuerySequence` over the socket transport and verifies the client remains healthy
- [ ] Existing socket client tests still pass (`go test ./abci/client/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
