### PR TITLE
fix: bump Go to 1.25.8 to resolve stdlib vulnerabilities

### DIFF
--- a/.changelog/unreleased/bug-fixes/bump-go-1.25.8.md
+++ b/.changelog/unreleased/bug-fixes/bump-go-1.25.8.md
@@ -1,0 +1,2 @@
+- Bump Go version from 1.25.7 to 1.25.8 to fix 5 stdlib vulnerabilities
+  (GO-2026-4599, GO-2026-4600, GO-2026-4601, GO-2026-4602, GO-2026-4603).

--- a/.changelog/unreleased/bug-fixes/bump-go-1.26.1.md
+++ b/.changelog/unreleased/bug-fixes/bump-go-1.26.1.md
@@ -1,2 +1,2 @@
-- Bump Go version from 1.25.7 to 1.25.8 to fix 5 stdlib vulnerabilities
+- Bump Go version from 1.25.7 to 1.26.1 to fix 5 stdlib vulnerabilities
   (GO-2026-4599, GO-2026-4600, GO-2026-4601, GO-2026-4602, GO-2026-4603).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.25.8
+go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -22,7 +22,7 @@ func TestWebsocketManagerHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	if got, want := dialResp.StatusCode, http.StatusSwitchingProtocols; got != want {
-		t.Errorf("dialResp.StatusCode = %q, want %q", got, want)
+		t.Errorf("dialResp.StatusCode = %d, want %d", got, want)
 	}
 
 	// check basic functionality works

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.25.8
+FROM golang:1.26.1
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -359,7 +359,7 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 	for heightStr, validators := range manifest.ValidatorUpdates {
 		height, err := strconv.Atoi(heightStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid validator update height %q: %w", height, err)
+			return nil, fmt.Errorf("invalid validator update height %q: %w", heightStr, err)
 		}
 		valUpdate := map[*Node]int64{}
 		for name, power := range validators {


### PR DESCRIPTION
## Summary

- Bumps Go from 1.25.7 to 1.25.8 to fix 5 standard library vulnerabilities flagged by govulncheck in CI
- Updates `go.mod` and `test/e2e/docker/Dockerfile`

### Vulnerabilities resolved

| ID | Package | Description |
|----|---------|-------------|
| GO-2026-4603 | `html/template` | URLs in meta content attribute actions are not escaped |
| GO-2026-4602 | `os` | FileInfo can escape from a Root |
| GO-2026-4601 | `net/url` | Incorrect parsing of IPv6 host literals |
| GO-2026-4600 | `crypto/x509` | Panic in name constraint checking for malformed certificates |
| GO-2026-4599 | `crypto/x509` | Incorrect enforcement of email constraints |

## Test plan

- [ ] CI govulncheck job passes
- [ ] All existing tests pass with Go 1.25.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
