### PR TITLE
fix: strip BlobTx wrappers in ExecCommitBlock during crash replay

### DIFF
--- a/.changelog/unreleased/bug-fixes/2843-exec-commit-block-blobtx-stripping.md
+++ b/.changelog/unreleased/bug-fixes/2843-exec-commit-block-blobtx-stripping.md
@@ -1,0 +1,3 @@
+- Strip BlobTx wrappers in `ExecCommitBlock` to match `applyBlock` behavior,
+  fixing a crash recovery replay determinism issue where different transaction
+  bytes were sent to `FinalizeBlock` during replay vs normal execution.

--- a/state/execution.go
+++ b/state/execution.go
@@ -876,6 +876,17 @@ func ExecCommitBlock(
 	commitInfo := buildLastCommitInfoFromStore(block, store, initialHeight)
 	pbHeader := block.Header.ToProto()
 
+	// Unmarshal blob txs to match the behavior of applyBlock, which strips
+	// BlobTx wrappers before sending transactions to FinalizeBlock.
+	txs := make([][]byte, len(block.Txs))
+	for i, tx := range block.Txs {
+		blobTx, isBlobTx := types.UnmarshalBlobTx(tx)
+		if isBlobTx {
+			tx = blobTx.Tx
+		}
+		txs[i] = tx
+	}
+
 	resp, err := appConnConsensus.FinalizeBlock(context.TODO(), &abci.RequestFinalizeBlock{
 		Hash:               block.Hash(),
 		NextValidatorsHash: block.NextValidatorsHash,
@@ -884,7 +895,7 @@ func ExecCommitBlock(
 		Time:               block.Time,
 		DecidedLastCommit:  commitInfo,
 		Misbehavior:        block.Evidence.Evidence.ToABCI(),
-		Txs:                block.Txs.ToSliceOfBytes(),
+		Txs:                txs,
 
 		// needed for v3 to sync with multiplexer as the header is stored in state
 		Header: pbHeader,

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -1,9 +1,9 @@
 package state_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"bytes"
 	"testing"
 	"time"
 

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -3,9 +3,11 @@ package state_test
 import (
 	"context"
 	"errors"
+	"bytes"
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/go-square/v3/share"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -75,6 +77,119 @@ func TestApplyBlock(t *testing.T) {
 
 	// TODO check state and mempool
 	assert.EqualValues(t, 1, state.Version.Consensus.App, "App version wasn't updated")
+}
+
+// txCapturingApp is a test ABCI application that records the transactions
+// received in FinalizeBlock so they can be inspected in tests.
+type txCapturingApp struct {
+	abci.BaseApplication
+	CapturedTxs [][]byte
+}
+
+func (app *txCapturingApp) FinalizeBlock(_ context.Context, req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+	app.CapturedTxs = make([][]byte, len(req.Txs))
+	copy(app.CapturedTxs, req.Txs)
+	txResults := make([]*abci.ExecTxResult, len(req.Txs))
+	for i := range req.Txs {
+		txResults[i] = &abci.ExecTxResult{Code: abci.CodeTypeOK}
+	}
+	return &abci.ResponseFinalizeBlock{
+		TxResults: txResults,
+		AppHash:   []byte("apphash"),
+		ConsensusParamUpdates: &cmtproto.ConsensusParams{
+			Version: &cmtproto.VersionParams{App: 1},
+		},
+	}, nil
+}
+
+func (app *txCapturingApp) Commit(_ context.Context, _ *abci.RequestCommit) (*abci.ResponseCommit, error) {
+	return &abci.ResponseCommit{RetainHeight: 1}, nil
+}
+
+// TestExecCommitBlockBlobTxStripping verifies that ExecCommitBlock strips
+// BlobTx wrappers before sending transactions to FinalizeBlock, matching
+// the behavior of applyBlock. This is critical for crash recovery replay
+// determinism: if ExecCommitBlock sends raw BlobTx bytes while applyBlock
+// sends unwrapped inner transactions, the application will compute a
+// different AppHash during replay, causing a panic.
+func TestExecCommitBlockBlobTxStripping(t *testing.T) {
+	// Create a BlobTx: an inner transaction wrapped with blob metadata
+	innerTx := []byte("inner-tx-bytes")
+	namespaceID := bytes.Repeat([]byte{1}, share.NamespaceIDSize)
+	blob := &cmtproto.Blob{
+		NamespaceId:      namespaceID,
+		Data:             []byte("blob-data"),
+		ShareVersion:     0,
+		NamespaceVersion: 0,
+	}
+	wrappedBlobTx, err := types.MarshalBlobTx(innerTx, blob)
+	require.NoError(t, err)
+
+	// Verify it's a valid BlobTx
+	blobTx, isBlobTx := types.UnmarshalBlobTx(wrappedBlobTx)
+	require.True(t, isBlobTx)
+	require.Equal(t, innerTx, blobTx.Tx)
+
+	// --- Path 1: ApplyBlock (normal execution) ---
+	applyApp := &txCapturingApp{}
+	cc1 := proxy.NewLocalClientCreator(applyApp)
+	proxyApp1 := proxy.NewAppConns(cc1, proxy.NopMetrics())
+	err = proxyApp1.Start()
+	require.NoError(t, err)
+	defer proxyApp1.Stop() //nolint:errcheck
+
+	state, stateDB, _ := makeState(1, 1)
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{DiscardABCIResponses: false})
+	blockStore := store.NewBlockStore(dbm.NewMemDB())
+
+	mp := &mpmocks.Mempool{}
+	mp.On("Lock").Return()
+	mp.On("Unlock").Return()
+	mp.On("FlushAppConn", mock.Anything).Return(nil)
+	mp.On("Update",
+		mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp1.Consensus(),
+		mp, sm.EmptyEvidencePool{}, blockStore)
+
+	// Create a block containing the BlobTx
+	block, bps, err := state.MakeBlock(1, types.MakeData(types.Txs{wrappedBlobTx}), new(types.Commit), nil, state.Validators.GetProposer().Address)
+	require.NoError(t, err)
+	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+
+	_, err = blockExec.ApplyBlock(state, blockID, block, nil)
+	require.NoError(t, err)
+
+	applyTxs := applyApp.CapturedTxs
+	require.Len(t, applyTxs, 1)
+
+	// --- Path 2: ExecCommitBlock (crash replay) ---
+	replayApp := &txCapturingApp{}
+	cc2 := proxy.NewLocalClientCreator(replayApp)
+	proxyApp2 := proxy.NewAppConns(cc2, proxy.NopMetrics())
+	err = proxyApp2.Start()
+	require.NoError(t, err)
+	defer proxyApp2.Stop() //nolint:errcheck
+
+	_, err = sm.ExecCommitBlock(proxyApp2.Consensus(), block, log.TestingLogger(), stateStore, 1)
+	require.NoError(t, err)
+
+	replayTxs := replayApp.CapturedTxs
+	require.Len(t, replayTxs, 1)
+
+	// The critical assertion: both paths must send the same transaction bytes
+	// to FinalizeBlock. If ExecCommitBlock doesn't strip BlobTx wrappers,
+	// it will send the raw wrapped bytes instead of the inner transaction.
+	assert.Equal(t, applyTxs[0], replayTxs[0],
+		"ExecCommitBlock sent different tx bytes to FinalizeBlock than ApplyBlock. "+
+			"ApplyBlock sent the unwrapped inner tx (%d bytes) but ExecCommitBlock sent raw BlobTx (%d bytes). "+
+			"This causes AppHash mismatch during crash recovery replay.",
+		len(applyTxs[0]), len(replayTxs[0]))
+
+	// Additionally verify that what was sent is the inner tx, not the wrapped BlobTx
+	assert.Equal(t, innerTx, applyTxs[0], "ApplyBlock should send unwrapped inner tx")
+	assert.Equal(t, innerTx, replayTxs[0], "ExecCommitBlock should send unwrapped inner tx")
 }
 
 // TestFinalizeBlockDecidedLastCommit ensures we correctly send the


### PR DESCRIPTION
Fixes https://dashboard.hackenproof.com/manager/companies/celestia/celestia/reports/CELESTIA-215

## Summary
- `ExecCommitBlock` (used during crash recovery replay) was sending raw BlobTx-wrapped transactions to `FinalizeBlock`, while `applyBlock` (normal execution) strips the wrappers and sends only inner transactions
- This inconsistency causes the application to compute a different `AppHash` during replay, preventing recovery when the app is multiple blocks behind the store
- Added the same BlobTx stripping loop from `applyBlock` to `ExecCommitBlock`

## Test plan
- [x] Added `TestExecCommitBlockBlobTxStripping` that verifies both `ApplyBlock` and `ExecCommitBlock` send identical transaction bytes to `FinalizeBlock`
- [ ] Existing `TestFinalizeBlockValidators` and `TestApplyBlock` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
