### PR TITLE
fix: prevent CompactBlock.Proofs() cache poisoning on validation failure

### DIFF
--- a/consensus/propagation/types/types.go
+++ b/consensus/propagation/types/types.go
@@ -206,22 +206,23 @@ func (c *CompactBlock) Proofs() ([]*merkle.Proof, error) {
 		return nil, errors.New("invalid number of partset hashes")
 	}
 
-	c.proofsCache = make([]*merkle.Proof, 0, len(c.PartsHashes))
+	tempProofs := make([]*merkle.Proof, 0, len(c.PartsHashes))
 
 	root, proofs := merkle.ParallelProofsFromLeafHashes(c.PartsHashes[:total])
-	c.proofsCache = append(c.proofsCache, proofs...)
+	tempProofs = append(tempProofs, proofs...)
 
 	if !bytes.Equal(root, c.Proposal.BlockID.PartSetHeader.Hash) {
-		return c.proofsCache, fmt.Errorf("incorrect PartsHash: original root")
+		return nil, fmt.Errorf("incorrect PartsHash: original root")
 	}
 
 	parityRoot, eproofs := merkle.ParallelProofsFromLeafHashes(c.PartsHashes[total:])
-	c.proofsCache = append(c.proofsCache, eproofs...)
+	tempProofs = append(tempProofs, eproofs...)
 
 	if !bytes.Equal(c.BpHash, parityRoot) {
-		return c.proofsCache, fmt.Errorf("incorrect PartsHash: parity root")
+		return nil, fmt.Errorf("incorrect PartsHash: parity root")
 	}
 
+	c.proofsCache = tempProofs
 	return c.proofsCache, nil
 }
 

--- a/consensus/propagation/types/types_test.go
+++ b/consensus/propagation/types/types_test.go
@@ -876,6 +876,107 @@ func TestRecoveryPart_ValidateBasic(t *testing.T) {
 	}
 }
 
+// TestProofsCachePoisoning verifies that Proofs() does not cache invalid proofs.
+// If the root hash verification fails on the first call, subsequent calls must
+// also return an error rather than serving the invalid proofs from cache.
+func TestProofsCachePoisoning(t *testing.T) {
+	const numParts = 4
+
+	// Generate valid leaf hashes and compute the correct Merkle roots.
+	originalHashes := make([][]byte, numParts)
+	parityHashes := make([][]byte, numParts)
+	for i := 0; i < numParts; i++ {
+		originalHashes[i] = rand.Bytes(tmhash.Size)
+		parityHashes[i] = rand.Bytes(tmhash.Size)
+	}
+
+	originalRoot, _ := merkle.ParallelProofsFromLeafHashes(originalHashes)
+	parityRoot, _ := merkle.ParallelProofsFromLeafHashes(parityHashes)
+
+	t.Run("original root mismatch poisons cache", func(t *testing.T) {
+		// Use manipulated original hashes so the computed root won't match.
+		manipulatedOriginal := make([][]byte, numParts)
+		for i := 0; i < numParts; i++ {
+			manipulatedOriginal[i] = rand.Bytes(tmhash.Size)
+		}
+
+		cb := &CompactBlock{
+			Proposal: types.Proposal{
+				BlockID: types.BlockID{
+					PartSetHeader: types.PartSetHeader{
+						Total: uint32(numParts),
+						Hash:  originalRoot, // correct root
+					},
+				},
+			},
+			BpHash:      parityRoot,
+			PartsHashes: append(manipulatedOriginal, parityHashes...), // wrong original hashes
+		}
+
+		// First call: should fail because manipulated hashes don't match originalRoot.
+		_, err := cb.Proofs()
+		require.Error(t, err, "first call should return an error for root hash mismatch")
+
+		// Second call: must also fail. This is the bug — without the fix,
+		// proofsCache is non-nil so Proofs() returns (cache, nil).
+		_, err = cb.Proofs()
+		require.Error(t, err, "second call must also return an error; cache should not hide the failure")
+	})
+
+	t.Run("parity root mismatch poisons cache", func(t *testing.T) {
+		// Use manipulated parity hashes so the computed parity root won't match.
+		manipulatedParity := make([][]byte, numParts)
+		for i := 0; i < numParts; i++ {
+			manipulatedParity[i] = rand.Bytes(tmhash.Size)
+		}
+
+		cb := &CompactBlock{
+			Proposal: types.Proposal{
+				BlockID: types.BlockID{
+					PartSetHeader: types.PartSetHeader{
+						Total: uint32(numParts),
+						Hash:  originalRoot, // correct root
+					},
+				},
+			},
+			BpHash:      parityRoot,                                    // correct parity root
+			PartsHashes: append(originalHashes, manipulatedParity...), // wrong parity hashes
+		}
+
+		// First call: original root matches, but parity root will not.
+		_, err := cb.Proofs()
+		require.Error(t, err, "first call should return an error for parity root mismatch")
+
+		// Second call: must also fail.
+		_, err = cb.Proofs()
+		require.Error(t, err, "second call must also return an error; cache should not hide the failure")
+	})
+
+	t.Run("valid compact block still works", func(t *testing.T) {
+		cb := &CompactBlock{
+			Proposal: types.Proposal{
+				BlockID: types.BlockID{
+					PartSetHeader: types.PartSetHeader{
+						Total: uint32(numParts),
+						Hash:  originalRoot,
+					},
+				},
+			},
+			BpHash:      parityRoot,
+			PartsHashes: append(originalHashes, parityHashes...),
+		}
+
+		proofs, err := cb.Proofs()
+		require.NoError(t, err)
+		require.Len(t, proofs, numParts*ParityRatio)
+
+		// Second call should also succeed from cache.
+		proofs2, err := cb.Proofs()
+		require.NoError(t, err)
+		require.Equal(t, proofs, proofs2)
+	})
+}
+
 func makeBlockID(hash []byte, partSetSize uint32, partSetHash []byte) types.BlockID {
 	var (
 		h   = make([]byte, tmhash.Size)

--- a/consensus/propagation/types/types_test.go
+++ b/consensus/propagation/types/types_test.go
@@ -894,11 +894,12 @@ func TestProofsCachePoisoning(t *testing.T) {
 	parityRoot, _ := merkle.ParallelProofsFromLeafHashes(parityHashes)
 
 	t.Run("original root mismatch poisons cache", func(t *testing.T) {
-		// Use manipulated original hashes so the computed root won't match.
-		manipulatedOriginal := make([][]byte, numParts)
+		// Build PartsHashes with manipulated original hashes so the computed root won't match.
+		partsHashes := make([][]byte, numParts*ParityRatio)
 		for i := 0; i < numParts; i++ {
-			manipulatedOriginal[i] = rand.Bytes(tmhash.Size)
+			partsHashes[i] = rand.Bytes(tmhash.Size) // manipulated
 		}
+		copy(partsHashes[numParts:], parityHashes)
 
 		cb := &CompactBlock{
 			Proposal: types.Proposal{
@@ -910,7 +911,7 @@ func TestProofsCachePoisoning(t *testing.T) {
 				},
 			},
 			BpHash:      parityRoot,
-			PartsHashes: append(manipulatedOriginal, parityHashes...), // wrong original hashes
+			PartsHashes: partsHashes,
 		}
 
 		// First call: should fail because manipulated hashes don't match originalRoot.
@@ -924,10 +925,11 @@ func TestProofsCachePoisoning(t *testing.T) {
 	})
 
 	t.Run("parity root mismatch poisons cache", func(t *testing.T) {
-		// Use manipulated parity hashes so the computed parity root won't match.
-		manipulatedParity := make([][]byte, numParts)
+		// Build PartsHashes with correct original hashes but manipulated parity hashes.
+		partsHashes := make([][]byte, numParts*ParityRatio)
+		copy(partsHashes, originalHashes)
 		for i := 0; i < numParts; i++ {
-			manipulatedParity[i] = rand.Bytes(tmhash.Size)
+			partsHashes[numParts+i] = rand.Bytes(tmhash.Size) // manipulated
 		}
 
 		cb := &CompactBlock{
@@ -935,12 +937,12 @@ func TestProofsCachePoisoning(t *testing.T) {
 				BlockID: types.BlockID{
 					PartSetHeader: types.PartSetHeader{
 						Total: uint32(numParts),
-						Hash:  originalRoot, // correct root
+						Hash:  originalRoot,
 					},
 				},
 			},
-			BpHash:      parityRoot,                                    // correct parity root
-			PartsHashes: append(originalHashes, manipulatedParity...), // wrong parity hashes
+			BpHash:      parityRoot,
+			PartsHashes: partsHashes,
 		}
 
 		// First call: original root matches, but parity root will not.
@@ -953,6 +955,10 @@ func TestProofsCachePoisoning(t *testing.T) {
 	})
 
 	t.Run("valid compact block still works", func(t *testing.T) {
+		partsHashes := make([][]byte, numParts*ParityRatio)
+		copy(partsHashes, originalHashes)
+		copy(partsHashes[numParts:], parityHashes)
+
 		cb := &CompactBlock{
 			Proposal: types.Proposal{
 				BlockID: types.BlockID{
@@ -963,7 +969,7 @@ func TestProofsCachePoisoning(t *testing.T) {
 				},
 			},
 			BpHash:      parityRoot,
-			PartsHashes: append(originalHashes, parityHashes...),
+			PartsHashes: partsHashes,
 		}
 
 		proofs, err := cb.Proofs()


### PR DESCRIPTION
Fixes https://dashboard.hackenproof.com/manager/companies/celestia/celestia/reports/CELESTIA-216

## Summary

- `CompactBlock.Proofs()` populated `proofsCache` before verifying Merkle root hashes. When verification failed, the non-nil cache caused subsequent calls to return invalid proofs with a nil error, bypassing the integrity check.
- Fix uses a temporary slice during computation and only commits to `proofsCache` after both root hash validations pass.
- Adds `TestProofsCachePoisoning` covering original root mismatch, parity root mismatch, and valid block (regression) cases.

## Test plan

- [x] `TestProofsCachePoisoning/original_root_mismatch_poisons_cache` — verifies second call still returns error
- [x] `TestProofsCachePoisoning/parity_root_mismatch_poisons_cache` — verifies parity path
- [x] `TestProofsCachePoisoning/valid_compact_block_still_works` — regression for happy path + cache reuse
- [x] Full `consensus/propagation/types` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
