### PR TITLE
fix: increase base ensureTimeout from 200ms to 400ms

### DIFF
--- a/.changelog/unreleased/improvements/ci-consensus-test-timeouts.md
+++ b/.changelog/unreleased/improvements/ci-consensus-test-timeouts.md
@@ -1,1 +1,1 @@
-Scale consensus test timeouts by 3x when running in CI to reduce flaky test failures.
+Increase consensus test base ensureTimeout from 200ms to 400ms to reduce flaky test failures.

--- a/.changelog/unreleased/improvements/ci-consensus-test-timeouts.md
+++ b/.changelog/unreleased/improvements/ci-consensus-test-timeouts.md
@@ -1,0 +1,1 @@
+Scale consensus test timeouts by 3x when running in CI to reduce flaky test failures.

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -61,6 +61,16 @@ var (
 	ensureProposalTimeout = ensureTimeout * 5 // proposals can be delayed by TimeoutCommit and scheduling jitter
 )
 
+func init() {
+	// CI runners are slower, especially with the race detector enabled.
+	// Scale timeouts to reduce flaky test failures.
+	if os.Getenv("CI") != "" {
+		ensureTimeout *= 3
+		ensureVoteTimeout *= 3
+		ensureProposalTimeout *= 3
+	}
+}
+
 func ensureDir(dir string, mode os.FileMode) {
 	if err := cmtos.EnsureDir(dir, mode); err != nil {
 		panic(err)

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -56,20 +56,10 @@ type cleanupFunc func()
 var (
 	config                *cfg.Config // NOTE: must be reset for each _test.go file
 	consensusReplayConfig *cfg.Config
-	ensureTimeout         = time.Millisecond * 200
+	ensureTimeout         = time.Millisecond * 400
 	ensureVoteTimeout     = time.Second * 2   // votes need longer timeout on slow CI with race detector
 	ensureProposalTimeout = ensureTimeout * 5 // proposals can be delayed by TimeoutCommit and scheduling jitter
 )
-
-func init() {
-	// CI runners are slower, especially with the race detector enabled.
-	// Scale timeouts to reduce flaky test failures.
-	if os.Getenv("CI") != "" {
-		ensureTimeout *= 3
-		ensureVoteTimeout *= 3
-		ensureProposalTimeout *= 3
-	}
-}
 
 func ensureDir(dir string, mode os.FileMode) {
 	if err := cmtos.EnsureDir(dir, mode); err != nil {


### PR DESCRIPTION
## Summary

Increases the base `ensureTimeout` in consensus tests from 200ms to 400ms. This also raises `ensureProposalTimeout` (defined as `ensureTimeout * 5`) from 1s to 2s. `ensureVoteTimeout` stays at 2s (already adequate).

## Motivation

Celestia-core has more per-round work than upstream CometBFT:
- Propagation reactor
- CAT mempool
- App-driven timeouts

The 200ms base timeout was inherited from upstream, where it is also known to be flaky ([cometbft#1923](https://github.com/cometbft/cometbft/issues/1923)). Upstream has not resolved their consensus test flakes. A modest increase to 400ms better reflects the actual time consensus operations take in celestia-core without meaningfully slowing down the test suite.

## Test plan
- [ ] `go test -v -run TestStateFullRound1 -count=10 ./consensus/` passes
- [ ] CI passes on this PR

Refs: #2430 #1017 #2702

🤖 Generated with [Claude Code](https://claude.com/claude-code)