### PR TITLE
fix: increase TestByzantinePrevoteEquivocation timeout to reduce flakes

### DIFF
--- a/.changelog/unreleased/bug-fixes/byzantine-evidence-test-timeout.md
+++ b/.changelog/unreleased/bug-fixes/byzantine-evidence-test-timeout.md
@@ -1,0 +1,1 @@
+Increase TestByzantinePrevoteEquivocation timeout and block watch limit to reduce CI flakes.

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -317,7 +317,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				}
 
 				// Stop watching after a reasonable number of blocks to prevent hanging
-				if blockCount >= 30 {
+				if blockCount >= 50 {
 					t.Logf("Validator %d watched %d blocks without finding evidence", i, blockCount)
 					return
 				}
@@ -336,8 +336,8 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		assert.Equal(t, pubkey.Address(), ev.VoteA.ValidatorAddress)
 		assert.Equal(t, prevoteHeight, ev.Height())
 		t.Logf("Successfully found evidence: %v", ev)
-	case <-time.After(60 * time.Second):
-		t.Fatalf("Timed out waiting for validators to commit evidence after 60 seconds")
+	case <-time.After(120 * time.Second):
+		t.Fatalf("Timed out waiting for validators to commit evidence after 120 seconds")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Increase overall test timeout from 60s to 120s
- Increase per-validator block watch limit from 30 to 50 blocks
- Evidence propagation takes longer on slow CI runners, causing this test to time out before evidence appears in a block

## Test plan
- [ ] `go test -v -run TestByzantinePrevoteEquivocation -count=3 ./consensus/` passes locally
- [ ] CI passes on this PR

Refs: #2200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
