### PR TITLE
fix: use dynamic ports in node tests to prevent port conflicts

### DIFF
--- a/.changelog/unreleased/bug-fixes/node-test-port-conflicts.md
+++ b/.changelog/unreleased/bug-fixes/node-test-port-conflicts.md
@@ -1,0 +1,1 @@
+Use dynamic port allocation in node tests to prevent "address already in use" flakes.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -38,6 +38,7 @@ import (
 func TestNodeStartStop(t *testing.T) {
 	config := test.ResetTestRoot("node_node_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 
 	// create & start node
 	n, err := DefaultNewNode(config, log.TestingLogger())
@@ -100,6 +101,7 @@ func TestSplitAndTrimEmpty(t *testing.T) {
 func TestNodeDelayedStart(t *testing.T) {
 	config := test.ResetTestRoot("node_delayed_start_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 	now := cmttime.Now()
 
 	// create & start node
@@ -118,6 +120,7 @@ func TestNodeDelayedStart(t *testing.T) {
 func TestNodeSetAppVersion(t *testing.T) {
 	config := test.ResetTestRoot("node_app_version_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 
 	// create & start node
 	n, err := DefaultNewNode(config, log.TestingLogger())
@@ -138,6 +141,7 @@ func TestNodeSetAppVersion(t *testing.T) {
 func TestPprofServer(t *testing.T) {
 	config := test.ResetTestRoot("node_pprof_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 	config.RPC.PprofListenAddress = testFreeAddr(t)
 
 	// should not work yet
@@ -163,6 +167,7 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 
 	config := test.ResetTestRoot("node_priv_val_tcp_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 	config.BaseConfig.PrivValidatorListenAddr = addr //nolint:staticcheck
 
 	dialer := privval.DialTCPFn(addr, 100*time.Millisecond, ed25519.GenPrivKey())
@@ -197,6 +202,7 @@ func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 
 	config := test.ResetTestRoot("node_priv_val_tcp_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 	config.BaseConfig.PrivValidatorListenAddr = addrNoPrefix //nolint:staticcheck
 
 	_, err := DefaultNewNode(config, log.TestingLogger())
@@ -209,6 +215,7 @@ func TestNodeSetPrivValIPC(t *testing.T) {
 
 	config := test.ResetTestRoot("node_priv_val_tcp_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 	config.BaseConfig.PrivValidatorListenAddr = "unix://" + tmpfile //nolint:staticcheck
 
 	dialer := privval.DialUnixFn(tmpfile)
@@ -242,6 +249,16 @@ func testFreeAddr(t *testing.T) string {
 	defer ln.Close()
 
 	return fmt.Sprintf("127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
+}
+
+// testFreeConfig overrides the default test config to use free ports
+// instead of hardcoded ports that cause "address already in use" errors
+// when tests run in parallel.
+func testFreeConfig(t *testing.T, config *cfg.Config) {
+	t.Helper()
+	config.P2P.ListenAddress = "tcp://" + testFreeAddr(t)
+	config.RPC.ListenAddress = "tcp://" + testFreeAddr(t)
+	config.RPC.GRPCListenAddress = "tcp://" + testFreeAddr(t)
 }
 
 // create a proposal block using real and full
@@ -429,6 +446,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 func TestNodeNewNodeCustomReactors(t *testing.T) {
 	config := test.ResetTestRoot("node_new_node_custom_reactors_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 
 	cr := p2pmock.NewReactor()
 	cr.Channels = []*conn.ChannelDescriptor{


### PR DESCRIPTION
## Summary
- Add `testFreeConfig` helper that overrides hardcoded test ports (36656-36658) with dynamically allocated free ports
- Apply to all node tests that create a `Node` instance
- Prevents `bind: address already in use` flakes when tests run in parallel

## Test plan
- [ ] `go test -v -count=5 ./node/...` passes without port conflicts
- [ ] CI passes on this PR

Refs: #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
