### PR TITLE
fix: enforce maxRequestsPerPeer on direct SeenTx path in CAT mempool

### DIFF
--- a/.changelog/unreleased/bug-fixes/seentx-per-peer-request-limit.md
+++ b/.changelog/unreleased/bug-fixes/seentx-per-peer-request-limit.md
@@ -1,0 +1,3 @@
+- Enforce `maxRequestsPerPeer` on the direct SeenTx→requestTx path in the
+  CAT mempool reactor. Previously, a peer could bypass the 30-request per-peer
+  cap by sending SeenTx messages without signer/sequence information.

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -422,7 +422,17 @@ func (memR *Reactor) Receive(e p2p.Envelope) {
 		}
 
 		// We don't have the transaction, nor are we requesting it so we send the node
-		// a want msg
+		// a want msg. Enforce the per-peer request limit so a single peer cannot
+		// drive unbounded outstanding requests via the direct SeenTx path.
+		if memR.requests.CountForPeer(peerID) >= maxRequestsPerPeer {
+			memR.Logger.Debug(
+				"not requesting tx from peer: at capacity",
+				"peer", peerID,
+				"txKey", txKey,
+				"maxRequestsPerPeer", maxRequestsPerPeer,
+			)
+			return
+		}
 		memR.requestTx(txKey, e.Src)
 
 	// A peer is requesting a transaction that we have claimed to have. Find the specified

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -1516,3 +1516,48 @@ func TestSeenTxWithEmptySignerNotBanned(t *testing.T) {
 	// The peer should NOT be disconnected for empty signer
 	require.Len(t, reactor0.Switch.Peers().List(), 1, "peer should not be disconnected for empty signer")
 }
+
+// TestSeenTxDirectPathEnforcesPerPeerRequestLimit verifies that the direct
+// SeenTx→requestTx code path enforces the maxRequestsPerPeer limit. A single
+// peer sending more than maxRequestsPerPeer unique SeenTx messages (with nil
+// signer / zero sequence) should NOT result in more than maxRequestsPerPeer
+// outstanding requests to that peer.
+func TestSeenTxDirectPathEnforcesPerPeerRequestLimit(t *testing.T) {
+	reactor, _ := setupReactor(t)
+
+	peer := genPeer()
+	// Allow unlimited WantTx sends (we're counting how many get through)
+	peer.On("TrySend", mock.MatchedBy(func(env p2p.Envelope) bool {
+		return env.ChannelID == MempoolWantsChannel
+	})).Return(true)
+
+	_, err := reactor.InitPeer(peer)
+	require.NoError(t, err)
+	peerID := reactor.ids.GetIDForPeer(peer.ID())
+
+	totalMessages := maxRequestsPerPeer * 4 // 120 messages from one peer
+
+	for i := 0; i < totalMessages; i++ {
+		tx := types.Tx(fmt.Sprintf("fake-seen-tx-%d", i))
+		key := tx.Key()
+		reactor.Receive(p2p.Envelope{
+			ChannelID: MempoolDataChannel,
+			Message: &protomem.SeenTx{
+				TxKey:    key[:],
+				Signer:   nil,
+				Sequence: 0,
+			},
+			Src: peer,
+		})
+	}
+
+	requestCount := reactor.requests.CountForPeer(peerID)
+	t.Logf("peer=%d requests=%d maxRequestsPerPeer=%d", peerID, requestCount, maxRequestsPerPeer)
+
+	// The per-peer request limit should be enforced on the direct SeenTx path.
+	// If this assertion fails, it means the SeenTx handler is calling requestTx
+	// without checking maxRequestsPerPeer first.
+	assert.LessOrEqual(t, requestCount, maxRequestsPerPeer,
+		"SeenTx direct path should not exceed maxRequestsPerPeer (%d) but got %d requests",
+		maxRequestsPerPeer, requestCount)
+}


### PR DESCRIPTION
## Summary

- Enforce `maxRequestsPerPeer` check before calling `requestTx` on the direct SeenTx handler path (when signer/sequence info is missing)
- Previously a single peer could bypass the intended 30-request per-peer cap by sending SeenTx messages with nil signer and zero sequence
- Add regression test `TestSeenTxDirectPathEnforcesPerPeerRequestLimit`

## Test plan

- [x] New test `TestSeenTxDirectPathEnforcesPerPeerRequestLimit` fails before fix (120 requests) and passes after (capped at 30)
- [x] All existing `mempool/cat` tests pass

Closes https://dashboard.hackenproof.com/manager/companies/celestia/celestia/reports/CELESTIA-235
Closes https://linear.app/celestia/issue/PROTOCO-1295/triage-celestia-235-should-be-treated-as-main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
