### PR TITLE
fix: guard nil syncer dereference in statesync Reactor.Receive

### DIFF
--- a/.changelog/unreleased/bug-fixes/statesync-nil-syncer-panic.md
+++ b/.changelog/unreleased/bug-fixes/statesync-nil-syncer-panic.md
@@ -1,0 +1,3 @@
+- `[statesync]` Guard against nil syncer dereference in Reactor.Receive
+  when processing oversized SnapshotsResponse messages while no state sync
+  is in progress.

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -115,7 +115,11 @@ func (r *Reactor) Receive(e p2p.Envelope) {
 	err := validateMsg(e.Message, r.cfg.MaxSnapshotChunks)
 	if err != nil {
 		if errors.Is(err, ErrExceedsMaxSnapshotChunks) {
-			r.syncer.RejectPeer(e.Src)
+			r.mtx.RLock()
+			if r.syncer != nil {
+				r.syncer.RejectPeer(e.Src)
+			}
+			r.mtx.RUnlock()
 		}
 		r.Logger.Error("Invalid message", "peer", e.Src, "msg", e.Message, "err", err)
 		r.Switch.StopPeerForError(e.Src, err, r.String())

--- a/statesync/reactor_test.go
+++ b/statesync/reactor_test.go
@@ -1,6 +1,7 @@
 package statesync
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -94,6 +95,61 @@ func TestReactor_Receive_ChunkRequest(t *testing.T) {
 			peer.AssertExpectations(t)
 		})
 	}
+}
+
+// TestReactor_Receive_OversizedSnapshotResponse_NilSyncer verifies that
+// receiving a SnapshotsResponse with Chunks > MaxSnapshotChunks does not
+// nil-dereference r.syncer when no state sync is in progress.
+func TestReactor_Receive_OversizedSnapshotResponse_NilSyncer(t *testing.T) {
+	cfg := config.DefaultStateSyncConfig()
+	conn := &proxymocks.AppConnSnapshot{}
+
+	peer := &p2pmocks.Peer{}
+	peer.On("ID").Return(p2p.ID("attacker"))
+	peer.On("IsRunning").Return(true)
+	peer.On("Stop").Return(nil)
+	peer.On("FlushStop").Return()
+	peer.On("String").Return("peer-attacker")
+	peer.On("RemoteAddr").Return(&net.TCPAddr{IP: net.IP{127, 0, 0, 1}, Port: 26656})
+	peer.On("CloseConn").Return(nil)
+	peer.On("NodeInfo").Return(p2p.DefaultNodeInfo{})
+	peer.On("SetRemovalFailed").Return()
+	peer.On("GetRemovalFailed").Return(false)
+	peer.On("IsPersistent").Return(false)
+	peer.On("IsOutbound").Return(false)
+	peer.On("SocketAddr").Return(nil)
+	peer.On("HasIPChanged").Return(false)
+
+	r := NewReactor(*cfg, conn, nil, NopMetrics())
+
+	sw := p2p.MakeSwitch(
+		config.DefaultP2PConfig(),
+		0,
+		func(i int, sw *p2p.Switch) *p2p.Switch { return sw },
+	)
+	r.SetSwitch(sw)
+
+	err := r.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := r.Stop(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	// This should NOT panic even though r.syncer is nil.
+	require.NotPanics(t, func() {
+		r.Receive(p2p.Envelope{
+			ChannelID: SnapshotChannel,
+			Src:       peer,
+			Message: &ssproto.SnapshotsResponse{
+				Height: 1,
+				Format: 1,
+				Chunks: cfg.MaxSnapshotChunks + 1,
+				Hash:   []byte{1},
+			},
+		})
+	})
 }
 
 func TestReactor_Receive_SnapshotsRequest(t *testing.T) {


### PR DESCRIPTION
Closes https://dashboard.hackenproof.com/manager/companies/celestia/celestia/reports/CELESTIA-239

## Summary

- A connected P2P peer could crash any non-state-syncing node (the default operating mode) by sending a single `SnapshotsResponse` with `Chunks > MaxSnapshotChunks`. The `validateMsg` error path in `Reactor.Receive` called `r.syncer.RejectPeer()` before checking whether `r.syncer` was nil, causing an unrecovered panic that terminates the node process.
- Added a nil guard with mutex protection around the `RejectPeer` call so oversized snapshot messages are safely rejected when no state sync is active.
- Added a regression test that confirms the panic without the fix and passes with it.

## Test plan

- [x] New test `TestReactor_Receive_OversizedSnapshotResponse_NilSyncer` verifies no panic when `r.syncer` is nil and an oversized `SnapshotsResponse` is received
- [x] Full `./statesync/...` test suite passes
- [x] `go vet ./statesync/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
