### PR TITLE
fix: validate PartSetHeader.Total upper bound in ValidateBasic

### DIFF
--- a/.changelog/unreleased/bug-fixes/part-set-header-total-validation.md
+++ b/.changelog/unreleased/bug-fixes/part-set-header-total-validation.md
@@ -1,0 +1,4 @@
+- Validate `PartSetHeader.Total` does not exceed
+  `MaxBlockPartsCount` in `ValidateBasic()` to prevent
+  OOM via oversized bit array allocation from malicious
+  peer proposals.

--- a/evidence/verify_test.go
+++ b/evidence/verify_test.go
@@ -364,8 +364,8 @@ func TestVerifyDuplicateVoteEvidence(t *testing.T) {
 
 	blockID := makeBlockID([]byte("blockhash"), 1000, []byte("partshash"))
 	blockID2 := makeBlockID([]byte("blockhash2"), 1000, []byte("partshash"))
-	blockID3 := makeBlockID([]byte("blockhash"), 10000, []byte("partshash"))
-	blockID4 := makeBlockID([]byte("blockhash"), 10000, []byte("partshash2"))
+	blockID3 := makeBlockID([]byte("blockhash"), 2000, []byte("partshash"))
+	blockID4 := makeBlockID([]byte("blockhash"), 2000, []byte("partshash2"))
 
 	const chainID = "mychain"
 

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -25,8 +25,8 @@ func TestTxFilter(t *testing.T) {
 		tx    types.Tx
 		isErr bool
 	}{
-		{types.Tx(cmtrand.Bytes(2155)), false},
-		{types.Tx(cmtrand.Bytes(2156)), true},
+		{types.Tx(cmtrand.Bytes(2161)), false},
+		{types.Tx(cmtrand.Bytes(2162)), true},
 		{types.Tx(cmtrand.Bytes(3000)), true},
 	}
 

--- a/types/block.go
+++ b/types/block.go
@@ -25,7 +25,7 @@ const (
 	// MaxHeaderBytes is a maximum header size.
 	// NOTE: Because app hash can be of arbitrary size, the header is therefore not
 	// capped in size and thus this number should be seen as a soft max
-	MaxHeaderBytes int64 = 626
+	MaxHeaderBytes int64 = 623
 
 	// MaxOverheadForBlock - maximum overhead to encode a block (up to
 	// MaxBlockSizeBytes in size) not including it's parts except Data.
@@ -613,8 +613,8 @@ const (
 )
 
 const (
-	// Max size of commit without any commitSigs -> 82 for BlockID, 8 for Height, 4 for Round.
-	MaxCommitOverheadBytes int64 = 94
+	// Max size of commit without any commitSigs -> 79 for BlockID, 8 for Height, 4 for Round.
+	MaxCommitOverheadBytes int64 = 91
 	// Commit sig size is made up of 64 bytes for the signature, 20 bytes for the address,
 	// 1 byte for the flag and 14 bytes for the timestamp
 	MaxCommitSigBytes int64 = 109

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -286,7 +286,7 @@ func TestMaxCommitBytes(t *testing.T) {
 		BlockID: BlockID{
 			Hash: tmhash.Sum([]byte("blockID_hash")),
 			PartSetHeader: PartSetHeader{
-				Total: math.MaxInt32,
+				Total: MaxBlockPartsCount,
 				Hash:  tmhash.Sum([]byte("blockID_part_set_header_hash")),
 			},
 		},
@@ -411,7 +411,7 @@ func TestMaxHeaderBytes(t *testing.T) {
 		ChainID:            maxChainID,
 		Height:             math.MaxInt64,
 		Time:               timestamp,
-		LastBlockID:        makeBlockID(make([]byte, tmhash.Size), math.MaxInt32, make([]byte, tmhash.Size)),
+		LastBlockID:        makeBlockID(make([]byte, tmhash.Size), MaxBlockPartsCount, make([]byte, tmhash.Size)),
 		LastCommitHash:     tmhash.Sum([]byte("last_commit_hash")),
 		DataHash:           tmhash.Sum([]byte("data_hash")),
 		ValidatorsHash:     tmhash.Sum([]byte("validators_hash")),
@@ -458,11 +458,11 @@ func TestBlockMaxDataBytes(t *testing.T) {
 	}{
 		0: {-10, 1, 0, true, 0},
 		1: {10, 1, 0, true, 0},
-		2: {841, 1, 0, true, 0},
-		3: {842, 1, 0, false, 0},
-		4: {843, 1, 0, false, 1},
-		5: {954, 2, 0, false, 1},
-		6: {1053, 2, 100, false, 0},
+		2: {835, 1, 0, true, 0},
+		3: {836, 1, 0, false, 0},
+		4: {837, 1, 0, false, 1},
+		5: {948, 2, 0, false, 1},
+		6: {1047, 2, 100, false, 0},
 	}
 
 	for i, tc := range testCases {
@@ -489,9 +489,9 @@ func TestBlockMaxDataBytesNoEvidence(t *testing.T) {
 	}{
 		0: {-10, 1, true, 0},
 		1: {10, 1, true, 0},
-		2: {841, 1, true, 0},
-		3: {842, 1, false, 0},
-		4: {843, 1, false, 1},
+		2: {835, 1, true, 0},
+		3: {836, 1, false, 0},
+		4: {837, 1, false, 1},
 	}
 
 	for i, tc := range testCases {

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -52,8 +52,8 @@ func TestDuplicateVoteEvidence(t *testing.T) {
 
 func TestDuplicateVoteEvidenceValidation(t *testing.T) {
 	val := NewMockPV()
-	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
-	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), MaxBlockPartsCount, tmhash.Sum([]byte("partshash")))
+	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), MaxBlockPartsCount, tmhash.Sum([]byte("partshash")))
 	const chainID = "mychain"
 
 	testCases := []struct {
@@ -98,7 +98,7 @@ func TestLightClientAttackEvidenceBasic(t *testing.T) {
 	voteSet, valSet, privVals := randVoteSet(height, 1, cmtproto.PrecommitType, nValidators, 1, false)
 	header := makeHeaderRandom()
 	header.Height = height
-	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), MaxBlockPartsCount, tmhash.Sum([]byte("partshash")))
 	extCommit, err := MakeExtCommit(blockID, height, 1, voteSet, privVals, defaultVoteTime, false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
@@ -160,7 +160,7 @@ func TestLightClientAttackEvidenceValidation(t *testing.T) {
 	header := makeHeaderRandom()
 	header.Height = height
 	header.ValidatorsHash = valSet.Hash()
-	blockID := makeBlockID(header.Hash(), math.MaxInt32, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(header.Hash(), MaxBlockPartsCount, tmhash.Sum([]byte("partshash")))
 	extCommit, err := MakeExtCommit(blockID, height, 1, voteSet, privVals, time.Now(), false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
@@ -257,8 +257,8 @@ func makeHeaderRandom() *Header {
 func TestEvidenceProto(t *testing.T) {
 	// -------- Votes --------
 	val := NewMockPV()
-	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
-	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), MaxBlockPartsCount, tmhash.Sum([]byte("partshash")))
+	blockID2 := makeBlockID(tmhash.Sum([]byte("blockhash2")), MaxBlockPartsCount, tmhash.Sum([]byte("partshash")))
 	const chainID = "mychain"
 	v := MakeVoteNoError(t, val, chainID, math.MaxInt32, math.MaxInt64, 1, 0x01, blockID, defaultVoteTime)
 	v2 := MakeVoteNoError(t, val, chainID, math.MaxInt32, math.MaxInt64, 2, 0x01, blockID2, defaultVoteTime)

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -163,6 +163,9 @@ func (psh PartSetHeader) Equals(other PartSetHeader) bool {
 
 // ValidateBasic performs basic validation.
 func (psh PartSetHeader) ValidateBasic() error {
+	if psh.Total > MaxBlockPartsCount {
+		return fmt.Errorf("total %d exceeds MaxBlockPartsCount %d", psh.Total, MaxBlockPartsCount)
+	}
 	// Hash can be empty in case of POLBlockID.PartSetHeader in Proposal.
 	if err := ValidateHash(psh.Hash); err != nil {
 		return fmt.Errorf("wrong Hash: %w", err)

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -219,6 +219,8 @@ func TestPartSetHeaderValidateBasic(t *testing.T) {
 	}{
 		{"Good PartSet", func(psHeader *PartSetHeader) {}, false},
 		{"Invalid Hash", func(psHeader *PartSetHeader) { psHeader.Hash = make([]byte, 1) }, true},
+		{"Total exceeds MaxBlockPartsCount", func(psHeader *PartSetHeader) { psHeader.Total = MaxBlockPartsCount + 1 }, true},
+		{"Total is max uint32", func(psHeader *PartSetHeader) { psHeader.Total = 1<<32 - 1 }, true},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -145,7 +144,7 @@ func TestProposalValidateBasic(t *testing.T) {
 			p.Signature = make([]byte, MaxSignatureSize+1)
 		}, true},
 	}
-	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
+	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), MaxBlockPartsCount, tmhash.Sum([]byte("partshash")))
 
 	for _, tc := range testCases {
 		tc := tc

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -42,7 +42,7 @@ func exampleVote(t byte) *Vote {
 		BlockID: BlockID{
 			Hash: tmhash.Sum([]byte("blockID_hash")),
 			PartSetHeader: PartSetHeader{
-				Total: 1000000,
+				Total: 1000,
 				Hash:  tmhash.Sum([]byte("blockID_part_set_header_hash")),
 			},
 		},


### PR DESCRIPTION
Closes https://dashboard.hackenproof.com/manager/companies/celestia/celestia/reports/CELESTIA-242

## Summary

- Add `Total > MaxBlockPartsCount` check in `PartSetHeader.ValidateBasic()` to reject oversized values before any allocation occurs
- Update `MaxCommitOverheadBytes` (94→91) and `MaxHeaderBytes` (626→623) to reflect the smaller max varint encoding of `MaxBlockPartsCount` vs the previously unchecked `MaxInt32`
- Fix test fixtures that used unrealistically large `PartSetHeader.Total` values (`math.MaxInt32`, `1000000`, `10000`)
- Update `TestTxFilter` thresholds (2155/2156→2161/2162) to account for the reduced overhead constants

## Background

`PartSetHeader.ValidateBasic()` only validated the Hash field but never bounds-checked `Total`. When `enable_legacy_block_prop=true`, an attacker peer could send a `ProposalMessage` on DataChannel `0x21` with `Total=MaxUint32`. The reactor calls `SetHasProposal` at `reactor.go:419` which allocates `bits.NewBitArray(MaxUint32)` = **512MB** per connection — before the consensus state machine's bounds check at `state.go:2228` has a chance to reject it. With ~32 connections this OOMs a 16GB node.

## Test plan

- [x] `TestPartSetHeaderValidateBasic` — new cases for `Total > MaxBlockPartsCount` and `Total = MaxUint32`
- [x] `TestVerifyDuplicateVoteEvidence` — fixed part set total from 10000 to 2000 (within MaxBlockPartsCount)
- [x] `TestTxFilter` — updated tx size thresholds for reduced overhead constants
- [x] All `types/`, `evidence/`, and `state/` package tests pass
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)