### PR TITLE
fix: prevent uint32 overflow in RowProof.Validate()

### DIFF
--- a/.changelog/unreleased/bug-fixes/row-proof-uint32-overflow.md
+++ b/.changelog/unreleased/bug-fixes/row-proof-uint32-overflow.md
@@ -1,0 +1,4 @@
+- `[types]` Fix uint32 overflow in `RowProof.Validate()` that allowed an
+  empty proof to validate against any data root. Reject empty row proofs
+  and use uint64 arithmetic to prevent overflow when computing the
+  expected number of rows.

--- a/types/row_proof.go
+++ b/types/row_proof.go
@@ -33,11 +33,17 @@ type RowProof struct {
 // the proof fails validation. If the proof passes validation, this function
 // attempts to verify the proof. It returns nil if the proof is valid.
 func (rp RowProof) Validate(root []byte) error {
+	if len(rp.RowRoots) == 0 {
+		return errors.New("row proof must contain at least one row root")
+	}
 	if rp.EndRow < rp.StartRow {
 		return fmt.Errorf("end row %d cannot be less than start row %d", rp.EndRow, rp.StartRow)
 	}
-	if int(rp.EndRow-rp.StartRow+1) != len(rp.RowRoots) {
-		return fmt.Errorf("the number of rows %d must equal the number of row roots %d", int(rp.EndRow-rp.StartRow+1), len(rp.RowRoots))
+	// Use uint64 arithmetic to prevent uint32 overflow when computing the
+	// expected number of rows (e.g. StartRow=0, EndRow=MaxUint32).
+	expectedRows := uint64(rp.EndRow) - uint64(rp.StartRow) + 1
+	if expectedRows != uint64(len(rp.RowRoots)) {
+		return fmt.Errorf("the number of rows %d must equal the number of row roots %d", expectedRows, len(rp.RowRoots))
 	}
 	if len(rp.Proofs) != len(rp.RowRoots) {
 		return fmt.Errorf("the number of proofs %d must equal the number of row roots %d", len(rp.Proofs), len(rp.RowRoots))

--- a/types/row_proof_overflow_test.go
+++ b/types/row_proof_overflow_test.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"crypto/rand"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRowProofUint32Overflow verifies that a RowProof with StartRow=0 and
+// EndRow=MaxUint32 is rejected. Previously, uint32 arithmetic caused
+// EndRow - StartRow + 1 to overflow to 0, which matched len(nil)==0 and
+// allowed an empty proof to validate against any data root.
+func TestRowProofUint32Overflow(t *testing.T) {
+	rp := RowProof{
+		RowRoots: nil,
+		Proofs:   nil,
+		StartRow: 0,
+		EndRow:   math.MaxUint32,
+	}
+
+	for i := 0; i < 10; i++ {
+		root := make([]byte, 32)
+		_, err := rand.Read(root)
+		require.NoError(t, err)
+
+		err = rp.Validate(root)
+		assert.Error(t, err, "empty RowProof with overflow should be rejected for root %x", root)
+	}
+}
+
+// TestRowProofEmptyRejected confirms that an empty RowProof is always rejected,
+// even without the uint32 overflow.
+func TestRowProofEmptyRejected(t *testing.T) {
+	rp := RowProof{
+		RowRoots: nil,
+		Proofs:   nil,
+		StartRow: 0,
+		EndRow:   0,
+	}
+
+	root := make([]byte, 32)
+	_, err := rand.Read(root)
+	require.NoError(t, err)
+
+	err = rp.Validate(root)
+	assert.Error(t, err, "empty RowProof should be rejected")
+}
+
+// TestShareProofUint32Overflow verifies that the uint32 overflow in RowProof
+// does not cascade through ShareProof.Validate() to allow empty proofs.
+func TestShareProofUint32Overflow(t *testing.T) {
+	sp := ShareProof{
+		Data:        nil,
+		ShareProofs: nil,
+		NamespaceID: nil,
+		RowProof: RowProof{
+			RowRoots: nil,
+			Proofs:   nil,
+			StartRow: 0,
+			EndRow:   math.MaxUint32,
+		},
+		NamespaceVersion: 0,
+	}
+
+	for i := 0; i < 10; i++ {
+		root := make([]byte, 32)
+		_, err := rand.Read(root)
+		require.NoError(t, err)
+
+		err = sp.Validate(root)
+		assert.Error(t, err, "empty ShareProof with overflow should be rejected for root %x", root)
+	}
+}


### PR DESCRIPTION
Closes https://dashboard.hackenproof.com/manager/companies/celestia/celestia/reports/CELESTIA-243?page=1

## Summary

- Fix uint32 overflow in `RowProof.Validate()` where `StartRow=0, EndRow=MaxUint32` caused `EndRow - StartRow + 1` to overflow to `0`, allowing an empty proof to validate against any data root.
- Reject empty row proofs early with an explicit `len(rp.RowRoots) == 0` check.
- Use `uint64` arithmetic for the row count computation to prevent overflow.

## Bug Details

`RowProof.Validate()` in `types/row_proof.go` computed the expected row count using uint32 arithmetic:

```go
int(rp.EndRow - rp.StartRow + 1) != len(rp.RowRoots)
```

With `StartRow=0` and `EndRow=4294967295` (MaxUint32), the subtraction `EndRow - StartRow + 1` overflows to `0` in uint32. This matches `len(nil)==0` for an empty proof, so the check passes. `VerifyProof()` then iterates an empty slice and returns `true`.

This cascades through `ShareProof.Validate()` — with all arrays empty, every length check compares `0 == 0`. The result: `ShareProof.Validate(anyRoot)` returns `nil` for a completely empty proof against any data root.

The light client at `light/rpc/client.go:492` uses `Validate()` as the sole proof check for `Tx()` queries, so a malicious RPC node could return a fabricated transaction with an empty overflow proof that the light client would accept.

## Test plan

- [x] `TestRowProofUint32Overflow` — empty RowProof with overflow values is rejected against random roots
- [x] `TestRowProofEmptyRejected` — empty RowProof without overflow is also rejected
- [x] `TestShareProofUint32Overflow` — overflow does not cascade through ShareProof.Validate()
- [ ] Existing RowProof/ShareProof tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
