### PR TITLE
feat: undeprecate timeout_commit consensus config parameter

### DIFF
--- a/.changelog/unreleased/improvements/2914-undeprecate-timeout-commit.md
+++ b/.changelog/unreleased/improvements/2914-undeprecate-timeout-commit.md
@@ -1,0 +1,1 @@
+- Undeprecate `timeout_commit` consensus configuration parameter for use in v9.

--- a/config/config.go
+++ b/config/config.go
@@ -201,9 +201,6 @@ func (cfg *Config) CheckDeprecated() []string {
 	if cfg.Consensus.TimeoutPrecommitDelta != 0 {
 		warnings = append(warnings, "consensus.timeout_precommit_delta is deprecated and will be removed in a future version")
 	}
-	if cfg.Consensus.TimeoutCommit != 0 {
-		warnings = append(warnings, "consensus.timeout_commit is deprecated and will be removed in a future version")
-	}
 	// CreateEmptyBlocks defaults to true, so we check if it's explicitly set to any value
 	warnings = append(warnings, "consensus.create_empty_blocks is deprecated and will be removed in a future version")
 
@@ -1089,7 +1086,6 @@ type ConsensusConfig struct {
 	// height (this gives us a chance to receive some more precommits, even
 	// though we already have +2/3).
 	// NOTE: when modifying, make sure to update time_iota_ms genesis parameter
-	// Deprecated: TimeoutCommit is deprecated and will be removed in a future version.
 	TimeoutCommit time.Duration `mapstructure:"timeout_commit"`
 
 	// Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)

--- a/config/toml.go
+++ b/config/toml.go
@@ -519,7 +519,6 @@ timeout_precommit = "{{ .Consensus.TimeoutPrecommit }}"
 timeout_precommit_delta = "{{ .Consensus.TimeoutPrecommitDelta }}"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
-# DEPRECATED: timeout_commit is deprecated and will be removed in a future version.
 # though we already have +2/3).
 timeout_commit = "{{ .Consensus.TimeoutCommit }}"
 


### PR DESCRIPTION
## Summary

- Remove deprecation markers from `timeout_commit` consensus config parameter so it can be actively used in v9
- Remove `Deprecated` godoc comment from `TimeoutCommit` struct field
- Remove runtime deprecation warning from `CheckDeprecated()`
- Remove `DEPRECATED` comment from TOML config template

Closes https://github.com/celestiaorg/celestia-core/issues/2914

PROTOCO-1464

## Test plan

- [x] `go build ./config/...` passes
- [x] `go test ./config/...` passes
- [ ] Verify no remaining deprecation markers for `timeout_commit` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
