### PR TITLE
fix: bump Go version from 1.26.1 to 1.26.2

### DIFF
--- a/.changelog/unreleased/bug-fixes/2916-bump-go-1.26.2.md
+++ b/.changelog/unreleased/bug-fixes/2916-bump-go-1.26.2.md
@@ -1,0 +1,2 @@
+- Bump Go version from 1.26.1 to 1.26.2 to fix 5 stdlib vulnerabilities
+  (GO-2026-4865, GO-2026-4866, GO-2026-4870, GO-2026-4946, GO-2026-4947).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,5 +1,5 @@
 # We use Debian instead of Alpine for compatibility.
-FROM golang:1.26.1
+FROM golang:1.26.2
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION
## Summary

Bumps the Go version in `go.mod` from `1.26.1` to `1.26.2` to fix 5 stdlib vulnerabilities flagged by govulncheck:

- [GO-2026-4865](https://pkg.go.dev/vuln/GO-2026-4865) — `html/template`
- [GO-2026-4866](https://pkg.go.dev/vuln/GO-2026-4866) — `crypto/x509`
- [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) — `crypto/tls`
- [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) — `crypto/x509`
- [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) — `crypto/x509`

Also bumps the e2e `golang:1.26.1` Docker base image to `golang:1.26.2` to keep it in sync.

## Test plan

- [x] `make vulncheck` passes locally with Go 1.26.2 (`No vulnerabilities found.`)
- [x] `go build ./...` succeeds
- [ ] CI `govulncheck` job passes on this PR

Closes https://github.com/celestiaorg/celestia-core/issues/2916
Closes https://linear.app/celestia/issue/PROTOCO-1467/fix-govuln-ci