### PR TITLE
fix(types): validate nil SignedHeader in LightClientAttackEvidence

### DIFF
--- a/.changelog/unreleased/bug-fixes/lcae-nil-signed-header.md
+++ b/.changelog/unreleased/bug-fixes/lcae-nil-signed-header.md
@@ -1,0 +1,3 @@
+- `[types]` Validate that `LightClientAttackEvidence.ConflictingBlock.SignedHeader`
+  is non-nil in `ValidateBasic` to prevent a nil pointer panic during block
+  deserialization. Backported from cometbft/cometbft#5757.

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -358,6 +358,9 @@ func (l *LightClientAttackEvidence) ValidateBasic() error {
 	}
 
 	// this check needs to be done before we can run validate basic
+	if l.ConflictingBlock.SignedHeader == nil {
+		return errors.New("conflicting block missing signed header")
+	}
 	if l.ConflictingBlock.Header == nil {
 		return errors.New("conflicting block missing header")
 	}

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -195,6 +195,7 @@ func TestLightClientAttackEvidenceValidation(t *testing.T) {
 		}, false},
 		{"Nil conflicting header", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock.Header = nil }, true},
 		{"Nil conflicting blocl", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock = nil }, true},
+		{"Nil signed header", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock.SignedHeader = nil }, true},
 		{"Nil validator set", func(ev *LightClientAttackEvidence) {
 			ev.ConflictingBlock.ValidatorSet = &ValidatorSet{}
 		}, true},


### PR DESCRIPTION
Closes [PROTOCO-1518](https://linear.app/celestia/issue/PROTOCO-1518/chain-halt-via-nil-signedheader-in-lightclientattackevidence).
Backports [cometbft/cometbft#5757](https://github.com/cometbft/cometbft/pull/5757) ([`336b47c`](https://github.com/cometbft/cometbft/commit/336b47cf5d5ea5d44155efe6888c85dde2cd3938)) to celestia-core `main`.

## Test plan
- [x] `go test ./types/...` passes locally
- [ ] CI green