### PR TITLE
chore: sync CODEOWNERS with main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,8 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+# CODEOWNERS: <https://help.github.com/articles/about-codeowners/>
 
-# Everything goes through the following "global owners" by default.
-# Unless a later match takes precedence, these three will be
-# requested for review when someone opens a PR.
-# Note that the last matching pattern takes precedence, so
-# global owners are only requested if there isn't a more specific
-# codeowner specified below. For this reason, the global codeowners
-# are often repeated in package-level definitions.
-*     @rach-id @evan-forbes @mcrakhman @ninabarbakadze
+# Everything goes through the protocol team by default. The team's review
+# assignment settings control how many reviewers are auto-assigned per PR.
+# See: https://github.com/orgs/celestiaorg/teams/protocol/edit/review_assignment
+
+# global owners
+* @celestiaorg/protocol


### PR DESCRIPTION
## Summary

- Replaces the individual CODEOWNERS (`@rach-id @evan-forbes @mcrakhman @ninabarbakadze`) with `@celestiaorg/protocol` so review assignment on `v0.39.x-celestia` goes through the protocol team, matching `main`.

## Test plan

- [x] `.github/CODEOWNERS` byte-identical to `main:.github/CODEOWNERS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/2942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
