### PR TITLE
feat(ci): add upstream CometBFT watcher workflow

### DIFF
--- a/.changelog/unreleased/improvements/2789-upstream-cometbft-watcher.md
+++ b/.changelog/unreleased/improvements/2789-upstream-cometbft-watcher.md
@@ -1,0 +1,3 @@
+- [ci] \#2789 Add `upstream-cometbft-watcher` GitHub Actions workflow
+  that files a triage issue when upstream CometBFT publishes a release
+  on the tracked version line or a new security advisory.

--- a/.github/workflows/upstream-cometbft-watcher.yml
+++ b/.github/workflows/upstream-cometbft-watcher.yml
@@ -1,0 +1,42 @@
+name: upstream-cometbft-watcher
+
+on:
+  schedule:
+    # 13:00 UTC daily
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log actions without creating issues'
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  UPSTREAM_REPO: cometbft/cometbft
+  TARGET_REPO: ${{ github.repository }}
+  TRACKED_PREFIX: 'v0.38.'
+  DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}
+
+jobs:
+  ensure-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh label create upstream-cometbft \
+            --repo "$TARGET_REPO" \
+            --color '0E8A16' \
+            --description 'Upstream CometBFT release or advisory that needs triage' \
+            --force
+          gh label create security \
+            --repo "$TARGET_REPO" \
+            --color 'D93F0B' \
+            --description 'Security-related issue' \
+            --force

--- a/.github/workflows/upstream-cometbft-watcher.yml
+++ b/.github/workflows/upstream-cometbft-watcher.yml
@@ -132,7 +132,7 @@ jobs:
           # Fetch last 30 upstream releases (non-draft, non-prerelease, tag starts with TRACKED_PREFIX).
           mapfile -t releases < <(
             gh release list --repo "$UPSTREAM_REPO" --limit 30 \
-              --json tagName,publishedAt,url,isDraft,isPrerelease \
+              --json tagName,publishedAt,isDraft,isPrerelease \
             | jq -c --arg prefix "$TRACKED_PREFIX" \
                 '.[] | select(.isDraft==false and .isPrerelease==false) | select(.tagName | startswith($prefix))'
           )
@@ -145,7 +145,7 @@ jobs:
           for release_json in "${releases[@]}"; do
             tag=$(echo "$release_json" | jq -r .tagName)
             published=$(echo "$release_json" | jq -r .publishedAt)
-            url=$(echo "$release_json" | jq -r .url)
+            url="https://github.com/${UPSTREAM_REPO}/releases/tag/${tag}"
 
             title="Upstream CometBFT release: ${tag}"
 

--- a/.github/workflows/upstream-cometbft-watcher.yml
+++ b/.github/workflows/upstream-cometbft-watcher.yml
@@ -126,7 +126,7 @@ jobs:
           done
 
   releases:
-    needs: advisories
+    needs: ensure-labels
     runs-on: ubuntu-latest
     steps:
       - name: File issues for new upstream releases

--- a/.github/workflows/upstream-cometbft-watcher.yml
+++ b/.github/workflows/upstream-cometbft-watcher.yml
@@ -118,3 +118,77 @@ jobs:
               --label security \
               --body "$body"
           done
+
+  releases:
+    needs: advisories
+    runs-on: ubuntu-latest
+    steps:
+      - name: File issues for new upstream releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Fetch last 30 upstream releases (non-draft, non-prerelease, tag starts with TRACKED_PREFIX).
+          mapfile -t releases < <(
+            gh release list --repo "$UPSTREAM_REPO" --limit 30 \
+              --json tagName,publishedAt,url,isDraft,isPrerelease \
+            | jq -c --arg prefix "$TRACKED_PREFIX" \
+                '.[] | select(.isDraft==false and .isPrerelease==false) | select(.tagName | startswith($prefix))'
+          )
+
+          if [ "${#releases[@]}" -eq 0 ]; then
+            echo "No releases on ${UPSTREAM_REPO} matching prefix ${TRACKED_PREFIX}."
+            exit 0
+          fi
+
+          for release_json in "${releases[@]}"; do
+            tag=$(echo "$release_json" | jq -r .tagName)
+            published=$(echo "$release_json" | jq -r .publishedAt)
+            url=$(echo "$release_json" | jq -r .url)
+
+            title="Upstream CometBFT release: ${tag}"
+
+            existing=$(
+              gh issue list --repo "$TARGET_REPO" \
+                --search "in:title \"${title}\"" \
+                --state all --limit 50 \
+                --json title \
+                --jq "[.[] | select(.title == \"${title}\")] | length"
+            )
+            if [ "$existing" -gt 0 ]; then
+              echo "Skipping (already exists): ${title}"
+              continue
+            fi
+
+            body=$(cat <<EOF
+          Upstream CometBFT published a new release on the \`${TRACKED_PREFIX}x\` line.
+
+          - **Tag:** ${tag}
+          - **Published:** ${published}
+          - **Link:** ${url}
+
+          ## Checklist
+
+          - [ ] Read the release notes
+          - [ ] Assess applicability to celestia-core (\`main\`, \`v0.39.x-celestia\`, \`v0.38.x-celestia\`)
+          - [ ] Backport any security-relevant or bug-fix commits
+          - [ ] Close this issue when triage is complete
+
+          See also: [open \`upstream-cometbft\` issues](https://github.com/${TARGET_REPO}/issues?q=is%3Aissue+is%3Aopen+label%3Aupstream-cometbft) for advisories to cross-reference.
+
+          _Filed automatically by \`.github/workflows/upstream-cometbft-watcher.yml\`._
+          EOF
+          )
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] Would create issue: ${title}"
+              continue
+            fi
+
+            gh issue create \
+              --repo "$TARGET_REPO" \
+              --title "$title" \
+              --label upstream-cometbft \
+              --body "$body"
+          done

--- a/.github/workflows/upstream-cometbft-watcher.yml
+++ b/.github/workflows/upstream-cometbft-watcher.yml
@@ -40,3 +40,81 @@ jobs:
             --color 'D93F0B' \
             --description 'Security-related issue' \
             --force
+
+  advisories:
+    needs: ensure-labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: File issues for new upstream advisories
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Fetch all published advisories, one compact JSON object per line.
+          mapfile -t advisories < <(
+            gh api "/repos/${UPSTREAM_REPO}/security-advisories" --paginate \
+              --jq '.[] | select(.state=="published") | {ghsa_id, summary, severity, published_at, html_url} | @json'
+          )
+
+          if [ "${#advisories[@]}" -eq 0 ]; then
+            echo "No published advisories found on ${UPSTREAM_REPO}."
+            exit 0
+          fi
+
+          for advisory_json in "${advisories[@]}"; do
+            ghsa_id=$(echo "$advisory_json" | jq -r .ghsa_id)
+            summary=$(echo "$advisory_json" | jq -r .summary)
+            severity=$(echo "$advisory_json" | jq -r .severity)
+            published=$(echo "$advisory_json" | jq -r .published_at)
+            url=$(echo "$advisory_json" | jq -r .html_url)
+
+            title="Upstream CometBFT advisory: ${ghsa_id}"
+
+            # Idempotency: skip if an issue with this exact title already exists.
+            existing=$(
+              gh issue list --repo "$TARGET_REPO" \
+                --search "in:title \"${title}\"" \
+                --state all --limit 50 \
+                --json title \
+                --jq "[.[] | select(.title == \"${title}\")] | length"
+            )
+            if [ "$existing" -gt 0 ]; then
+              echo "Skipping (already exists): ${title}"
+              continue
+            fi
+
+            body=$(cat <<EOF
+          Upstream CometBFT published a new security advisory.
+
+          - **GHSA ID:** ${ghsa_id}
+          - **Severity:** ${severity}
+          - **Published:** ${published}
+          - **Link:** ${url}
+
+          ## Summary
+
+          ${summary}
+
+          ## Checklist
+
+          - [ ] Assess applicability to celestia-core (\`main\`, \`v0.39.x-celestia\`, \`v0.38.x-celestia\`)
+          - [ ] Backport any applicable fixes
+          - [ ] Close this issue when triage is complete
+
+          _Filed automatically by \`.github/workflows/upstream-cometbft-watcher.yml\`._
+          EOF
+          )
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] Would create issue: ${title}"
+              continue
+            fi
+
+            gh issue create \
+              --repo "$TARGET_REPO" \
+              --title "$title" \
+              --label upstream-cometbft \
+              --label security \
+              --body "$body"
+          done

--- a/.github/workflows/upstream-cometbft-watcher.yml
+++ b/.github/workflows/upstream-cometbft-watcher.yml
@@ -51,18 +51,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Fetch all published advisories, one compact JSON object per line.
-          mapfile -t advisories < <(
+          # Fetch all published advisories (compact JSON, one per line). Capturing
+          # to a variable first so a failed API call fails the job via set -e
+          # instead of being swallowed by the process substitution below.
+          advisories_raw=$(
             gh api "/repos/${UPSTREAM_REPO}/security-advisories" --paginate \
               --jq '.[] | select(.state=="published") | {ghsa_id, summary, severity, published_at, html_url} | @json'
           )
 
-          if [ "${#advisories[@]}" -eq 0 ]; then
+          if [ -z "$advisories_raw" ]; then
             echo "No published advisories found on ${UPSTREAM_REPO}."
             exit 0
           fi
 
+          mapfile -t advisories <<< "$advisories_raw"
+
           for advisory_json in "${advisories[@]}"; do
+            [ -n "$advisory_json" ] || continue
             ghsa_id=$(echo "$advisory_json" | jq -r .ghsa_id)
             summary=$(echo "$advisory_json" | jq -r .summary)
             severity=$(echo "$advisory_json" | jq -r .severity)
@@ -71,13 +76,14 @@ jobs:
 
             title="Upstream CometBFT advisory: ${ghsa_id}"
 
-            # Idempotency: skip if an issue with this exact title already exists.
+            # Idempotency: narrow the search by the unique GHSA ID and post-filter
+            # with an exact title match via jq --arg (safe against special chars).
             existing=$(
               gh issue list --repo "$TARGET_REPO" \
-                --search "in:title \"${title}\"" \
-                --state all --limit 50 \
+                --search "in:title ${ghsa_id}" \
+                --state all --limit 100 \
                 --json title \
-                --jq "[.[] | select(.title == \"${title}\")] | length"
+              | jq --arg t "$title" '[.[] | select(.title == $t)] | length'
             )
             if [ "$existing" -gt 0 ]; then
               echo "Skipping (already exists): ${title}"
@@ -129,32 +135,39 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Fetch last 30 upstream releases (non-draft, non-prerelease, tag starts with TRACKED_PREFIX).
-          mapfile -t releases < <(
-            gh release list --repo "$UPSTREAM_REPO" --limit 30 \
+          # Fetch last 100 upstream releases (non-draft, non-prerelease, tag starts
+          # with TRACKED_PREFIX). Capturing to a variable first so a failed API
+          # call fails the job via set -e instead of being swallowed.
+          releases_raw=$(
+            gh release list --repo "$UPSTREAM_REPO" --limit 100 \
               --json tagName,publishedAt,isDraft,isPrerelease \
             | jq -c --arg prefix "$TRACKED_PREFIX" \
                 '.[] | select(.isDraft==false and .isPrerelease==false) | select(.tagName | startswith($prefix))'
           )
 
-          if [ "${#releases[@]}" -eq 0 ]; then
+          if [ -z "$releases_raw" ]; then
             echo "No releases on ${UPSTREAM_REPO} matching prefix ${TRACKED_PREFIX}."
             exit 0
           fi
 
+          mapfile -t releases <<< "$releases_raw"
+
           for release_json in "${releases[@]}"; do
+            [ -n "$release_json" ] || continue
             tag=$(echo "$release_json" | jq -r .tagName)
             published=$(echo "$release_json" | jq -r .publishedAt)
             url="https://github.com/${UPSTREAM_REPO}/releases/tag/${tag}"
 
             title="Upstream CometBFT release: ${tag}"
 
+            # Idempotency: narrow the search by the unique tag and post-filter
+            # with an exact title match via jq --arg (safe against special chars).
             existing=$(
               gh issue list --repo "$TARGET_REPO" \
-                --search "in:title \"${title}\"" \
-                --state all --limit 50 \
+                --search "in:title ${tag}" \
+                --state all --limit 100 \
                 --json title \
-                --jq "[.[] | select(.title == \"${title}\")] | length"
+              | jq --arg t "$title" '[.[] | select(.title == $t)] | length'
             )
             if [ "$existing" -gt 0 ]; then
               echo "Skipping (already exists): ${title}"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/upstream-cometbft-watcher.yml`, a daily GitHub Actions workflow that files a triage issue in this repo when upstream [`cometbft/cometbft`](https://github.com/cometbft/cometbft) publishes a release on the tracked version line (`v0.38.x`) or a new security advisory.

- Uses the built-in `GITHUB_TOKEN` — no new secrets required.
- Idempotent via GitHub issue title search (no local state file).
- Supports `workflow_dispatch` with a `dry_run` input for verification.
- `advisories` and `releases` watchers run in parallel after `ensure-labels`, so a failure in one API endpoint doesn't block the other.

## Why `v0.38.x`?

All three active celestia-core branches (`main`, `v0.39.x-celestia`, `v0.38.x-celestia`) currently track upstream CometBFT **v0.38.x**. When `main` advances to a newer upstream line, update the `TRACKED_PREFIX` env var in the workflow.

## Test plan

- [x] `actionlint` passes on the workflow.
- [x] Local simulation of both watchers against live `cometbft/cometbft` APIs returned the expected data (12 published advisories, 13 `v0.38.*` releases in the last 100), with the tightened idempotency search correctly reporting 0 existing issues.
- [x] Review feedback addressed: decoupled `releases` from `advisories` so the two watchers run independently.
- [ ] GitHub's `workflow_dispatch` API can only look up a workflow by filename once the file exists on the default branch. After merge, trigger a first run via:
  ```
  gh workflow run upstream-cometbft-watcher.yml --ref main -f dry_run=true
  ```
  and confirm the advisory and release watchers list the expected items without creating issues. Then let the 13:00 UTC cron file catch-up issues for currently-unseen upstream items.

Closes https://github.com/celestiaorg/celestia-core/issues/2789
Closes https://linear.app/celestia/issue/PROTOCO-1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)