### PR TITLE
fix(rpc/grpc): non-blocking broadcast to height-subscribers

### DIFF
--- a/.changelog/unreleased/bug-fixes/2967-broadcast-to-listeners-non-blocking.md
+++ b/.changelog/unreleased/bug-fixes/2967-broadcast-to-listeners-non-blocking.md
@@ -1,0 +1,7 @@
+- Fix gRPC `BlockAPI.broadcastToListeners` holding the global mutex while
+  sending to subscriber channels. A slow subscriber would block the
+  broadcaster, starving every other subscriber and growing the EventBus
+  subscription buffer until the process was OOM-killed. The broadcaster
+  now snapshots listeners under the lock and does non-blocking sends
+  outside it. Server-side gRPC keepalive params were also added so dead
+  client connections get reaped. ([\#2967](https://github.com/celestiaorg/celestia-core/issues/2967))

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -156,23 +156,44 @@ func (blockAPI *BlockAPI) retryNewBlocksSubscription(ctx context.Context) (bool,
 }
 
 func (blockAPI *BlockAPI) broadcastToListeners(ctx context.Context, height int64, hash []byte) {
+	// Snapshot the current set of listeners under the lock so we do not
+	// hold the lock during sends. A slow listener must not block the
+	// broadcaster (see https://github.com/celestiaorg/celestia-core/issues/2967).
 	blockAPI.Lock()
-	defer blockAPI.Unlock()
+	listeners := make([]chan SubscribeNewHeightsResponse, 0, len(blockAPI.heightListeners))
 	for ch := range blockAPI.heightListeners {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// logging the error then removing the heights listener
-					blockAPI.env.Logger.Debug("failed to write to heights listener", "err", r)
-					blockAPI.removeHeightListener(ch)
-				}
-			}()
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- SubscribeNewHeightsResponse{Height: height, Hash: hash}:
-			}
-		}()
+		listeners = append(listeners, ch)
+	}
+	blockAPI.Unlock()
+
+	if ctx.Err() != nil {
+		return
+	}
+
+	event := SubscribeNewHeightsResponse{Height: height, Hash: hash}
+	for _, ch := range listeners {
+		blockAPI.sendNonBlocking(ch, event)
+	}
+}
+
+// sendNonBlocking attempts to deliver event to ch without blocking.
+// If ch is full, the event is dropped and a debug log is emitted: a
+// slow subscriber must not block the broadcaster or any other
+// subscriber. Callers that require lossless delivery should use
+// BlockByHeight to back-fill any gaps. The recover guards against a
+// concurrent close of ch and evicts the listener in that case
+// (matching the prior behavior).
+func (blockAPI *BlockAPI) sendNonBlocking(ch chan SubscribeNewHeightsResponse, event SubscribeNewHeightsResponse) {
+	defer func() {
+		if r := recover(); r != nil {
+			blockAPI.env.Logger.Debug("failed to write to heights listener", "err", r)
+			blockAPI.removeHeightListener(ch)
+		}
+	}()
+	select {
+	case ch <- event:
+	default:
+		blockAPI.env.Logger.Debug("dropped height event for slow subscriber", "height", event.Height)
 	}
 }
 

--- a/rpc/grpc/api_test.go
+++ b/rpc/grpc/api_test.go
@@ -1,0 +1,166 @@
+package coregrpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/rpc/core"
+)
+
+// newTestBlockAPI returns a BlockAPI suitable for unit-testing the
+// broadcast / listener bookkeeping paths. It avoids spinning up a full
+// node — only fields read by these paths are populated.
+func newTestBlockAPI(t *testing.T) *BlockAPI {
+	t.Helper()
+	env := &core.Environment{Logger: log.NewNopLogger()}
+	return NewBlockAPI(env)
+}
+
+// fillChannel writes n placeholder events to ch without blocking the test
+// if ch's capacity is smaller than n.
+func fillChannel(t *testing.T, ch chan SubscribeNewHeightsResponse, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case ch <- SubscribeNewHeightsResponse{Height: int64(i)}:
+		default:
+			t.Fatalf("channel full after %d writes (cap=%d)", i, cap(ch))
+		}
+	}
+}
+
+// TestBroadcastToListeners_DoesNotBlockOnSlowSubscriber verifies that a
+// listener whose channel buffer is full does not block the broadcaster.
+// Regression for https://github.com/celestiaorg/celestia-core/issues/2967.
+func TestBroadcastToListeners_DoesNotBlockOnSlowSubscriber(t *testing.T) {
+	api := newTestBlockAPI(t)
+
+	slow := api.addHeightListener()
+	fast := api.addHeightListener()
+
+	// Saturate the slow listener's channel (cap=50, see addHeightListener).
+	fillChannel(t, slow, cap(slow))
+
+	done := make(chan struct{})
+	go func() {
+		api.broadcastToListeners(context.Background(), 100, []byte("hash"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("broadcastToListeners blocked on slow subscriber")
+	}
+
+	// Fast listener still receives the broadcast event.
+	select {
+	case ev := <-fast:
+		assert.Equal(t, int64(100), ev.Height)
+		assert.Equal(t, []byte("hash"), ev.Hash)
+	case <-time.After(1 * time.Second):
+		t.Fatal("fast subscriber did not receive the broadcast")
+	}
+}
+
+// TestBroadcastToListeners_DoesNotHoldLockDuringSend verifies that
+// addHeightListener / removeHeightListener can make progress while a
+// broadcast is in flight to a saturated subscriber. Regression for
+// https://github.com/celestiaorg/celestia-core/issues/2967.
+func TestBroadcastToListeners_DoesNotHoldLockDuringSend(t *testing.T) {
+	api := newTestBlockAPI(t)
+
+	slow := api.addHeightListener()
+	fillChannel(t, slow, cap(slow))
+
+	// Run the broadcast concurrently. With the bug present, this acquires
+	// the lock and then blocks indefinitely on the saturated channel.
+	// We synchronize on `started` and yield briefly so the broadcast
+	// goroutine has actually entered broadcastToListeners and acquired
+	// the lock before the test contends for it.
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		api.broadcastToListeners(context.Background(), 100, []byte("hash"))
+	}()
+	<-started
+	time.Sleep(5 * time.Millisecond)
+
+	// addHeightListener must not block on the broadcaster's lock.
+	addDone := make(chan chan SubscribeNewHeightsResponse, 1)
+	go func() {
+		addDone <- api.addHeightListener()
+	}()
+
+	var newCh chan SubscribeNewHeightsResponse
+	select {
+	case newCh = <-addDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("addHeightListener blocked while broadcast was in flight")
+	}
+
+	// removeHeightListener must also not block.
+	removeDone := make(chan struct{})
+	go func() {
+		api.removeHeightListener(newCh)
+		close(removeDone)
+	}()
+
+	select {
+	case <-removeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("removeHeightListener blocked while broadcast was in flight")
+	}
+}
+
+// TestBroadcastToListeners_DeliversToAllSubscribersWhenAllDrain verifies
+// that with all subscribers actively draining their channels, every
+// broadcast reaches every subscriber.
+func TestBroadcastToListeners_DeliversToAllSubscribersWhenAllDrain(t *testing.T) {
+	api := newTestBlockAPI(t)
+
+	const numSubs = 4
+	const numEvents = 25
+
+	chans := make([]chan SubscribeNewHeightsResponse, numSubs)
+	for i := range chans {
+		chans[i] = api.addHeightListener()
+	}
+
+	var wg sync.WaitGroup
+	received := make([][]int64, numSubs)
+	for i, ch := range chans {
+		i, ch := i, ch
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for len(received[i]) < numEvents {
+				select {
+				case ev := <-ch:
+					received[i] = append(received[i], ev.Height)
+				case <-time.After(2 * time.Second):
+					return
+				}
+			}
+		}()
+	}
+
+	for h := int64(1); h <= numEvents; h++ {
+		api.broadcastToListeners(context.Background(), h, []byte("hash"))
+	}
+
+	wg.Wait()
+
+	for i, got := range received {
+		require.Len(t, got, numEvents, "subscriber %d missed events", i)
+		for j, h := range got {
+			assert.Equal(t, int64(j+1), h, "subscriber %d out-of-order", i)
+		}
+	}
+}

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -5,9 +5,11 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 
 	cmtnet "github.com/cometbft/cometbft/libs/net"
@@ -31,7 +33,21 @@ type Config struct {
 //
 // Deprecated: A new gRPC API will be introduced after v0.38.
 func StartGRPCServer(env *core.Environment, ln net.Listener) error {
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			// Send a keepalive ping every 30s of inactivity.
+			Time: 30 * time.Second,
+			// Close the connection if the ping is not ACKed within 10s.
+			Timeout: 10 * time.Second,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			// Do not require the client to have an active stream to ping.
+			PermitWithoutStream: true,
+			// Allow client pings as frequent as every 10s. Clients that
+			// ping faster will be disconnected.
+			MinTime: 10 * time.Second,
+		}),
+	)
 	RegisterBroadcastAPIServer(grpcServer, &broadcastAPI{env: env})
 
 	api := NewBlockAPI(env)


### PR DESCRIPTION
## Summary
- `BlockAPI.broadcastToListeners` no longer holds the global mutex during channel sends. Listeners are snapshotted under the lock and sent to non-blocking outside it; slow subscribers drop the current height event instead of OOM-killing the process.
- Added gRPC server keepalive params (`Time=30s`, `Timeout=10s`, `MinTime=10s`, `PermitWithoutStream=true`) so dead client connections get reaped instead of pinning listener channels.

Closes #2967
Closes https://linear.app/celestia/issue/PROTOCO-1618/bug-blocking-broadcasttolisteners

## Test plan
- [x] New regression tests in `rpc/grpc/api_test.go` reproduce the lock contention bug and verify the fix
- [x] Existing `TestGRPC` suite passes (including `TestSubscribeNewHeights`)
- [x] Race detector clean
- [x] `make lint` and `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/3002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
