### PR TITLE
fix(rpc/grpc): lock-protect initial newBlockSubscription write

### DIFF
--- a/.changelog/unreleased/bug-fixes/3005-lock-newblocksubscription.md
+++ b/.changelog/unreleased/bug-fixes/3005-lock-newblocksubscription.md
@@ -1,0 +1,4 @@
+- Lock-protect the initial write to `BlockAPI.newBlockSubscription` in
+  `StartNewBlockEventListener` so all writes to the field are consistently
+  synchronized with `Stop` and `retryNewBlocksSubscription`.
+  ([\#3005](https://github.com/celestiaorg/celestia-core/issues/3005))

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -68,18 +68,8 @@ func NewBlockAPI(env *core.Environment) *BlockAPI {
 }
 
 func (blockAPI *BlockAPI) StartNewBlockEventListener(ctx context.Context) error {
-	if blockAPI.newBlockSubscription == nil {
-		var err error
-		blockAPI.newBlockSubscription, err = blockAPI.env.EventBus.Subscribe(
-			ctx,
-			blockAPI.subscriptionID,
-			blockAPI.subscriptionQuery,
-			500,
-		)
-		if err != nil {
-			blockAPI.env.Logger.Error("Failed to subscribe to new blocks", "err", err)
-			return err
-		}
+	if err := blockAPI.subscribe(ctx); err != nil {
+		return err
 	}
 	for {
 		select {
@@ -127,6 +117,30 @@ const RetryAttempts = 6
 
 // SubscriptionCapacity the maximum number of pending blocks in the subscription.
 const SubscriptionCapacity = 500
+
+// subscribe creates the initial EventBus subscription if one does not
+// already exist. Holding blockAPI.Lock keeps this write synchronized
+// with retryNewBlocksSubscription (which also writes the field under
+// the lock) and Stop (which reads it under the lock).
+func (blockAPI *BlockAPI) subscribe(ctx context.Context) error {
+	blockAPI.Lock()
+	defer blockAPI.Unlock()
+	if blockAPI.newBlockSubscription != nil {
+		return nil
+	}
+	sub, err := blockAPI.env.EventBus.Subscribe(
+		ctx,
+		blockAPI.subscriptionID,
+		blockAPI.subscriptionQuery,
+		500,
+	)
+	if err != nil {
+		blockAPI.env.Logger.Error("Failed to subscribe to new blocks", "err", err)
+		return err
+	}
+	blockAPI.newBlockSubscription = sub
+	return nil
+}
 
 func (blockAPI *BlockAPI) retryNewBlocksSubscription(ctx context.Context) (bool, error) {
 	ticker := time.NewTicker(time.Second)


### PR DESCRIPTION
## Summary
- `StartNewBlockEventListener` wrote `blockAPI.newBlockSubscription` without holding the lock.
- `retryNewBlocksSubscription` writes the same field under the lock and `Stop` reads it under the lock — leaving the start-write unsynchronized in the Go memory model.
- Extracted a `subscribe()` helper that holds the lock for the read+write so all field accesses are consistently lock-protected.

> **Note:** depends on #3004 (the `Stop()` deadlock fix). Base branch is `fix/blockapi-stop-deadlock`. Once #3004 merges to main, GitHub will auto-rebase this PR onto main.

Closes #3005

## Test plan
- [x] `go test -race -count=1 ./rpc/grpc/` clean across 10 consecutive runs
- [x] Existing `TestGRPC` suite still passes
- [x] `make lint` and `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/3006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
