### PR TITLE
fix(rpc/grpc): lock-protect initial newBlockSubscription write

### DIFF
--- a/.changelog/unreleased/bug-fixes/3005-lock-newblocksubscription.md
+++ b/.changelog/unreleased/bug-fixes/3005-lock-newblocksubscription.md
@@ -1,0 +1,4 @@
+- Lock-protect the initial write to `BlockAPI.newBlockSubscription` in
+  `StartNewBlockEventListener` so all writes to the field are consistently
+  synchronized with `Stop` and `retryNewBlocksSubscription`.
+  ([\#3005](https://github.com/celestiaorg/celestia-core/issues/3005))

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -68,18 +68,8 @@ func NewBlockAPI(env *core.Environment) *BlockAPI {
 }
 
 func (blockAPI *BlockAPI) StartNewBlockEventListener(ctx context.Context) error {
-	if blockAPI.newBlockSubscription == nil {
-		var err error
-		blockAPI.newBlockSubscription, err = blockAPI.env.EventBus.Subscribe(
-			ctx,
-			blockAPI.subscriptionID,
-			blockAPI.subscriptionQuery,
-			500,
-		)
-		if err != nil {
-			blockAPI.env.Logger.Error("Failed to subscribe to new blocks", "err", err)
-			return err
-		}
+	if err := blockAPI.subscribe(ctx); err != nil {
+		return err
 	}
 	for {
 		select {
@@ -127,6 +117,30 @@ const RetryAttempts = 6
 
 // SubscriptionCapacity the maximum number of pending blocks in the subscription.
 const SubscriptionCapacity = 500
+
+// subscribe creates the initial EventBus subscription if one does not
+// already exist. Holding blockAPI.Lock keeps this write synchronized
+// with retryNewBlocksSubscription (which also writes the field under
+// the lock) and Stop (which reads it under the lock).
+func (blockAPI *BlockAPI) subscribe(ctx context.Context) error {
+	blockAPI.Lock()
+	defer blockAPI.Unlock()
+	if blockAPI.newBlockSubscription != nil {
+		return nil
+	}
+	sub, err := blockAPI.env.EventBus.Subscribe(
+		ctx,
+		blockAPI.subscriptionID,
+		blockAPI.subscriptionQuery,
+		SubscriptionCapacity,
+	)
+	if err != nil {
+		blockAPI.env.Logger.Error("Failed to subscribe to new blocks", "err", err)
+		return err
+	}
+	blockAPI.newBlockSubscription = sub
+	return nil
+}
 
 func (blockAPI *BlockAPI) retryNewBlocksSubscription(ctx context.Context) (bool, error) {
 	ticker := time.NewTicker(time.Second)


### PR DESCRIPTION
## Summary
- `StartNewBlockEventListener` wrote `blockAPI.newBlockSubscription` without holding the lock.
- `retryNewBlocksSubscription` writes the same field under the lock and `Stop` reads it under the lock — leaving the start-write unsynchronized in the Go memory model.
- Extracted a `subscribe()` helper that holds the lock for the read+write so all field accesses are consistently lock-protected.
- Switched the buffer capacity to the `SubscriptionCapacity` constant for consistency with `retryNewBlocksSubscription` (per Devin's review of the prior attempt at this fix in #3006).

> **Note:** the race surfaced by this fix only fires once #3004's `Stop()` deadlock fix lands. This PR is independent of #3004 — both are correct on their own — but the operational benefit of this PR is gated on #3004 also landing.

> **Re-do:** an earlier attempt (#3006) was inadvertently merged into #3004's feature branch without an independent review (auto-merge stuck on a non-default base). That merge has been reverted from #3004's branch and this PR is the proper review-gated replacement.

Closes #3005

## Test plan
- [x] `go test -race -count=1 ./rpc/grpc/` clean across 10+ consecutive runs (5 in this branch + 10 in the prior attempt against the same diff)
- [x] Existing `TestGRPC` suite still passes
- [x] `make lint` and `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-core/pull/3007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
