### PR TITLE
refactor: only unmarshal a single page from the tx index

### DIFF
--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -14,6 +14,7 @@ import (
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/cometbft/cometbft/state"
+	"github.com/cometbft/cometbft/state/txindex"
 	"github.com/cometbft/cometbft/state/txindex/null"
 	"github.com/cometbft/cometbft/types"
 )
@@ -97,9 +98,53 @@ func (env *Environment) TxSearch(
 		return nil, err
 	}
 
-	results, err := env.TxIndexer.Search(ctx.Context(), q)
+	switch orderBy {
+	case "desc", "asc", "":
+	default:
+		return nil, errors.New("expected order_by to be either `asc` or `desc` or empty")
+	}
+
+	perPage := env.validatePerPage(perPagePtr)
+
+	results, totalCount, err := env.txSearchPage(ctx.Context(), q, pagePtr, perPage, orderBy)
 	if err != nil {
 		return nil, err
+	}
+
+	apiResults, err := env.txResultsToRPC(results, prove)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ctypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
+}
+
+func (env *Environment) txSearchPage(
+	ctx context.Context,
+	q *cmtquery.Query,
+	pagePtr *int,
+	perPage int,
+	orderBy string,
+) ([]*abcitypes.TxResult, int, error) {
+	if pagedIndexer, ok := env.TxIndexer.(txindex.PagedTxIndexer); ok {
+		requestedPage := 1
+		if pagePtr != nil {
+			requestedPage = *pagePtr
+		}
+
+		results, totalCount, err := pagedIndexer.SearchPaged(ctx, q, orderBy, validateSkipCount(requestedPage, perPage), perPage)
+		if err != nil {
+			return nil, 0, err
+		}
+		if _, err := validatePage(pagePtr, perPage, totalCount); err != nil {
+			return nil, 0, err
+		}
+		return results, totalCount, nil
+	}
+
+	results, err := env.TxIndexer.Search(ctx, q)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	// sort results (must be done before pagination)
@@ -118,30 +163,30 @@ func (env *Environment) TxSearch(
 			}
 			return results[i].Height < results[j].Height
 		})
-	default:
-		return nil, errors.New("expected order_by to be either `asc` or `desc` or empty")
 	}
 
 	// paginate results
 	totalCount := len(results)
-	perPage := env.validatePerPage(perPagePtr)
 
 	page, err := validatePage(pagePtr, perPage, totalCount)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	skipCount := validateSkipCount(page, perPage)
 	pageSize := cmtmath.MinInt(perPage, totalCount-skipCount)
 
-	apiResults := make([]*ctypes.ResultTx, 0, pageSize)
-	for i := skipCount; i < skipCount+pageSize; i++ {
-		r := results[i]
+	return results[skipCount : skipCount+pageSize], totalCount, nil
+}
 
+func (env *Environment) txResultsToRPC(results []*abcitypes.TxResult, prove bool) ([]*ctypes.ResultTx, error) {
+	apiResults := make([]*ctypes.ResultTx, 0, len(results))
+	for _, r := range results {
 		var shareProof types.ShareProof
 		if prove {
 			block := env.BlockStore.LoadBlock(r.Height)
 			if block != nil {
+				var err error
 				shareProof, err = env.proveTx(r.Height, r.Index)
 				if err != nil {
 					return nil, err
@@ -159,7 +204,7 @@ func (env *Environment) TxSearch(
 		})
 	}
 
-	return &ctypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
+	return apiResults, nil
 }
 
 func (env *Environment) proveTx(height int64, index uint32) (types.ShareProof, error) {

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -179,6 +179,7 @@ func (env *Environment) txSearchPage(
 	return results[skipCount : skipCount+pageSize], totalCount, nil
 }
 
+// Deprecated: helper for the deprecated tx and tx_search endpoints.
 func (env *Environment) txResultsToRPC(results []*abcitypes.TxResult, prove bool) ([]*ctypes.ResultTx, error) {
 	apiResults := make([]*ctypes.ResultTx, 0, len(results))
 	for _, r := range results {

--- a/state/txindex/indexer.go
+++ b/state/txindex/indexer.go
@@ -33,6 +33,12 @@ type TxIndexer interface {
 	SetLogger(l log.Logger)
 }
 
+// PagedTxIndexer can return a single ordered page of transaction results
+// without loading every matched transaction into memory.
+type PagedTxIndexer interface {
+	SearchPaged(ctx context.Context, q *query.Query, orderBy string, skipCount, pageSize int) ([]*abci.TxResult, int, error)
+}
+
 // Batch groups together multiple Index operations to be performed at the same time.
 // NOTE: Batch is NOT thread-safe and must not be modified after starting its execution.
 type Batch struct {

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -32,6 +33,13 @@ const (
 )
 
 var _ txindex.TxIndexer = (*TxIndex)(nil)
+var _ txindex.PagedTxIndexer = (*TxIndex)(nil)
+
+type txRef struct {
+	hash   []byte
+	height int64
+	index  uint32
+}
 
 // TxIndex is the simplest possible indexer, backed by key-value storage (levelDB).
 type TxIndex struct {
@@ -191,15 +199,89 @@ func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store dbm.Ba
 // Search will exit early and return any result fetched so far,
 // when a message is received on the context chan.
 func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResult, error) {
+	filteredHashes, err := txi.searchRefs(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return txi.loadResults(ctx, uniqueRefs(filteredHashes))
+}
+
+// SearchPaged performs the same match as Search, but applies ordering and
+// pagination before loading full TxResult protobufs.
+func (txi *TxIndex) SearchPaged(
+	ctx context.Context,
+	q *query.Query,
+	orderBy string,
+	skipCount, pageSize int,
+) ([]*abci.TxResult, int, error) {
+	if pageSize < 0 {
+		pageSize = 0
+	}
+	if skipCount < 0 {
+		skipCount = 0
+	}
+
+	filteredHashes, err := txi.searchRefs(ctx, q)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	refs := uniqueRefs(filteredHashes)
+	if err := sortRefs(refs, orderBy); err != nil {
+		return nil, 0, err
+	}
+
+	totalCount := len(refs)
+	if skipCount >= totalCount || pageSize == 0 {
+		return []*abci.TxResult{}, totalCount, nil
+	}
+
+	end := skipCount + pageSize
+	if end < skipCount || end > totalCount {
+		end = totalCount
+	}
+
+	results, err := txi.loadResults(ctx, refs[skipCount:end])
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return results, totalCount, nil
+}
+
+func (txi *TxIndex) loadResults(ctx context.Context, refs []txRef) ([]*abci.TxResult, error) {
+	results := make([]*abci.TxResult, 0, len(refs))
+	for _, ref := range refs {
+		res, err := txi.Get(ref.hash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Tx{%X}: %w", ref.hash, err)
+		}
+		if res == nil {
+			continue
+		}
+		results = append(results, res)
+
+		select {
+		case <-ctx.Done():
+			return results, nil
+		default:
+		}
+	}
+
+	return results, nil
+}
+
+func (txi *TxIndex) searchRefs(ctx context.Context, q *query.Query) (map[string]txRef, error) {
 	select {
 	case <-ctx.Done():
-		return make([]*abci.TxResult, 0), nil
+		return make(map[string]txRef), nil
 
 	default:
 	}
 
 	var hashesInitialized bool
-	filteredHashes := make(map[string][]byte)
+	filteredHashes := make(map[string]txRef)
 
 	// get a list of conditions (like "tx.height > 5")
 	conditions := q.Syntax()
@@ -212,11 +294,17 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResul
 		res, err := txi.Get(hash)
 		switch {
 		case err != nil:
-			return []*abci.TxResult{}, fmt.Errorf("error while retrieving the result: %w", err)
+			return map[string]txRef{}, fmt.Errorf("error while retrieving the result: %w", err)
 		case res == nil:
-			return []*abci.TxResult{}, nil
+			return map[string]txRef{}, nil
 		default:
-			return []*abci.TxResult{res}, nil
+			return map[string]txRef{
+				string(hash): {
+					hash:   hash,
+					height: res.Height,
+					index:  res.Index,
+				},
+			}, nil
 		}
 	}
 
@@ -286,29 +374,7 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResul
 		}
 	}
 
-	results := make([]*abci.TxResult, 0, len(filteredHashes))
-	resultMap := make(map[string]struct{})
-RESULTS_LOOP:
-	for _, h := range filteredHashes {
-
-		res, err := txi.Get(h)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get Tx{%X}: %w", h, err)
-		}
-		hashString := string(h)
-		if _, ok := resultMap[hashString]; !ok {
-			resultMap[hashString] = struct{}{}
-			results = append(results, res)
-		}
-		// Potentially exit early.
-		select {
-		case <-ctx.Done():
-			break RESULTS_LOOP
-		default:
-		}
-	}
-
-	return results, nil
+	return filteredHashes, nil
 }
 
 func lookForHash(conditions []syntax.Condition) (hash []byte, ok bool, err error) {
@@ -321,14 +387,32 @@ func lookForHash(conditions []syntax.Condition) (hash []byte, ok bool, err error
 	return
 }
 
-func (*TxIndex) setTmpHashes(tmpHeights map[string][]byte, key, value []byte) {
+func (txi *TxIndex) setTmpHashes(tmpHeights map[string]txRef, key, value []byte) {
 	eventSeq := extractEventSeqFromKey(key)
 
 	// Copy the value because the iterator will be reused.
 	valueCopy := make([]byte, len(value))
 	copy(valueCopy, value)
 
-	tmpHeights[string(valueCopy)+eventSeq] = valueCopy
+	ref, err := txRefFromKeyValue(key, valueCopy)
+	if err != nil {
+		res, getErr := txi.Get(valueCopy)
+		if getErr != nil {
+			txi.log.Error("failure to parse tx ref from key and load tx result:", "parse_err", err, "get_err", getErr)
+			return
+		}
+		if res == nil {
+			txi.log.Error("failure to parse tx ref from key and tx result is missing:", "parse_err", err)
+			return
+		}
+		ref = txRef{
+			hash:   valueCopy,
+			height: res.Height,
+			index:  res.Index,
+		}
+	}
+
+	tmpHeights[string(valueCopy)+eventSeq] = ref
 }
 
 // match returns all matching txs by hash that meet a given condition and start
@@ -340,17 +424,17 @@ func (txi *TxIndex) match(
 	ctx context.Context,
 	c syntax.Condition,
 	startKeyBz []byte,
-	filteredHashes map[string][]byte,
+	filteredHashes map[string]txRef,
 	firstRun bool,
 	heightInfo HeightInfo,
-) map[string][]byte {
+) map[string]txRef {
 	// A previous match was attempted but resulted in no matches, so we return
 	// no matches (assuming AND operand).
 	if !firstRun && len(filteredHashes) == 0 {
 		return filteredHashes
 	}
 
-	tmpHashes := make(map[string][]byte)
+	tmpHashes := make(map[string]txRef)
 
 	switch { //nolint:staticcheck
 	case c.Op == syntax.TEq:
@@ -493,7 +577,7 @@ func (txi *TxIndex) match(
 REMOVE_LOOP:
 	for k, v := range filteredHashes {
 		tmpHash := tmpHashes[k]
-		if tmpHash == nil || !bytes.Equal(tmpHash, v) {
+		if tmpHash.hash == nil || !bytes.Equal(tmpHash.hash, v.hash) {
 			delete(filteredHashes, k)
 
 			// Potentially exit early.
@@ -517,17 +601,17 @@ func (txi *TxIndex) matchRange(
 	ctx context.Context,
 	qr indexer.QueryRange,
 	startKey []byte,
-	filteredHashes map[string][]byte,
+	filteredHashes map[string]txRef,
 	firstRun bool,
 	heightInfo HeightInfo,
-) map[string][]byte {
+) map[string]txRef {
 	// A previous match was attempted but resulted in no matches, so we return
 	// no matches (assuming AND operand).
 	if !firstRun && len(filteredHashes) == 0 {
 		return filteredHashes
 	}
 
-	tmpHashes := make(map[string][]byte)
+	tmpHashes := make(map[string]txRef)
 
 	it, err := dbm.IteratePrefix(txi.store, startKey)
 	if err != nil {
@@ -620,7 +704,7 @@ LOOP:
 REMOVE_LOOP:
 	for k, v := range filteredHashes {
 		tmpHash := tmpHashes[k]
-		if tmpHash == nil || !bytes.Equal(tmpHashes[k], v) {
+		if tmpHash.hash == nil || !bytes.Equal(tmpHash.hash, v.hash) {
 			delete(filteredHashes, k)
 
 			// Potentially exit early.
@@ -633,6 +717,48 @@ REMOVE_LOOP:
 	}
 
 	return filteredHashes
+}
+
+func uniqueRefs(filteredHashes map[string]txRef) []txRef {
+	refsByHash := make(map[string]txRef, len(filteredHashes))
+	for _, ref := range filteredHashes {
+		hashKey := string(ref.hash)
+		existing, ok := refsByHash[hashKey]
+		if !ok || txRefLess(existing, ref) {
+			refsByHash[hashKey] = ref
+		}
+	}
+
+	refs := make([]txRef, 0, len(refsByHash))
+	for _, ref := range refsByHash {
+		refs = append(refs, ref)
+	}
+
+	return refs
+}
+
+func sortRefs(refs []txRef, orderBy string) error {
+	switch orderBy {
+	case "desc":
+		sort.Slice(refs, func(i, j int) bool {
+			return txRefLess(refs[j], refs[i])
+		})
+	case "asc", "":
+		sort.Slice(refs, func(i, j int) bool {
+			return txRefLess(refs[i], refs[j])
+		})
+	default:
+		return errors.New("expected order_by to be either `asc` or `desc` or empty")
+	}
+
+	return nil
+}
+
+func txRefLess(a, b txRef) bool {
+	if a.height == b.height {
+		return a.index < b.index
+	}
+	return a.height < b.height
 }
 
 // Keys
@@ -674,6 +800,42 @@ func extractHeightFromKey(key []byte) (int64, error) {
 		return 0, err
 	}
 	return height, nil
+}
+
+func extractIndexFromKey(key []byte) (uint32, error) {
+	startPos := bytes.LastIndexByte(key, tagKeySeparatorRune)
+	if startPos == -1 {
+		return 0, errors.New("separator not found")
+	}
+
+	indexBz := key[startPos+1:]
+	if eventSeqPos := bytes.Index(indexBz, []byte(eventSeqSeparator)); eventSeqPos != -1 {
+		indexBz = indexBz[:eventSeqPos]
+	}
+
+	index, err := strconv.ParseUint(string(indexBz), 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(index), nil
+}
+
+func txRefFromKeyValue(key, value []byte) (txRef, error) {
+	height, err := extractHeightFromKey(key)
+	if err != nil {
+		return txRef{}, err
+	}
+
+	index, err := extractIndexFromKey(key)
+	if err != nil {
+		return txRef{}, err
+	}
+
+	return txRef{
+		hash:   value,
+		height: height,
+		index:  index,
+	}, nil
 }
 
 func extractValueFromKey(key []byte) string {

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -676,6 +676,110 @@ func TestTxSearchMultipleTxs(t *testing.T) {
 	require.Len(t, results, 2)
 }
 
+func TestTxSearchPagedOrdersAndCounts(t *testing.T) {
+	indexer := NewTxIndex(db.NewMemDB())
+
+	testTxs := []*abci.TxResult{
+		txResultWithEvents([]abci.Event{
+			{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
+		}),
+		txResultWithEvents([]abci.Event{
+			{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
+		}),
+		txResultWithEvents([]abci.Event{
+			{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
+		}),
+	}
+	testTxs[0].Tx = types.Tx("height 2 index 1")
+	testTxs[0].Height = 2
+	testTxs[0].Index = 1
+	testTxs[1].Tx = types.Tx("height 1 index 2")
+	testTxs[1].Height = 1
+	testTxs[1].Index = 2
+	testTxs[2].Tx = types.Tx("height 1 index 1")
+	testTxs[2].Height = 1
+	testTxs[2].Index = 1
+
+	for _, txResult := range testTxs {
+		require.NoError(t, indexer.Index(txResult))
+	}
+
+	ctx := context.Background()
+	q := query.MustCompile("account.number = 1")
+
+	results, totalCount, err := indexer.SearchPaged(ctx, q, "asc", 0, 2)
+	require.NoError(t, err)
+	require.Equal(t, 3, totalCount)
+	require.Len(t, results, 2)
+	require.Equal(t, int64(1), results[0].Height)
+	require.Equal(t, uint32(1), results[0].Index)
+	require.Equal(t, int64(1), results[1].Height)
+	require.Equal(t, uint32(2), results[1].Index)
+
+	results, totalCount, err = indexer.SearchPaged(ctx, q, "desc", 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, 3, totalCount)
+	require.Len(t, results, 1)
+	require.Equal(t, int64(1), results[0].Height)
+	require.Equal(t, uint32(2), results[0].Index)
+}
+
+func TestTxSearchPagedOnlyUnmarshalsRequestedPage(t *testing.T) {
+	indexer := NewTxIndex(db.NewMemDB())
+
+	for i := int64(1); i <= 3; i++ {
+		txResult := txResultWithEvents([]abci.Event{
+			{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
+		})
+		txResult.Tx = types.Tx(fmt.Sprintf("tx %d", i))
+		txResult.Height = i
+		require.NoError(t, indexer.Index(txResult))
+
+		if i == 3 {
+			require.NoError(t, indexer.store.Set(types.Tx(txResult.Tx).Hash(), []byte("not a tx result")))
+		}
+	}
+
+	ctx := context.Background()
+	q := query.MustCompile("account.number = 1")
+
+	results, totalCount, err := indexer.SearchPaged(ctx, q, "asc", 0, 2)
+	require.NoError(t, err)
+	require.Equal(t, 3, totalCount)
+	require.Len(t, results, 2)
+	require.Equal(t, int64(1), results[0].Height)
+	require.Equal(t, int64(2), results[1].Height)
+
+	results, totalCount, err = indexer.SearchPaged(ctx, q, "asc", 2, 1)
+	require.Error(t, err)
+	require.Nil(t, results)
+	require.Zero(t, totalCount)
+}
+
+func TestTxSearchPagedFallsBackToStoredResultForMalformedIndexKey(t *testing.T) {
+	indexer := NewTxIndex(db.NewMemDB())
+
+	txResult := txResultWithEvents(nil)
+	txResult.Tx = types.Tx("malformed index key")
+	txResult.Height = 7
+	txResult.Index = 3
+	hash := types.Tx(txResult.Tx).Hash()
+
+	rawBytes, err := proto.Marshal(txResult)
+	require.NoError(t, err)
+
+	b := indexer.store.NewBatch()
+	require.NoError(t, b.Set([]byte("sender/addr1/7/not-an-index"), hash))
+	require.NoError(t, b.Set(hash, rawBytes))
+	require.NoError(t, b.Write())
+
+	results, totalCount, err := indexer.SearchPaged(context.Background(), query.MustCompile("sender = 'addr1'"), "asc", 0, 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, totalCount)
+	require.Len(t, results, 1)
+	require.True(t, proto.Equal(txResult, results[0]))
+}
+
 func txResultWithEvents(events []abci.Event) *abci.TxResult {
 	tx := types.Tx("HELLO WORLD")
 	return &abci.TxResult{


### PR DESCRIPTION
Forward-port of #2962 (which targets `v0.39.x-celestia`) onto `main`.

---

The current `tx_search` path applies pagination too late:

1. `rpc/core/tx.go` — `env.TxIndexer.Search(ctx.Context(), q)` returns the fully materialized `[]*abci.TxResult`.
2. `state/txindex/kv/kv.go` — accumulates `filteredHashes` as an unbounded `map[string][]byte`.
3. `state/txindex/kv/kv.go` — calls `txi.Get(h)` for every matching hash, which proto-unmarshals the full `TxResult`.
4. `rpc/core/tx.go` — sorts the entire slice.
5. `rpc/core/tx.go` — applies `per_page` **only after** the full unmarshal+sort.

Pyroscope shows this exact path dominating `memory:inuse_space`: `TxSearch`, `TxIndex.Get`, `TxResult.Unmarshal`, `ExecTxResult.Unmarshal`, `Event.Unmarshal`, `EventAttribute.Unmarshal`.

Per-row cost: a `TxResult` is typically 1-10 KB unmarshalled. A lightweight ref `(hash, height, index, eventSeq)` is ~40-50 B. For a 1M-match query: ~1-10 GB → ~40-50 MB intermediate.

Tracked in https://linear.app/celestia/issue/PROTOCO-1572/oom-from-celestia-core-w-many-txsearch-queries.