### PR TITLE
feat(mempool): guarantee SeenTx broadcasts to persistent peers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,10 @@ const (
 
 	MempoolTypeNop = "nop"
 	MempoolTypeCAT = "cat"
+
+	// DefaultMaxPersistentStickyPeers caps how many persistent peers are guaranteed
+	// in the SeenTx broadcast set per signer when the config field is unset.
+	DefaultMaxPersistentStickyPeers = 4
 )
 
 // NOTE: Most of the structs & relevant comments + the
@@ -846,6 +850,12 @@ type MempoolConfig struct {
 	// it's insertion time into the mempool is beyond TTLDuration.
 	// Deprecated: TTLNumBlocks is deprecated and will be removed in a future version.
 	TTLNumBlocks int64 `mapstructure:"ttl-num-blocks"`
+
+	// MaxPersistentStickyPeers is the upper bound on persistent peers guaranteed
+	// to receive SeenTx broadcasts per signer (added on top of the natural sticky
+	// set, never displacing it). 0 falls back to the default. This key is omitted
+	// from the generated config.toml; set it explicitly to override.
+	MaxPersistentStickyPeers int `mapstructure:"max_persistent_sticky_peers"`
 }
 
 // DefaultMempoolConfig returns a default configuration for the CometBFT mempool
@@ -864,8 +874,9 @@ func DefaultMempoolConfig() *MempoolConfig {
 		MaxTxBytes:  1024 * 1024, // 1MB
 		ExperimentalMaxGossipConnectionsToNonPersistentPeers: 0,
 		ExperimentalMaxGossipConnectionsToPersistentPeers:    0,
-		TTLDuration:  0 * time.Second,
-		TTLNumBlocks: 0,
+		TTLDuration:              0 * time.Second,
+		TTLNumBlocks:             0,
+		MaxPersistentStickyPeers: DefaultMaxPersistentStickyPeers,
 	}
 }
 
@@ -911,6 +922,9 @@ func (cfg *MempoolConfig) ValidateBasic() error {
 	}
 	if cfg.ExperimentalMaxGossipConnectionsToNonPersistentPeers < 0 {
 		return errors.New("experimental_max_gossip_connections_to_non_persistent_peers can't be negative")
+	}
+	if cfg.MaxPersistentStickyPeers < 0 {
+		return errors.New("max_persistent_sticky_peers can't be negative")
 	}
 	return nil
 }

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -42,6 +42,12 @@ const (
 	// maxSeenTxBroadcast defines the maximum number of peers to which a SeenTx message should be broadcasted.
 	maxSeenTxBroadcast = 15
 
+	// defaultMaxPersistentStickyPeers caps how many persistent peers are guaranteed
+	// to receive SeenTx broadcasts per signer (added on top of the natural sticky
+	// set, never displacing it). Used when ReactorOptions.MaxPersistentStickyPeers
+	// is unset.
+	defaultMaxPersistentStickyPeers = 4
+
 	// maxReceivedBufferSize limits how far ahead of the expected sequence we will
 	// request/buffer transactions. Txs with sequence > expected + maxReceivedBufferSize are rejected.
 	maxReceivedBufferSize = 30
@@ -94,6 +100,11 @@ type ReactorOptions struct {
 	// StickyPeerSalt is used to derive the rendezvous hash for sticky peer selection.
 	// If unset, all nodes will derive the same peer ordering.
 	StickyPeerSalt []byte
+
+	// MaxPersistentStickyPeers caps how many persistent peers are guaranteed
+	// to receive SeenTx broadcasts per signer, added on top of the natural sticky
+	// set without displacing it. <= 0 falls back to defaultMaxPersistentStickyPeers.
+	MaxPersistentStickyPeers int
 }
 
 func (opts *ReactorOptions) VerifyAndComplete() error {
@@ -103,6 +114,10 @@ func (opts *ReactorOptions) VerifyAndComplete() error {
 
 	if opts.MaxGossipDelay == 0 {
 		opts.MaxGossipDelay = DefaultGossipDelay
+	}
+
+	if opts.MaxPersistentStickyPeers <= 0 {
+		opts.MaxPersistentStickyPeers = defaultMaxPersistentStickyPeers
 	}
 
 	if opts.MaxTxSize < 0 {
@@ -512,10 +527,19 @@ func (memR *Reactor) broadcastSeenTxWithHeight(txKey types.TxKey, height int64, 
 	}
 
 	orderedPeers := selectStickyPeers(signer, peers, len(peers), memR.currentStickyPeerSalt())
+	maxPersistent := memR.opts.MaxPersistentStickyPeers
 	sent := 0
+	sentPersistent := 0
 	for _, peerInfo := range orderedPeers {
-		if sent >= maxSeenTxBroadcast {
-			break
+		// Send to the natural top maxSeenTxBroadcast peers; additionally guarantee
+		// up to maxPersistent persistent peers receive the SeenTx, even if they
+		// rank outside the top maxSeenTxBroadcast. Persistent peers are appended,
+		// never displacing the natural set.
+		isPersistent := peerInfo.peer.IsPersistent()
+		underMainCap := sent < maxSeenTxBroadcast
+		needPersistent := isPersistent && sentPersistent < maxPersistent
+		if !underMainCap && !needPersistent {
+			continue
 		}
 
 		id := peerInfo.id
@@ -543,6 +567,9 @@ func (memR *Reactor) broadcastSeenTxWithHeight(txKey types.TxKey, height int64, 
 			memR.mempool.PeerHasTx(id, txKey)
 			schema.WriteMempoolPeerState(memR.traceClient, string(peer.ID()), schema.SeenTx, txKey[:], schema.Upload)
 			sent++
+			if isPersistent {
+				sentPersistent++
+			}
 		}
 	}
 }

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -536,9 +536,8 @@ func (memR *Reactor) broadcastSeenTxWithHeight(txKey types.TxKey, height int64, 
 		// rank outside the top maxSeenTxBroadcast. Persistent peers are appended,
 		// never displacing the natural set.
 		isPersistent := peerInfo.peer.IsPersistent()
-		underMainCap := sent < maxSeenTxBroadcast
-		needPersistent := isPersistent && sentPersistent < maxPersistent
-		if !underMainCap && !needPersistent {
+		canSend := sent < maxSeenTxBroadcast || (isPersistent && sentPersistent < maxPersistent)
+		if !canSend {
 			continue
 		}
 

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -594,15 +594,6 @@ func genPeer() *mocks.Peer {
 	return peer
 }
 
-func genPersistentPeer() *mocks.Peer {
-	peer := &mocks.Peer{}
-	nodeKey := p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
-	peer.On("ID").Return(nodeKey.ID())
-	peer.On("Get", types.PeerStateKey).Return(nil).Maybe()
-	peer.On("IsPersistent").Return(true).Maybe()
-	return peer
-}
-
 // sequenceTrackingApp is a test application that implements SequenceQuerier
 type sequenceTrackingApp struct {
 	*kvstore.Application

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -382,8 +382,9 @@ func TestReactorOptionsVerifyAndComplete(t *testing.T) {
 			name: "default options should use DefaultGossipDelay",
 			opts: ReactorOptions{},
 			expected: ReactorOptions{
-				MaxTxSize:      cfg.DefaultMempoolConfig().MaxTxBytes,
-				MaxGossipDelay: DefaultGossipDelay,
+				MaxTxSize:                cfg.DefaultMempoolConfig().MaxTxBytes,
+				MaxGossipDelay:           DefaultGossipDelay,
+				MaxPersistentStickyPeers: defaultMaxPersistentStickyPeers,
 			},
 			wantErr: false,
 		},
@@ -393,8 +394,9 @@ func TestReactorOptionsVerifyAndComplete(t *testing.T) {
 				MaxGossipDelay: 30 * time.Second,
 			},
 			expected: ReactorOptions{
-				MaxTxSize:      cfg.DefaultMempoolConfig().MaxTxBytes,
-				MaxGossipDelay: 30 * time.Second,
+				MaxTxSize:                cfg.DefaultMempoolConfig().MaxTxBytes,
+				MaxGossipDelay:           30 * time.Second,
+				MaxPersistentStickyPeers: defaultMaxPersistentStickyPeers,
 			},
 			wantErr: false,
 		},
@@ -412,6 +414,36 @@ func TestReactorOptionsVerifyAndComplete(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "unset MaxPersistentStickyPeers falls back to default",
+			opts: ReactorOptions{},
+			expected: ReactorOptions{
+				MaxTxSize:                cfg.DefaultMempoolConfig().MaxTxBytes,
+				MaxGossipDelay:           DefaultGossipDelay,
+				MaxPersistentStickyPeers: defaultMaxPersistentStickyPeers,
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative MaxPersistentStickyPeers falls back to default",
+			opts: ReactorOptions{MaxPersistentStickyPeers: -3},
+			expected: ReactorOptions{
+				MaxTxSize:                cfg.DefaultMempoolConfig().MaxTxBytes,
+				MaxGossipDelay:           DefaultGossipDelay,
+				MaxPersistentStickyPeers: defaultMaxPersistentStickyPeers,
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom MaxPersistentStickyPeers is preserved",
+			opts: ReactorOptions{MaxPersistentStickyPeers: 7},
+			expected: ReactorOptions{
+				MaxTxSize:                cfg.DefaultMempoolConfig().MaxTxBytes,
+				MaxGossipDelay:           DefaultGossipDelay,
+				MaxPersistentStickyPeers: 7,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -424,6 +456,7 @@ func TestReactorOptionsVerifyAndComplete(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected.MaxTxSize, tt.opts.MaxTxSize)
 			assert.Equal(t, tt.expected.MaxGossipDelay, tt.opts.MaxGossipDelay)
+			assert.Equal(t, tt.expected.MaxPersistentStickyPeers, tt.opts.MaxPersistentStickyPeers)
 		})
 	}
 }
@@ -557,6 +590,16 @@ func genPeer() *mocks.Peer {
 	nodeKey := p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
 	peer.On("ID").Return(nodeKey.ID())
 	peer.On("Get", types.PeerStateKey).Return(nil).Maybe()
+	peer.On("IsPersistent").Return(false).Maybe()
+	return peer
+}
+
+func genPersistentPeer() *mocks.Peer {
+	peer := &mocks.Peer{}
+	nodeKey := p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
+	peer.On("ID").Return(nodeKey.ID())
+	peer.On("Get", types.PeerStateKey).Return(nil).Maybe()
+	peer.On("IsPersistent").Return(true).Maybe()
 	return peer
 }
 
@@ -1560,4 +1603,227 @@ func TestSeenTxDirectPathEnforcesPerPeerRequestLimit(t *testing.T) {
 	assert.LessOrEqual(t, requestCount, maxRequestsPerPeer,
 		"SeenTx direct path should not exceed maxRequestsPerPeer (%d) but got %d requests",
 		maxRequestsPerPeer, requestCount)
+}
+
+// plannedPeer is a deterministic peer descriptor used to build mocks.Peer
+// instances with known IDs and pre-computed rendezvous rankings.
+type plannedPeer struct {
+	id         p2p.ID
+	persistent bool
+}
+
+// planPeers generates `total` peers with deterministic IDs, computes their
+// rendezvous ranking against (signer, salt), and marks the bottom
+// `persistentBottom` ranked peers as persistent (or top `persistentTop` if set
+// instead). Use this to control which peers fall outside the natural sticky cap.
+func planPeers(signer, salt []byte, total, persistentBottom, persistentTop int) []plannedPeer {
+	plans := make([]plannedPeer, total)
+	for i := range plans {
+		plans[i].id = p2p.ID(fmt.Sprintf("test-peer-%04d-deterministic-id-padding-fillerz", i))
+	}
+	type scored struct {
+		idx   int
+		score uint64
+	}
+	s := make([]scored, total)
+	for i := range plans {
+		s[i] = scored{i, stickyScore64(signer, string(plans[i].id), salt)}
+	}
+	sort.Slice(s, func(i, j int) bool {
+		if s[i].score == s[j].score {
+			return plans[s[i].idx].id < plans[s[j].idx].id
+		}
+		return s[i].score > s[j].score
+	})
+	for i := 0; i < persistentTop; i++ {
+		plans[s[i].idx].persistent = true
+	}
+	for i := total - persistentBottom; i < total; i++ {
+		plans[s[i].idx].persistent = true
+	}
+	return plans
+}
+
+// newPlannedPeer creates a *mocks.Peer with the given ID, IsPersistent flag,
+// and a permissive Send stub.
+func newPlannedPeer(p plannedPeer) *mocks.Peer {
+	peer := &mocks.Peer{}
+	peer.On("ID").Return(p.id)
+	peer.On("Get", types.PeerStateKey).Return(nil).Maybe()
+	peer.On("IsPersistent").Return(p.persistent).Maybe()
+	peer.On("Send", mock.Anything).Return(true).Maybe()
+	return peer
+}
+
+// stickyTestReactor builds a reactor wired with the planned peers.
+func stickyTestReactor(t *testing.T, opts *ReactorOptions, plans []plannedPeer) (*Reactor, []*mocks.Peer) {
+	t.Helper()
+	app := &application{kvstore.NewApplication(db.NewMemDB())}
+	cc := proxy.NewLocalClientCreator(app)
+	pool, cleanup := newMempoolWithApp(cc)
+	t.Cleanup(cleanup)
+	if opts == nil {
+		opts = &ReactorOptions{}
+	}
+	reactor, err := NewReactor(pool, opts)
+	require.NoError(t, err)
+
+	mockPeers := make([]*mocks.Peer, len(plans))
+	for i, p := range plans {
+		mockPeers[i] = newPlannedPeer(p)
+		_, err := reactor.InitPeer(mockPeers[i])
+		require.NoError(t, err)
+	}
+	return reactor, mockPeers
+}
+
+// sendRecipientIDs returns the set of peer IDs whose Send mock was invoked.
+func sendRecipientIDs(peers []*mocks.Peer) map[p2p.ID]bool {
+	recipients := make(map[p2p.ID]bool)
+	for _, p := range peers {
+		for _, c := range p.Calls {
+			if c.Method == "Send" {
+				recipients[p.ID()] = true
+				break
+			}
+		}
+	}
+	return recipients
+}
+
+// TestBroadcastSeenTxIncludesPersistentBeyondCap verifies persistent peers ranked
+// outside the natural top-maxSeenTxBroadcast still receive the SeenTx, additively.
+func TestBroadcastSeenTxIncludesPersistentBeyondCap(t *testing.T) {
+	const totalPeers = 30
+	const persistentCount = 4
+
+	signer := []byte("signer-A")
+	salt := []byte("salt-A")
+	plans := planPeers(signer, salt, totalPeers, persistentCount, 0)
+
+	reactor, peers := stickyTestReactor(t, &ReactorOptions{
+		StickyPeerSalt:           salt,
+		MaxPersistentStickyPeers: persistentCount,
+	}, plans)
+
+	persistentIDs := make(map[p2p.ID]bool)
+	for _, p := range plans {
+		if p.persistent {
+			persistentIDs[p.id] = true
+		}
+	}
+	require.Len(t, persistentIDs, persistentCount)
+
+	ordered := selectStickyPeers(signer, reactor.ids.GetAll(), totalPeers, salt)
+
+	txKey := types.TxKey{}
+	copy(txKey[:], bytes.Repeat([]byte{0xab}, 32))
+	reactor.broadcastSeenTxWithHeight(txKey, 1, signer, 1)
+
+	recipients := sendRecipientIDs(peers)
+	for i := 0; i < maxSeenTxBroadcast; i++ {
+		require.True(t, recipients[ordered[i].peer.ID()], "natural top-%d peer missing at index %d", maxSeenTxBroadcast, i)
+	}
+	for id := range persistentIDs {
+		require.True(t, recipients[id], "persistent peer %s missing from broadcast", id)
+	}
+	require.Len(t, recipients, maxSeenTxBroadcast+persistentCount)
+}
+
+// TestBroadcastSeenTxNoPersistentNoChange verifies behavior is unchanged when no
+// persistent peers are connected: only the natural top-maxSeenTxBroadcast receive.
+func TestBroadcastSeenTxNoPersistentNoChange(t *testing.T) {
+	const totalPeers = 30
+
+	signer := []byte("signer-B")
+	salt := []byte("salt-B")
+	plans := planPeers(signer, salt, totalPeers, 0, 0)
+
+	reactor, peers := stickyTestReactor(t, &ReactorOptions{StickyPeerSalt: salt}, plans)
+	ordered := selectStickyPeers(signer, reactor.ids.GetAll(), totalPeers, salt)
+
+	txKey := types.TxKey{}
+	copy(txKey[:], bytes.Repeat([]byte{0xcd}, 32))
+	reactor.broadcastSeenTxWithHeight(txKey, 1, signer, 1)
+
+	recipients := sendRecipientIDs(peers)
+	require.Len(t, recipients, maxSeenTxBroadcast)
+	for i := 0; i < maxSeenTxBroadcast; i++ {
+		require.True(t, recipients[ordered[i].peer.ID()])
+	}
+}
+
+// TestBroadcastSeenTxPersistentInTopCapNoExtras verifies the broadcast set does
+// not grow when persistent peers are already inside the natural top set.
+func TestBroadcastSeenTxPersistentInTopCapNoExtras(t *testing.T) {
+	const totalPeers = 30
+
+	signer := []byte("signer-C")
+	salt := []byte("salt-C")
+	// Mark only top-2 ranked peers as persistent so they're already in top-15.
+	plans := planPeers(signer, salt, totalPeers, 0, 2)
+
+	reactor, peers := stickyTestReactor(t, &ReactorOptions{StickyPeerSalt: salt}, plans)
+
+	txKey := types.TxKey{}
+	copy(txKey[:], bytes.Repeat([]byte{0xef}, 32))
+	reactor.broadcastSeenTxWithHeight(txKey, 1, signer, 1)
+
+	recipients := sendRecipientIDs(peers)
+	require.Len(t, recipients, maxSeenTxBroadcast)
+}
+
+// TestBroadcastSeenTxRespectsMaxPersistent verifies extra persistent peers beyond
+// MaxPersistentStickyPeers are not added.
+func TestBroadcastSeenTxRespectsMaxPersistent(t *testing.T) {
+	const totalPeers = 30
+	const persistentBottom = 10
+	const maxPersistent = 4
+
+	signer := []byte("signer-D")
+	salt := []byte("salt-D")
+	plans := planPeers(signer, salt, totalPeers, persistentBottom, 0)
+
+	reactor, peers := stickyTestReactor(t, &ReactorOptions{
+		StickyPeerSalt:           salt,
+		MaxPersistentStickyPeers: maxPersistent,
+	}, plans)
+
+	txKey := types.TxKey{}
+	copy(txKey[:], bytes.Repeat([]byte{0x12}, 32))
+	reactor.broadcastSeenTxWithHeight(txKey, 1, signer, 1)
+
+	recipients := sendRecipientIDs(peers)
+	require.Len(t, recipients, maxSeenTxBroadcast+maxPersistent)
+}
+
+// TestBroadcastSeenTxDeterministicPersistentSelection verifies that the same
+// persistent peers are picked across reactors with identical (signer, salt, peers).
+func TestBroadcastSeenTxDeterministicPersistentSelection(t *testing.T) {
+	const totalPeers = 30
+	const persistentBottom = 10
+	const maxPersistent = 3
+
+	signer := []byte("signer-E")
+	salt := []byte("salt-E")
+	plans := planPeers(signer, salt, totalPeers, persistentBottom, 0)
+
+	r1, peers1 := stickyTestReactor(t, &ReactorOptions{
+		StickyPeerSalt:           salt,
+		MaxPersistentStickyPeers: maxPersistent,
+	}, plans)
+	r2, peers2 := stickyTestReactor(t, &ReactorOptions{
+		StickyPeerSalt:           salt,
+		MaxPersistentStickyPeers: maxPersistent,
+	}, plans)
+
+	txKey := types.TxKey{}
+	copy(txKey[:], bytes.Repeat([]byte{0x77}, 32))
+	r1.broadcastSeenTxWithHeight(txKey, 1, signer, 1)
+	r2.broadcastSeenTxWithHeight(txKey, 1, signer, 1)
+
+	rec1 := sendRecipientIDs(peers1)
+	rec2 := sendRecipientIDs(peers2)
+	require.Equal(t, rec1, rec2, "persistent peer selection must be deterministic across reactors")
+	require.Len(t, rec1, maxSeenTxBroadcast+maxPersistent)
 }

--- a/node/setup.go
+++ b/node/setup.go
@@ -265,10 +265,11 @@ func createMempoolAndMempoolReactor(
 		reactor, err := cat.NewReactor(
 			mp,
 			&cat.ReactorOptions{
-				ListenOnly:     !config.Mempool.Broadcast,
-				MaxTxSize:      config.Mempool.MaxTxBytes,
-				TraceClient:    traceClient,
-				MaxGossipDelay: config.Mempool.MaxGossipDelay,
+				ListenOnly:               !config.Mempool.Broadcast,
+				MaxTxSize:                config.Mempool.MaxTxBytes,
+				TraceClient:              traceClient,
+				MaxGossipDelay:           config.Mempool.MaxGossipDelay,
+				MaxPersistentStickyPeers: config.Mempool.MaxPersistentStickyPeers,
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
Closes [PROTOCO-1468](https://linear.app/celestia/issue/PROTOCO-1468/synchronise-mempools-of-persistent-peers-in-celestia-core).

## Summary
- Sticky-set SeenTx broadcasts now additionally cover up to `MaxPersistentStickyPeers` (default 4) persistent peers per signer, picked deterministically by rendezvous order.
- Natural top-`maxSeenTxBroadcast` set is unchanged — persistent peers are appended, never displaced; existing height/seen filters apply uniformly.
- `MempoolConfig.MaxPersistentStickyPeers` is configurable but omitted from the generated `config.toml`; operators add the key manually to override.

## Test plan
- [x] `go test ./mempool/cat/...`
- [x] `go test ./config/...`
- [x] `go test ./node/...`
- [x] New unit tests cover: persistent peer added past the cap, no-op when no persistent peers, no-op when persistent peers already in top set, `MaxPersistentStickyPeers` cap respected, cross-reactor determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)