### PR TITLE
chore: consolidate go.mod require blocks

### DIFF
--- a/.changelog/unreleased/improvements/3020-consolidate-require-blocks.md
+++ b/.changelog/unreleased/improvements/3020-consolidate-require-blocks.md
@@ -1,0 +1,1 @@
+- [deps] Consolidate `require` blocks in `go.mod` into one block for direct dependencies and one block for indirect dependencies.

--- a/.changelog/unreleased/improvements/3020-consolidate-require-blocks.md
+++ b/.changelog/unreleased/improvements/3020-consolidate-require-blocks.md
@@ -1,1 +1,0 @@
-- [deps] Consolidate `require` blocks in `go.mod` into one block for direct dependencies and one block for indirect dependencies.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/celestiaorg/go-square/v3 v3.0.2
 	github.com/celestiaorg/nmt v0.24.3
-	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cometbft/cometbft-db v1.0.4
 	github.com/cosmos/gogoproto v1.7.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
@@ -23,6 +22,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/go-logfmt/logfmt v0.6.1
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/orderedcode v0.0.1
 	github.com/google/uuid v1.6.0
@@ -31,6 +31,7 @@ require (
 	github.com/grafana/pyroscope-go v1.2.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/informalsystems/tm-load-test v1.3.0
+	github.com/klauspost/reedsolomon v1.13.3
 	github.com/lib/pq v1.12.3
 	github.com/minio/highwayhash v1.0.4
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20220708102147-0a8a51822cae
@@ -46,7 +47,6 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -56,12 +56,6 @@ require (
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
-)
-
-require (
-	github.com/gogo/protobuf v1.3.2
-	github.com/golang/snappy v0.0.4 // indirect
-	github.com/klauspost/reedsolomon v1.13.3
 )
 
 require (
@@ -122,6 +116,7 @@ require (
 	github.com/butuzov/mirror v1.3.0 // indirect
 	github.com/catenacyber/perfsprint v0.10.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
@@ -177,6 +172,7 @@ require (
 	github.com/godoc-lint/godoc-lint v0.11.1 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
 	github.com/golangci/go-printf-func-name v0.1.1 // indirect
@@ -286,6 +282,7 @@ require (
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect


### PR DESCRIPTION
## Summary

Consolidate the three `require` blocks in `go.mod` into one block for direct dependencies and one block for indirect dependencies.

Closes https://github.com/celestiaorg/celestia-core/issues/3020
Closes https://linear.app/celestia/issue/PROTOCO-1692

## Test plan

- [x] `go mod tidy` is a no-op after the change
- [x] `go build ./...` succeeds
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)