### PR TITLE
test(mempool/cat): fix TestReactorBroadcastTxsMessage flake from tied priorities

### DIFF
--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -77,10 +77,8 @@ func TestWaitForTxsOnReactor_AcceptsArbitraryOrderForTiedPriorities(t *testing.T
 	require.NoError(t, pool.CheckTx(txA, nil, mempool.TxInfo{}))
 	require.NoError(t, pool.CheckTx(txB, nil, mempool.TxInfo{}))
 
-	// Pass the expected txs in the opposite order from how they were inserted.
-	// The mempool returns them in insertion order (txA before txB), but the
-	// helper must accept any order because gossip-induced reordering means
-	// remote reactors may see them in either sequence.
+	// Pass expected in opposite order from insertion to exercise the
+	// order-agnostic comparison.
 	expected := types.CachedTxFromTxs(types.Txs{txB, txA})
 	waitForTxsOnReactor(t, expected, reactor, 0)
 }

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -63,6 +63,28 @@ func TestReactorBroadcastTxsMessage(t *testing.T) {
 	waitForTxsOnReactors(t, transactions, reactors)
 }
 
+// When two txs share a priority, gossip order across reactors is
+// non-deterministic, so waitForTxsOnReactor must verify set membership rather
+// than per-index equality. See issue #2945.
+func TestWaitForTxsOnReactor_AcceptsArbitraryOrderForTiedPriorities(t *testing.T) {
+	reactor, pool := setupReactor(t)
+	t.Cleanup(func() { _ = reactor.Stop() })
+
+	const sharedPriority = int64(5)
+	txA := types.Tx(newTx(0, mempool.UnknownPeerID, []byte("A"), sharedPriority))
+	txB := types.Tx(newTx(1, mempool.UnknownPeerID, []byte("B"), sharedPriority))
+
+	require.NoError(t, pool.CheckTx(txA, nil, mempool.TxInfo{}))
+	require.NoError(t, pool.CheckTx(txB, nil, mempool.TxInfo{}))
+
+	// Pass the expected txs in the opposite order from how they were inserted.
+	// The mempool returns them in insertion order (txA before txB), but the
+	// helper must accept any order because gossip-induced reordering means
+	// remote reactors may see them in either sequence.
+	expected := types.CachedTxFromTxs(types.Txs{txB, txA})
+	waitForTxsOnReactor(t, expected, reactor, 0)
+}
+
 func TestReactorSendWantTxAfterReceivingSeenTx(t *testing.T) {
 	reactor, _ := setupReactor(t)
 
@@ -568,11 +590,15 @@ func waitForTxsOnReactor(t *testing.T, txs []*types.CachedTx, reactor *Reactor, 
 	}
 
 	reapedTxs := mempool.ReapMaxTxs(len(txs))
-	for i, tx := range txs {
+	require.Equal(t, len(txs), len(reapedTxs),
+		"reactor %d: expected %d txs, got %d", reactorIndex, len(txs), len(reapedTxs))
+	// Compare as a set: across reactors, txs with equal priority can be reaped
+	// in different orders depending on gossip arrival, so per-index equality is
+	// non-deterministic. See issue #2945.
+	for _, tx := range txs {
 		_ = tx.Hash() // to set the hash field in the cached tx
-		require.Contains(t, reapedTxs, tx)
-		require.Equal(t, tx, reapedTxs[i],
-			"txs at index %d on reactor %d don't match: %x vs %x", i, reactorIndex, tx, reapedTxs[i])
+		require.Contains(t, reapedTxs, tx,
+			"reactor %d: missing expected tx %x", reactorIndex, tx)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the recurring `TestReactorBroadcastTxsMessage` flake in `mempool/cat`. The helper `waitForTxsOnReactor` asserts each reactor's reaped txs match the expected slice **at every index**. When two of the 10 random priorities (drawn from 8 999 distinct values, so collisions hit at ~0.5% per run) end up tied, the mempool's secondary sort key — `firstTimestamp` — depends on which order each reactor received the tx via gossip. Reactor 0 sees them in insertion order; remote reactors see them in arbitrary gossip order. The result is a `txs at index N on reactor M don't match` failure that retrying typically clears.

The fix replaces per-index equality with a length check + set membership, which expresses the test's actual intent (broadcast propagated all txs to all reactors) without depending on tie-break ordering.

## Changes

- `mempool/cat/reactor_test.go`: Drop racy `require.Equal(t, tx, reapedTxs[i], ...)` from `waitForTxsOnReactor`; add explicit length assertion; comment why per-index comparison is unsafe.
- Add `TestWaitForTxsOnReactor_AcceptsArbitraryOrderForTiedPriorities`: a focused unit test that inserts two tied-priority txs and passes them in opposite order. Fails on the previous helper, passes after the fix — locks in the relaxed contract.

## Test plan

- [x] `go test -tags deadlock -v -run '^TestWaitForTxsOnReactor_AcceptsArbitraryOrderForTiedPriorities$' ./mempool/cat/` — fails on previous code (RED), passes on fix (GREEN)
- [x] `go test -tags deadlock -count=50 -run '^TestReactorBroadcastTxsMessage$' ./mempool/cat/` — 50/50 pass
- [x] `go test -tags deadlock ./mempool/cat/` — full package passes
- [x] `go tool golangci-lint run ./mempool/cat/...` — 0 issues
- [ ] CI is green on this PR

Closes #2945
Closes https://linear.app/celestia/issue/PROTOCO-1521/flaky-testreactorbroadcasttxsmessage-in-mempoolcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)