### PR TITLE
fix(consensus): flake in TestSetValidBlockOnDelayedProposal

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1415,11 +1415,17 @@ func TestSetValidBlockOnDelayedProposal(t *testing.T) {
 	}
 
 	ensureNewProposal(proposalCh, height, round)
-	rs := cs1.GetRoundState()
 
-	assert.True(t, bytes.Equal(rs.ValidBlock.Hash(), propBlockHash))
-	assert.True(t, rs.ValidBlockParts.Header().Equals(propBlockParts.Header()))
-	assert.True(t, rs.ValidRound == round)
+	// EventCompleteProposal fires before handleCompleteProposal updates ValidBlock,
+	// so poll until the round state has settled.
+	require.Eventually(t, func() bool {
+		rs := cs1.GetRoundState()
+		return rs.ValidBlock != nil &&
+			bytes.Equal(rs.ValidBlock.Hash(), propBlockHash) &&
+			rs.ValidBlockParts != nil &&
+			rs.ValidBlockParts.Header().Equals(propBlockParts.Header()) &&
+			rs.ValidRound == round
+	}, ensureTimeout, 10*time.Millisecond)
 }
 
 func TestProcessProposalAccept(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestSetValidBlockOnDelayedProposal` flaked in CI ([run 25473478672](https://github.com/celestiaorg/celestia-core/actions/runs/25473478672), attempt 1 failed, attempt 2 succeeded).

## Root cause

In `consensus/state.go`, the `BlockPartMessage` handler calls `addProposalBlockPart`, which publishes `EventCompleteProposal` once the block is reassembled. The handler then unlocks, re-locks, and only afterward calls `handleCompleteProposal`, which is what actually updates `ValidBlock`, `ValidBlockParts`, and `ValidRound`.

The test wakes on `EventCompleteProposal` via `ensureNewProposal`, then reads `RoundState`. When the runtime schedules things just right, that read lands between the event publish and `handleCompleteProposal`, so the assertions on `ValidBlock` fail with `Should be true`.

Locally reproducible with `-count=200 -p 4 -race` (fails 1-2 times per run).

## Fix

Wrap the post-event assertions in `require.Eventually`, matching the pattern used in commit 2e3e8c715 to fix similar consensus test races. Production code is unchanged; this only makes the test tolerant of the existing event/state-update ordering.

## Test plan

- [x] `go test -tags deadlock -race -run TestSetValidBlockOnDelayedProposal -count=500 -p 8 ./consensus/` — 500/500 pass
- [x] `go tool golangci-lint run ./consensus/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)