### PR TITLE
fix(p2p/pex): de-flake TestPEXReactorRunning by ignoring duplicate-peer dial rejections

### DIFF
--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -106,6 +106,18 @@ func (e ErrRejected) IsAuthFailure() bool { return e.isAuthFailure }
 // IsDuplicate when Peer ID or IP are present already.
 func (e ErrRejected) IsDuplicate() bool { return e.isDuplicate }
 
+// DuplicatePeerID returns the peer ID and true when the rejection was caused
+// by a duplicate peer ID. Returns "", false for duplicate-IP rejections or
+// non-duplicate errors. Callers that need to know *why* a peer was deemed a
+// duplicate (e.g. to decide whether to penalize the dialed address) should
+// use this in preference to IsDuplicate.
+func (e ErrRejected) DuplicatePeerID() (ID, bool) {
+	if e.isDuplicate && e.id != "" {
+		return e.id, true
+	}
+	return "", false
+}
+
 // IsFiltered when Peer ID or IP was filtered.
 func (e ErrRejected) IsFiltered() bool { return e.isFiltered }
 

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -118,6 +118,22 @@ func (e ErrRejected) DuplicatePeerID() (ID, bool) {
 	return "", false
 }
 
+// NewErrRejectedDuplicateID builds a duplicate-by-peer-ID rejection. The
+// returned error reports DuplicatePeerID() == (id, true). Exposed primarily
+// so tests outside the p2p package can construct rejections without
+// reaching into unexported fields.
+func NewErrRejectedDuplicateID(id ID) ErrRejected {
+	return ErrRejected{id: id, isDuplicate: true}
+}
+
+// NewErrRejectedDuplicateIP builds a duplicate-by-IP rejection (no peer ID
+// recorded). The returned error reports IsDuplicate() == true but
+// DuplicatePeerID() == ("", false). Mirrors the rejection produced by the
+// duplicate-IP filter in the transport layer.
+func NewErrRejectedDuplicateIP() ErrRejected {
+	return ErrRejected{isDuplicate: true}
+}
+
 // IsFiltered when Peer ID or IP was filtered.
 func (e ErrRejected) IsFiltered() bool { return e.isFiltered }
 

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -560,6 +560,18 @@ func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
 		if _, ok := err.(p2p.ErrCurrentlyDialingOrExistingAddress); ok {
 			return err
 		}
+		// Treat duplicate-peer rejections as a successful dial: the peer is
+		// already connected (typically via an inbound connection raced against
+		// our outbound dial), so we shouldn't penalize this address with the
+		// 30s dial backoff or increment its attempt counter.
+		if e, ok := err.(p2p.ErrRejected); ok && e.IsDuplicate() {
+			r.attemptsToDial.Delete(addr.DialString())
+			return err
+		}
+		if _, ok := err.(p2p.ErrSwitchDuplicatePeerID); ok {
+			r.attemptsToDial.Delete(addr.DialString())
+			return err
+		}
 
 		markAddrInBookBasedOnErr(addr, r.book, err)
 		switch err.(type) {

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -543,6 +543,26 @@ func (r *Reactor) dialAttemptsInfo(addr *p2p.NetAddress) (attempts int, lastDial
 	return atd.number, atd.lastDialed
 }
 
+// isDuplicatePeerIDRejection reports whether err is a rejection caused by a
+// peer with id wantedID already being connected. Used by dialPeer to skip
+// backoff when an outbound dial loses a race to an inbound connection from
+// the same peer. Duplicate-IP rejections (no peer ID recorded) and
+// duplicate-ID rejections naming a *different* peer return false so they
+// follow the normal failure path — preventing an unrelated peer sharing an
+// IP, or a peer presenting an unexpected ID, from suppressing backoff for
+// the address we actually wanted to reach.
+func isDuplicatePeerIDRejection(err error, wantedID p2p.ID) bool {
+	if e, ok := err.(p2p.ErrRejected); ok {
+		if id, ok := e.DuplicatePeerID(); ok && id == wantedID {
+			return true
+		}
+	}
+	if e, ok := err.(p2p.ErrSwitchDuplicatePeerID); ok && e.ID == wantedID {
+		return true
+	}
+	return false
+}
+
 func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
 	attempts, lastDialed := r.dialAttemptsInfo(addr)
 	if attempts > maxAttemptsToDial && !r.Switch.IsPeerPersistent(addr) {
@@ -567,13 +587,7 @@ func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
 		// 30s dial backoff or increment its attempt counter. Duplicate-IP
 		// rejections take the normal failure path, since the colliding peer
 		// may not be the one we wanted (e.g. an unrelated peer sharing an IP).
-		if e, ok := err.(p2p.ErrRejected); ok {
-			if id, ok := e.DuplicatePeerID(); ok && id == addr.ID {
-				r.attemptsToDial.Delete(addr.DialString())
-				return err
-			}
-		}
-		if e, ok := err.(p2p.ErrSwitchDuplicatePeerID); ok && e.ID == addr.ID {
+		if isDuplicatePeerIDRejection(err, addr.ID) {
 			r.attemptsToDial.Delete(addr.DialString())
 			return err
 		}

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -560,15 +560,20 @@ func (r *Reactor) dialPeer(addr *p2p.NetAddress) error {
 		if _, ok := err.(p2p.ErrCurrentlyDialingOrExistingAddress); ok {
 			return err
 		}
-		// Treat duplicate-peer rejections as a successful dial: the peer is
+		// If the rejection came from a duplicate *peer ID* matching the peer
+		// we tried to dial, treat the dial as success-equivalent: the peer is
 		// already connected (typically via an inbound connection raced against
 		// our outbound dial), so we shouldn't penalize this address with the
-		// 30s dial backoff or increment its attempt counter.
-		if e, ok := err.(p2p.ErrRejected); ok && e.IsDuplicate() {
-			r.attemptsToDial.Delete(addr.DialString())
-			return err
+		// 30s dial backoff or increment its attempt counter. Duplicate-IP
+		// rejections take the normal failure path, since the colliding peer
+		// may not be the one we wanted (e.g. an unrelated peer sharing an IP).
+		if e, ok := err.(p2p.ErrRejected); ok {
+			if id, ok := e.DuplicatePeerID(); ok && id == addr.ID {
+				r.attemptsToDial.Delete(addr.DialString())
+				return err
+			}
 		}
-		if _, ok := err.(p2p.ErrSwitchDuplicatePeerID); ok {
+		if e, ok := err.(p2p.ErrSwitchDuplicatePeerID); ok && e.ID == addr.ID {
 			r.attemptsToDial.Delete(addr.DialString())
 			return err
 		}

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -111,7 +111,7 @@ func TestPEXReactorRunning(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	assertPeersWithTimeout(t, switches, 10*time.Millisecond, 30*time.Second, N-1)
+	assertPeersWithTimeout(t, switches, 10*time.Millisecond, 60*time.Second, N-1)
 
 	// stop them
 	for _, s := range switches {

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -111,7 +111,7 @@ func TestPEXReactorRunning(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	assertPeersWithTimeout(t, switches, 10*time.Millisecond, 10*time.Second, N-1)
+	assertPeersWithTimeout(t, switches, 10*time.Millisecond, 30*time.Second, N-1)
 
 	// stop them
 	for _, s := range switches {

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -978,3 +978,67 @@ func TestCapAddresses(t *testing.T) {
 		assert.True(t, result.Size() <= maxMsgSize)
 	})
 }
+
+// TestIsDuplicatePeerIDRejection pins the classification used in dialPeer to
+// decide whether a rejected dial should be treated as success-equivalent (a
+// peer with the same ID is already connected, e.g. via an inbound race) or
+// as a normal failure that should bump the attempt counter and trigger the
+// 30s backoff.
+//
+// The narrow case (id match) is what makes the de-flake fix safe: an attacker
+// who shares an IP with an honest address — but presents a different peer ID
+// (or no ID at all, as in duplicate-IP rejections) — cannot suppress backoff
+// for the honest address.
+func TestIsDuplicatePeerIDRejection(t *testing.T) {
+	const wantedID p2p.ID = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const otherID p2p.ID = "cafebabecafebabecafebabecafebabecafebabe"
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "ErrRejected duplicate-by-ID, matching ID -> success-equivalent",
+			err:  p2p.NewErrRejectedDuplicateID(wantedID),
+			want: true,
+		},
+		{
+			name: "ErrRejected duplicate-by-ID, mismatched ID -> normal failure",
+			err:  p2p.NewErrRejectedDuplicateID(otherID),
+			want: false,
+		},
+		{
+			name: "ErrRejected duplicate-by-IP (no peer ID) -> normal failure",
+			err:  p2p.NewErrRejectedDuplicateIP(),
+			want: false,
+		},
+		{
+			name: "ErrSwitchDuplicatePeerID, matching ID -> success-equivalent",
+			err:  p2p.ErrSwitchDuplicatePeerID{ID: wantedID},
+			want: true,
+		},
+		{
+			name: "ErrSwitchDuplicatePeerID, mismatched ID -> normal failure",
+			err:  p2p.ErrSwitchDuplicatePeerID{ID: otherID},
+			want: false,
+		},
+		{
+			name: "unrelated error -> normal failure",
+			err:  fmt.Errorf("dial tcp: i/o timeout"),
+			want: false,
+		},
+		{
+			name: "nil error -> normal failure",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isDuplicatePeerIDRejection(tc.err, wantedID)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Closes #3023

## Summary

`TestPEXReactorRunning` has been intermittently failing on celestia-core CI (see [25653712587](https://github.com/celestiaorg/celestia-core/actions/runs/25653712587), which failed on a clean push to `main`). Locally it reproduces in ~20% of runs without race and ~5% under `-race`.

**Root cause**: when two switches simultaneously dial each other, the loser's outbound `DialPeerWithAddress` returns `ErrSwitchDuplicatePeerID` or `ErrRejected{isDuplicate: true, id: <peer ID>}` because the inbound connection has already been added to the peer set. The PEX reactor previously treated these as ordinary dial failures: it stamped `attemptsToDial[addr] = (count+1, now)`, which then blocks redials for `minTimeBetweenDials = 30s`. The test's 10s assertion window can't recover from that, even though the peer is actually connected (just via the other direction).

The fix is symmetric with the existing handling of `ErrCurrentlyDialingOrExistingAddress` — treat duplicate-peer-ID rejections from the address we were trying to reach as success-equivalent: don't mark the address bad, don't bump the attempt counter, don't backoff.

Per review feedback ([#discussion_r3221861340](https://github.com/celestiaorg/celestia-core/pull/3033#discussion_r3221861340)), the check is narrowed to require that the duplicate *peer ID* in the rejection match `addr.ID`. Duplicate-IP rejections (`ErrRejected` with `isDuplicate=true` but no ID) take the normal failure path, since the colliding peer may not be the one we wanted — e.g. an unrelated peer (potentially malicious) sharing an IP shouldn't be able to suppress backoff for an honest address.

## Changes
- `p2p/errors.go`:
  - Add `ErrRejected.DuplicatePeerID() (ID, bool)` — returns the peer ID only when the rejection was caused by a duplicate ID, so callers can distinguish ID vs IP duplicates.
  - Add `NewErrRejectedDuplicateID` and `NewErrRejectedDuplicateIP` constructors so tests outside the `p2p` package can build duplicate rejections without reaching into unexported fields.
- `p2p/pex/pex_reactor.go`:
  - Extract a pure helper `isDuplicatePeerIDRejection(err, wantedID)` that returns true only when the rejection names the same peer ID we dialed.
  - `dialPeer` now uses this helper to skip the backoff/attempt-counter for both `ErrRejected` and `ErrSwitchDuplicatePeerID` cases.
- `p2p/pex/pex_reactor_test.go`:
  - Bump `TestPEXReactorRunning` assertion timeout 10s → 60s. The 60s value gives the test one full `minTimeBetweenDials` (30s) backoff cycle of headroom for unrelated transient dial failures.
  - Add `TestIsDuplicatePeerIDRejection`, a 7-case table-driven test pinning the classifier's behavior: duplicate-ID-match clears backoff; duplicate-ID-mismatch, duplicate-IP, unrelated errors, and nil all fall through to the normal failure path.

## Test plan

Local flake rates with `-race` (`go test -race -count=N -run TestPEXReactorRunning ./p2p/pex/`):

| Assertion timeout | Failures / runs | Rate |
|---|---|---|
| 10s (pre-fix on `main`) | n/a (PR description local repro) | ~5% |
| 30s (this branch @ e145483 / 8806f66) | 10 / 1000 | 1.0% |
| 60s (this branch @ a3bf802, head) | 1 / 1000 | 0.1% |
| 90s (this branch + 90s timeout) | 0 / 500 | ~0% |

Together the dial-handling fix and the timeout bump are a ~50× reduction in flake rate. The residual 0.1% at 60s is from an unrelated startup-timing issue (a *first* dial fails for some non-duplicate reason, then PEX's 30s backoff window pushes the recovery past the deadline) — to be tracked in a follow-up rather than addressed here.

- [x] `go test -race ./p2p/...` passes
- [x] `go test -tags deadlock ./p2p/pex/` passes (incl. new `TestIsDuplicatePeerIDRejection`)
- [x] `make lint` passes
