### PR TITLE
fix: bump Go to 1.26.3 to resolve govulncheck failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,5 +1,5 @@
 # We use Debian instead of Alpine for compatibility.
-FROM golang:1.26.2
+FROM golang:1.26.3
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION
## Summary

Bump Go from 1.26.2 to 1.26.3 to resolve govulncheck failures on `main`. The 1.26.2 stdlib is affected by 4 vulnerabilities, all fixed in 1.26.3:

- **GO-2026-4971** (`net`) — Panic in `Dial` and `LookupPort` on NUL byte (Windows). Called from `p2p/netaddress.go`, `p2p/transport.go`, `node/node.go`, etc.
- **GO-2026-4918** (`net/http`) — Infinite loop in HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE`. Called from `rpc/jsonrpc/client`, `libs/trace/fileserver.go`, etc.
- **GO-2026-4xxx** (`html/template`) — Called from `rpc/jsonrpc/server/http_server.go`.
- (One more in stdlib, see govulncheck output.)

These fail govulncheck for any PR touching Go code on `main` (e.g. https://github.com/celestiaorg/celestia-core/actions/runs/25713495762/job/75498480091).

Updates `go.mod` directive and the e2e Dockerfile base image.

## Test plan

- [x] `make vulncheck` passes locally
- [x] `make lint` passes locally
- [ ] CI is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)