### PR TITLE
fix(consensus): stabilize TestByzantinePrevoteEquivocation in CI

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -50,9 +50,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 	genDoc, privVals := randGenesisDoc(nValidators, false, 30, nil)
 	css := make([]*State, nValidators)
-	evpools := make([]*evidence.Pool, nValidators)
 	blockStores := make([]*store.BlockStore, nValidators)
-	maxEvidenceBytes := int64(0)
 
 	for i := 0; i < nValidators; i++ {
 		logger := consensusLogger().With("test", "byzantine", "validator", i)
@@ -117,11 +115,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		evpool, err := evidence.NewPool(evidenceDB, stateStore, blockStore)
 		require.NoError(t, err)
 		evpool.SetLogger(logger.With("module", "evidence"))
-		evpools[i] = evpool
 		blockStores[i] = blockStore
-		if i == 0 {
-			maxEvidenceBytes = state.ConsensusParams.Evidence.MaxBytes
-		}
 
 		// Make State
 		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, blockStore)
@@ -316,22 +310,14 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	pubkey, err := bcs.privValidator.GetPubKey()
 	require.NoError(t, err)
 
-	// Wait for the duplicate-vote evidence to land EITHER in a validator's
-	// pending evidence pool OR in a committed block. Evidence transitions from
-	// pending → committed in a single block-commit, which on a fast loop can be
-	// shorter than a polling interval; checking both makes the test
-	// deterministic regardless of which side of that boundary we observe.
+	// Wait for the duplicate-vote evidence to be committed in a block on any
+	// validator. Block inclusion is a strictly stronger assertion than
+	// pending-pool inclusion (evidence must be detected and flushed to pending
+	// before it can be proposed and committed), and the pending → committed
+	// transition can complete inside a single poll interval under -race, so
+	// observing the committed block is the only reliable signal.
 	var foundEvidence types.Evidence
 	require.Eventually(t, func() bool {
-		for i := 0; i < nValidators; i++ {
-			pending, _ := evpools[i].PendingEvidence(maxEvidenceBytes)
-			for _, ev := range pending {
-				if dve, ok := ev.(*types.DuplicateVoteEvidence); ok && prevoteHeight == dve.Height() {
-					foundEvidence = dve
-					return true
-				}
-			}
-		}
 		for i := 0; i < nValidators; i++ {
 			for h := int64(1); h <= blockStores[i].Height(); h++ {
 				b := blockStores[i].LoadBlock(h)
@@ -347,7 +333,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			}
 		}
 		return false
-	}, 30*time.Second, 50*time.Millisecond, "DuplicateVoteEvidence at height %d never appeared (in any evpool or any block)", prevoteHeight)
+	}, 60*time.Second, 200*time.Millisecond, "DuplicateVoteEvidence at height %d was never committed in a block", prevoteHeight)
 
 	ev, ok := foundEvidence.(*types.DuplicateVoteEvidence)
 	require.True(t, ok, "Evidence should be DuplicateVoteEvidence")

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -316,16 +316,30 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	pubkey, err := bcs.privValidator.GetPubKey()
 	require.NoError(t, err)
 
-	// Stage 1: wait for the duplicate-vote evidence to land in any validator's
-	// evidence pool. This isolates "evidence detected" from "evidence committed"
-	// so that future failures point at the correct failing stage.
+	// Wait for the duplicate-vote evidence to land EITHER in a validator's
+	// pending evidence pool OR in a committed block. Evidence transitions from
+	// pending → committed in a single block-commit, which on a fast loop can be
+	// shorter than a polling interval; checking both makes the test
+	// deterministic regardless of which side of that boundary we observe.
 	var foundEvidence types.Evidence
 	require.Eventually(t, func() bool {
 		for i := 0; i < nValidators; i++ {
 			pending, _ := evpools[i].PendingEvidence(maxEvidenceBytes)
 			for _, ev := range pending {
-				if dve, ok := ev.(*types.DuplicateVoteEvidence); ok {
-					if prevoteHeight == dve.Height() {
+				if dve, ok := ev.(*types.DuplicateVoteEvidence); ok && prevoteHeight == dve.Height() {
+					foundEvidence = dve
+					return true
+				}
+			}
+		}
+		for i := 0; i < nValidators; i++ {
+			for h := int64(1); h <= blockStores[i].Height(); h++ {
+				b := blockStores[i].LoadBlock(h)
+				if b == nil {
+					continue
+				}
+				for _, ev := range b.Evidence.Evidence {
+					if dve, ok := ev.(*types.DuplicateVoteEvidence); ok && prevoteHeight == dve.Height() {
 						foundEvidence = dve
 						return true
 					}
@@ -333,20 +347,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			}
 		}
 		return false
-	}, 30*time.Second, 100*time.Millisecond, "evidence pool never received DuplicateVoteEvidence at height %d", prevoteHeight)
-
-	// Stage 2: wait for evidence to be committed in some block on any validator.
-	require.Eventually(t, func() bool {
-		for i := 0; i < nValidators; i++ {
-			for h := int64(1); h <= blockStores[i].Height(); h++ {
-				b := blockStores[i].LoadBlock(h)
-				if b != nil && len(b.Evidence.Evidence) > 0 {
-					return true
-				}
-			}
-		}
-		return false
-	}, 60*time.Second, 200*time.Millisecond, "evidence was detected in pool but never committed in a block")
+	}, 30*time.Second, 50*time.Millisecond, "DuplicateVoteEvidence at height %d never appeared (in any evpool or any block)", prevoteHeight)
 
 	ev, ok := foundEvidence.(*types.DuplicateVoteEvidence)
 	require.True(t, ok, "Evidence should be DuplicateVoteEvidence")


### PR DESCRIPTION
## Summary

Follow-up to #2950. The previous PR reduced several real races (peer-mesh wait, mock ticker, send-to-all-peers, two-stage polling) but a residual race remained that surfaced on Linux CI runners under `-race`: the *very first* `Test` workflow run on `main` after #2950 merged (run [25756318695](https://github.com/celestiaorg/celestia-core/actions/runs/25756318695)) still failed `TestByzantinePrevoteEquivocation` at 30.09s.

I reproduced the CI failure inside a Linux container with `go test -race` (17/100 baseline flake rate) and traced it end-to-end with instrumentation. The byzantine's conflicting prevotes *are* delivered to receivers, the receivers *do* detect the conflict and call `evpool.ReportConflictingVotes`, and the consensus buffer *is* flushed to pending evidence during the next `evpool.Update` (called from `ApplyBlock`). What the test misses is the timing of the next step:

1. Conflict detected at height 2 → entry appended to `consensusBuffer`
2. Block 2 finalized → `ApplyBlock` → `evpool.Update` → `processConsensusBuffer` flushes to pending evidence
3. Next proposer pulls evidence from pending into a proposed block
4. That block finalizes → `markEvidenceAsCommitted` removes it from pending and moves it to the committed set

Under `-race` on the runner, blocks finalize roughly every 50 ms, so the pending → committed transition can complete **inside a single 100 ms poll**. The old Stage 1 then times out at 30 s with `evpool.size=0 pending=0` on every validator even though evidence was delivered, detected, and committed within milliseconds.

The fix drops the pending-pool check entirely and waits only for `DuplicateVoteEvidence` at the equivocation height to be committed in a block on any validator. Block inclusion is a strictly stronger assertion than pending-pool inclusion — evidence must be detected and flushed to pending before it can be proposed and committed — so we don't lose any coverage, and we sidestep the pending → committed observation race entirely.

## Test plan

- [x] Reproduce on Linux: 17/100 failures (`go test -race -count=100` in a `golang:1.26.2` container on `darwin/arm64` host)
- [x] With this fix: 0/500 failures in the same container
- [x] macOS native: 20/20 under `-race`
- [x] `go tool golangci-lint run ./consensus/...` → 0 issues
- [ ] CI is green on this PR
- [ ] Re-run CI a few times to confirm no regressions

Closes #2200
Closes https://linear.app/celestia/issue/PROTOCO-580/flaky-test-testbyzantineprevoteequivocation-in-consensusbyzantine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
