### PR TITLE
fix(blocksync): prevent maxPeerHeight poisoning

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -312,6 +312,10 @@ func (pool *BlockPool) PopRequest() {
 	}
 	delete(pool.requesters, pool.height)
 	pool.height++
+
+	// Re-evaluate maxPeerHeight: peers whose pruned base was just beyond the
+	// previous pool.height may now be able to contribute.
+	pool.updateMaxPeerHeight()
 }
 
 // RemovePeerAndRedoAllPeerRequests retries the request at the given height and
@@ -439,6 +443,17 @@ func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
+	// A peer whose own reported base exceeds its own height is structurally
+	// impossible and treated as malicious.
+	if base > height {
+		pool.Logger.Info("Peer reporting base greater than height", "peer", peerID, "base", base, "height", height)
+		if _, exists := pool.peers[peerID]; exists {
+			pool.removePeer(peerID)
+		}
+		pool.banPeer(peerID)
+		return
+	}
+
 	peer := pool.peers[peerID]
 	if peer != nil {
 		if base < peer.base || height < peer.height {
@@ -466,9 +481,7 @@ func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 		pool.sortedPeers = append([]*bpPeer{peer}, pool.sortedPeers...)
 	}
 
-	if height > pool.maxPeerHeight {
-		pool.maxPeerHeight = height
-	}
+	pool.updateMaxPeerHeight()
 }
 
 // RemovePeer removes the peer with peerID from the pool. If there's no peer
@@ -510,10 +523,18 @@ func (pool *BlockPool) removePeer(peerID p2p.ID) {
 	}
 }
 
-// If no peers are left, maxPeerHeight is set to 0.
+// updateMaxPeerHeight sets maxPeerHeight to the highest height among peers
+// whose advertised range still covers pool.height. If no peers are left,
+// maxPeerHeight is set to 0.
 func (pool *BlockPool) updateMaxPeerHeight() {
 	var max int64
 	for _, peer := range pool.peers {
+		if pool.height > 0 && peer.base > pool.height {
+			// Block a malicious peer from poisoning maxPeerHeight with an
+			// inflated base/height pair no peer can actually serve, which
+			// would stall IsCaughtUp forever.
+			continue
+		}
 		if peer.height > max {
 			max = peer.height
 		}

--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -297,6 +297,15 @@ func (pool *BlockPool) PeekTwoBlocks() (first, second *types.Block, firstExtComm
 	return
 }
 
+// SetHeight sets the current pool height under the mutex. Used by the
+// blocksync reactor when switching from state sync, where pool.height must be
+// advanced past the snapshot height before requesters start firing.
+func (pool *BlockPool) SetHeight(height int64) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	pool.height = height
+}
+
 // PopRequest removes the requester at pool.height and increments pool.height.
 func (pool *BlockPool) PopRequest() {
 	pool.mtx.Lock()

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -191,7 +191,8 @@ func TestBlockPoolTimeout(t *testing.T) {
 	// Introduce each peer.
 	go func() {
 		for _, peer := range peers {
-			pool.SetPeerRange(peer.id, peer.base, peer.height)
+			// Force uniform base so every peer contributes to maxPeerHeight at pool startup.
+			pool.SetPeerRange(peer.id, start, peer.height)
 		}
 	}()
 
@@ -575,4 +576,54 @@ func TestRecalculateParams(t *testing.T) {
 	pool.recalculateParams()
 	assert.Equal(t, 30*time.Second, pool.retryTimeout, "expected retry seconds to be equal for empty buffer")
 	assert.Equal(t, 5, pool.reqLimit, "expected retry limit to be equal for empty buffer")
+}
+
+// TestBlockPoolBansPeerWithBaseGreaterThanHeight verifies that a peer whose self-reported base
+// exceeds its own height (a structurally impossible state) is banned.
+func TestBlockPoolBansPeerWithBaseGreaterThanHeight(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	badID := p2p.ID("bad")
+	pool.SetPeerRange(badID, 500, 100)
+
+	require.True(t, pool.IsPeerBanned(badID), "peer reporting base > height must be banned")
+	require.EqualValues(t, 0, pool.MaxPeerHeight(), "banned peer must not raise maxPeerHeight")
+}
+
+// TestBlockPoolMaxPeerHeightRefreshesOnPopRequest covers:
+//  1. A peer whose base is ahead of pool.height must not contribute to maxPeerHeight
+//  2. When pool.height advances past a pruned peer's base, maxPeerHeight is re-evaluated.
+func TestBlockPoolMaxPeerHeightRefreshesOnPopRequest(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(10, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	// Peer A's range covers pool.height, so it contributes to maxPeerHeight.
+	pool.SetPeerRange(p2p.ID("A"), 1, 20)
+	// Peer B is pruned ahead of pool.height and must be excluded until the
+	// pool advances past its base.
+	pool.SetPeerRange(p2p.ID("B"), 15, 100)
+	require.EqualValues(t, 20, pool.MaxPeerHeight(),
+		"peer B is pruned ahead of pool.height and must not contribute yet")
+
+	// Advance pool.height from 10 to 15 via PopRequest. Install a dummy
+	// requester at each height so PopRequest has something to pop; the
+	// requester is never started, so Stop() is a logged no-op.
+	for h := int64(10); h < 15; h++ {
+		pool.mtx.Lock()
+		pool.requesters[h] = newBPRequester(pool, h)
+		pool.mtx.Unlock()
+		pool.PopRequest()
+	}
+
+	// pool.height is now 15, so B (base=15) becomes eligible and must lift
+	// maxPeerHeight to its advertised height without B re-sending status.
+	require.EqualValues(t, 100, pool.MaxPeerHeight(),
+		"peer B must contribute to maxPeerHeight once pool.height reaches its base")
 }

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -510,13 +510,13 @@ func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 }
 
 // TestBlockPoolMaliciousNodeUnreachableBase tests that the max-height poisoning
-// attack described in CELESTIA-188 is not a persistent issue.
+// attack described in CELESTIA-188 is structurally prevented.
 //
 // A malicious peer sends a StatusResponse with an unreachable base/height
-// (base=2^60, height=2^60+100), poisoning maxPeerHeight so IsCaughtUp returns
-// false. Once the P2P layer disconnects the peer (SendTimeout, ping/pong
-// timeout, or TCP failure), RemovePeer recalculates maxPeerHeight from the
-// remaining honest peers and IsCaughtUp returns true.
+// (base=2^60, height=2^60+100). The pool excludes peers whose base is ahead
+// of pool.height from maxPeerHeight, so the poison never takes effect.
+// RemovePeer is exercised as a follow-up to confirm state remains consistent
+// once the P2P layer disconnects the peer.
 func TestBlockPoolMaliciousNodeUnreachableBase(t *testing.T) {
 	const honestHeight = int64(20)
 	var (
@@ -534,14 +534,15 @@ func TestBlockPoolMaliciousNodeUnreachableBase(t *testing.T) {
 	pool.SetPeerRange("honest2", 1, honestHeight)
 	pool.SetPeerRange("poison", poisonBase, poisonHeight)
 
-	// maxPeerHeight is poisoned, IsCaughtUp returns false.
-	require.Equal(t, poisonHeight, pool.MaxPeerHeight())
-	require.False(t, pool.IsCaughtUp())
+	// The poison peer's base is ahead of pool.height, so it's excluded from
+	// maxPeerHeight. The honest peers determine the sync target and the pool
+	// is already caught up.
+	require.Equal(t, honestHeight, pool.MaxPeerHeight())
+	require.True(t, pool.IsCaughtUp())
 
-	// Simulate the P2P layer disconnecting the malicious peer.
+	// Simulate the P2P layer disconnecting the malicious peer. State remains
+	// consistent: maxPeerHeight still tracks the honest peers.
 	pool.RemovePeer("poison")
-
-	// maxPeerHeight recalculates from honest peers, IsCaughtUp returns true.
 	require.Equal(t, honestHeight, pool.MaxPeerHeight())
 	require.True(t, pool.IsCaughtUp())
 }

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -174,7 +174,7 @@ func (bcR *Reactor) SwitchToBlockSync(state sm.State) error {
 	bcR.blockSync = true
 	bcR.initialState = state
 
-	bcR.pool.height = state.LastBlockHeight + 1
+	bcR.pool.SetHeight(state.LastBlockHeight + 1)
 	err := bcR.pool.Start()
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes https://linear.app/celestia/issue/PROTOCO-1562

## Notes

- Adds a mutex-guarded `BlockPool.SetHeight` setter used by `Reactor.SwitchToBlockSync`. The new `updateMaxPeerHeight` reads `pool.height` under `pool.mtx`; the reactor's previous unsynchronized write to `pool.height` raced with that read and tripped the e2e race detector (`GORACE=halt_on_error=1`).