### PR TITLE
fix(abci): prevent panic on unlock in socket server panic recovery

### DIFF
--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -164,6 +164,8 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 	var count int
 	var bufReader = bufio.NewReader(conn)
 
+	locked := false // true only while appMtx is held inside the loop
+
 	defer func() {
 		// make sure to recover from any app-related panics to allow proper socket cleanup.
 		// In the case of a panic, we do not notify the client by passing an exception so
@@ -178,6 +180,8 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 				fmt.Fprintln(os.Stderr, err)
 			}
 			closeConn <- err
+		}
+		if locked {
 			s.appMtx.Unlock()
 		}
 	}()
@@ -195,6 +199,7 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 			return
 		}
 		s.appMtx.Lock()
+		locked = true
 		count++
 		resp, err := s.handleRequest(context.TODO(), req)
 		if err != nil {
@@ -206,6 +211,7 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 			responses <- resp
 		}
 		s.appMtx.Unlock()
+		locked = false
 	}
 }
 

--- a/abci/server/socket_server_test.go
+++ b/abci/server/socket_server_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/abci/types"
+)
+
+type panicReader struct{}
+
+func (panicReader) Read(_ []byte) (int, error) {
+	panic("boom")
+}
+
+// TestHandleRequestsPanicBeforeLock ensures the panic recovery block does not
+// attempt to unlock appMtx when the lock was never acquired.
+func TestHandleRequestsPanicBeforeLock(t *testing.T) {
+	s := &SocketServer{}
+	closeConn := make(chan error, 1)
+	responses := make(chan *types.Response, 1)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		s.handleRequests(closeConn, panicReader{}, responses)
+	}()
+
+	select {
+	case <-closeConn:
+	case <-time.After(time.Second):
+		t.Fatal("closeConn not signaled")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleRequests did not exit")
+	}
+}


### PR DESCRIPTION
## Summary

Backport of [cometbft/cometbft#5593](https://github.com/cometbft/cometbft/pull/5593) (merge commit [`320e79e`](https://github.com/cometbft/cometbft/commit/320e79ef982a69a5e32ec98a49ef6b6db1ad9c4f), released in CometBFT v0.38.22).

Fix a bug in `SocketServer.handleRequests` where the panic recovery defer function would attempt to `Unlock` `appMtx` even when the lock was never acquired — for example if `types.ReadMessage` panicked before reaching `s.appMtx.Lock()`. Unlocking an unlocked `sync.Mutex` panics, which masked the original panic and bypassed the orderly socket cleanup the defer was designed to perform.

The fix tracks whether the mutex is currently held via a `locked` flag scoped to `handleRequests`, and only calls 
`Unlock` from the defer when it is.

Note: this is very highly unlikely to be hit given we run don't run the socket client. So, I'm fine with not patching.

## Test plan

- [x] `go test ./abci/server/...` passes
- [x] New `TestHandleRequestsPanicBeforeLock` (byte-identical to upstream) exercises the panic-before-lock path and asserts the goroutine exits cleanly via `closeConn`