### PR TITLE
fix: bump Go to 1.26.3 to clear govulncheck failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,5 +1,5 @@
 # We use Debian instead of Alpine for compatibility.
-FROM golang:1.26.2
+FROM golang:1.26.3
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION
## Summary

- Bumps `go.mod` from `1.26.2` → `1.26.3` and `test/e2e/docker/Dockerfile` to match.
- Clears the 4 stdlib vulnerabilities flagged by `govulncheck` on `main` ([GO-2026-4982](https://pkg.go.dev/vuln/GO-2026-4982), [GO-2026-4980](https://pkg.go.dev/vuln/GO-2026-4980), [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971), [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918)) — all fixed in `go1.26.3`.

Closes #3041 PROTOCO-1738

## Test plan

- [x] `make vulncheck` → `No vulnerabilities found.`
- [x] `go build ./...`
- [ ] CI govulncheck job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)