### PR TITLE
fix(light): stop witness comparison after divergence checks

### DIFF
--- a/light/detector.go
+++ b/light/detector.go
@@ -208,12 +208,14 @@ func (c *Client) compareNewLightBlockWithWitness(ctx context.Context, errc chan 
 
 	if !bytes.Equal(h.Hash(), lightBlock.Hash()) {
 		errc <- ErrConflictingHeaders{Block: lightBlock, WitnessIndex: witnessIndex}
+		return
 	}
 
 	// ProposerPriorityHash is not part of the header hash, so we need to check it separately.
 	wanted, got := l.ValidatorSet.ProposerPriorityHash(), lightBlock.ValidatorSet.ProposerPriorityHash()
 	if !bytes.Equal(wanted, got) {
 		errc <- ErrProposerPrioritiesDiverge{WitnessHash: got, WitnessIndex: witnessIndex, PrimaryHash: wanted}
+		return
 	}
 
 	c.logger.Trace("Matching header received by witness", "height", h.Height, "witness", witnessIndex)

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -1,6 +1,7 @@
 package light_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -427,4 +428,123 @@ func TestClientDivergentTraces4(t *testing.T) {
 	_, err = c.VerifyLightBlockAtHeight(ctx, 10, bTime.Add(1*time.Hour))
 	assert.Error(t, err)
 	assert.Equal(t, 1, len(c.Witnesses()))
+}
+
+func TestClientDivergentHeadersNoTraces(t *testing.T) {
+	primaryHeaders, primaryVals, primaryKeys := genMockNodeWithKeys(chainID, 10, 5, 2, bTime)
+	primary := mockp.New(chainID, primaryHeaders, primaryVals)
+
+	firstBlock, err := primary.LightBlock(ctx, 1)
+	require.NoError(t, err)
+
+	keysAtH10 := primaryKeys[10]
+	valsAtH10 := primaryVals[10]
+	nextValsAtH11 := primaryKeys[11].ToValidators(2, 0)
+
+	// generate a header with an app hash that diverges from the primary
+	makeDivergentHeader := func(appHashSeed string) *types.SignedHeader {
+		return keysAtH10.GenSignedHeader(
+			chainID, 10,
+			primaryHeaders[10].Time, nil,
+			valsAtH10, nextValsAtH11,
+			hash(appHashSeed), hash("cons_hash"), hash("results_hash"),
+			0, len(keysAtH10),
+		)
+	}
+	divergentHeader1 := makeDivergentHeader("divergent_app_1")
+	divergentHeader2 := makeDivergentHeader("divergent_app_2")
+	require.NotEqual(t, primaryHeaders[10].Hash(), divergentHeader1.Hash())
+	require.NotEqual(t, primaryHeaders[10].Hash(), divergentHeader2.Hash())
+
+	// generate a witness that has this divergent app hash but the same
+	// proposer priority hash
+	makeSparseWitness := func(divergent *types.SignedHeader) *mockp.Mock {
+		return mockp.New(
+			chainID,
+			map[int64]*types.SignedHeader{1: primaryHeaders[1], 10: divergent},
+			map[int64]*types.ValidatorSet{1: primaryVals[1], 10: valsAtH10},
+		)
+	}
+
+	// run for multiple iterations since this is exercising a race, 100
+	// typically causes it
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		witness1 := makeSparseWitness(divergentHeader1)
+		witness2 := makeSparseWitness(divergentHeader2)
+
+		c, err := light.NewClient(
+			ctx,
+			chainID,
+			light.TrustOptions{
+				Height: 1,
+				Hash:   firstBlock.Hash(),
+				Period: 4 * time.Hour,
+			},
+			primary,
+			[]provider.Provider{witness1, witness2},
+			dbs.New(dbm.NewMemDB(), chainID),
+			light.Logger(log.TestingLogger()),
+		)
+		require.NoError(t, err)
+
+		// try and validate the block using our two witnesses that have
+		// diverged from the primary, this should error
+		_, err = c.VerifyLightBlockAtHeight(ctx, 10, bTime.Add(1*time.Hour))
+		require.Error(t, err)
+	}
+}
+
+func TestClientDivergentProposerPriorities(t *testing.T) {
+	const (
+		latestHeight = int64(10)
+		valSize      = 5
+	)
+
+	primaryHeaders, primaryValidators, _ := genMockNodeWithKeys(chainID, latestHeight, valSize, 2, bTime)
+	primary := mockp.New(chainID, primaryHeaders, primaryValidators)
+
+	witnessHeaders := make(map[int64]*types.SignedHeader, len(primaryHeaders))
+	witnessValidators := make(map[int64]*types.ValidatorSet, len(primaryValidators))
+	for height, header := range primaryHeaders {
+		witnessHeaders[height] = header
+	}
+	for height, valSet := range primaryValidators {
+		witnessValidators[height] = valSet
+	}
+
+	// Keep header hash identical while changing only proposer priorities in the validator set.
+	witnessValidators[latestHeight] = primaryValidators[latestHeight].CopyIncrementProposerPriority(1)
+	require.Equal(t, primaryHeaders[latestHeight].Hash(), witnessHeaders[latestHeight].Hash())
+	require.Equal(t, primaryValidators[latestHeight].Hash(), witnessValidators[latestHeight].Hash())
+	require.NotEqual(t,
+		primaryValidators[latestHeight].ProposerPriorityHash(),
+		witnessValidators[latestHeight].ProposerPriorityHash(),
+	)
+
+	witness := mockp.New(chainID, witnessHeaders, witnessValidators)
+	c, err := light.NewClient(
+		ctx,
+		chainID,
+		light.TrustOptions{
+			Period: 4 * time.Hour,
+			Height: 1,
+			Hash:   primaryHeaders[1].Hash(),
+		},
+		primary,
+		[]provider.Provider{witness},
+		dbs.New(dbm.NewMemDB(), chainID),
+		light.Logger(log.TestingLogger()),
+		light.MaxRetryAttempts(1),
+	)
+	require.NoError(t, err)
+
+	_, err = c.VerifyLightBlockAtHeight(ctx, latestHeight, bTime.Add(1*time.Hour))
+	require.Error(t, err)
+
+	var divergeErr light.ErrProposerPrioritiesDiverge
+	require.True(t, errors.As(err, &divergeErr), "expected ErrProposerPrioritiesDiverge, got %T: %v", err, err)
+	assert.Equal(t, 0, divergeErr.WitnessIndex)
+	assert.Equal(t, primaryValidators[latestHeight].ProposerPriorityHash(), divergeErr.PrimaryHash)
+	assert.Equal(t, witnessValidators[latestHeight].ProposerPriorityHash(), divergeErr.WitnessHash)
 }


### PR DESCRIPTION
## Summary

Ports [cometbft/cometbft#5820](https://github.com/cometbft/cometbft/pull/5820) to celestia-core.

After sending `ErrConflictingHeaders` or `ErrProposerPrioritiesDiverge`, `compareNewLightBlockWithWitness` continued on and unconditionally emitted `errc <- nil`. The caller in `Client.detectDivergence` reads exactly `cap(errc) = len(witnesses)` messages and treats `nil` as `headerMatched = true`. So with ≥2 witnesses a divergent witness's trailing `nil` could be consumed first into the `case nil` branch, masking its own divergence error — particularly when `handleConflictingHeaders` couldn't produce an attack trace and returned `nil`, in which case the function would return success even though one witness explicitly contradicted the primary at that height. The trailing send also leaked the goroutine when the buffer was already full.

The fix is two `return` statements after the error sends in `light/detector.go`, so each witness emits exactly one verdict.

Includes two ported regression tests:

- `TestClientDivergentHeadersNoTraces` — two sparse witnesses with diverging app hashes and no provable trace; loops 100x to exercise the race.
- `TestClientDivergentProposerPriorities` — same header hash, different `ProposerPriorityHash`; asserts `ErrProposerPrioritiesDiverge` surfaces with the right fields.

## Test plan

- [x] `go test ./light/...` passes locally (full package + targeted divergence tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)