### PR TITLE
test(consensus): wait for peers to reach prevote height to de-flake TestByzantinePrevoteEquivocation

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -204,13 +204,40 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	bcs.doPrevote = func(height int64, round int32) {
 		// allow first height to happen normally so that byzantine validator is no longer proposer
 		if height == prevoteHeight {
-			t.Logf("[byz] sending two conflicting prevotes at height=%d round=%d", height, round)
 			prevote1, err := bcs.signVote(cmtproto.PrevoteType, bcs.rs.ProposalBlock.Hash(), bcs.rs.ProposalBlockParts.Header(), nil)
 			require.NoError(t, err)
 			prevote2, err := bcs.signVote(cmtproto.PrevoteType, nil, types.PartSetHeader{}, nil)
 			require.NoError(t, err)
 			peerList := reactors[byzantineNode].Switch.Peers().List()
-			t.Logf("[byz] peer count at prevote time: %d", len(peerList))
+			// Wait for every peer to report reaching prevoteHeight before firing.
+			// State.addVote silently drops any vote whose height does not match the
+			// receiver's current cs.rs.Height (state.go: "Height mismatch is
+			// ignored"). The byzantine reaches enterPrevote(2,0) as soon as it
+			// receives the proposal from the height-2 proposer, but other
+			// validators may still be finalizing height=1; if the conflicting
+			// prevotes arrive before they transition to height=2, both variants
+			// are dropped and DuplicateVoteEvidence never forms. PeerState.PRS
+			// is updated when a peer broadcasts NewRoundStepMessage on entering
+			// a new height, so polling GetHeight() bounds this race.
+			require.Eventually(t, func() bool {
+				for _, peer := range peerList {
+					ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
+					if !ok {
+						return false
+					}
+					if ps.GetHeight() < height {
+						return false
+					}
+				}
+				return true
+			}, 10*time.Second, 20*time.Millisecond, "all peers should reach height %d before byzantine fires conflicting prevotes", height)
+			t.Logf("[byz] sending two conflicting prevotes at height=%d round=%d peerCount=%d", height, round, len(peerList))
+			for _, peer := range peerList {
+				ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
+				if ok {
+					t.Logf("[byz] peer=%s reported height=%d", peer.ID(), ps.GetHeight())
+				}
+			}
 			// Send both conflicting prevotes to every peer. Splitting the votes
 			// across peers (one variant to each half) is unreliable: the consensus
 			// reactor's HasVote gossip optimization (consensus/reactor.go:


### PR DESCRIPTION
## Summary

`TestByzantinePrevoteEquivocation` continued to flake on Linux CI after #2950 — **3 failures in the past 24 hours**, including on the merge commit of #2950 itself (runs [25756318695](https://github.com/celestiaorg/celestia-core/actions/runs/25756318695), [25804008211](https://github.com/celestiaorg/celestia-core/actions/runs/25804008211), [25806215593](https://github.com/celestiaorg/celestia-core/actions/runs/25806215593)). All three hit Stage 1 (`evidence pool never received DuplicateVoteEvidence at height 2`) after the full 30s deadline, even though `peer.Send` returned `sent=true` for every prevote.

### Root cause

`consensus/state.go`'s `addVote` silently drops any vote whose height does not match the receiver's current `cs.rs.Height` (the explicit "Height mismatch is ignored" branch at line 2473). The byzantine reaches `enterPrevote(2,0)` as soon as it receives the proposal from the height-2 proposer, but its peers only advance to height=2 after each independently receives +2/3 height-1 precommits. With the mock ticker there are no timeouts to mask this, and on slower CI runners the byzantine can fire conflicting prevotes before one or more peers have finalized height=1. Both votes are dropped at the receiver, and because the byzantine override never adds its own conflicting votes to its local vote set, gossip never re-delivers them — no peer ever sees both variants and `DuplicateVoteEvidence` cannot form.

This race is invisible on macOS (50/50 local passes both pre and post fix) because of different scheduler dynamics; CI Linux runners (smaller vCPU count, `-race -coverprofile` overhead) are wide enough to hit it.

### Fix

Poll each peer's `PeerState.PRS.Height` (updated when peers broadcast `NewRoundStepMessage` on entering a new height) and wait up to 10s for every peer to reach `prevoteHeight` before sending the conflicting prevotes. Also log each peer's reported height at fire time so future failures surface whether the wait held or `PRS` gossip itself fell behind.

## Test plan

- [x] `go test -count=30 -race -tags deadlock -coverprofile=/tmp/profile.out -run '^TestByzantinePrevoteEquivocation$' ./consensus/` — 30/30 pass locally
- [x] `go tool golangci-lint run ./consensus/` — 0 issues
- [ ] CI green
- [ ] Re-run CI multiple times to confirm flake rate dropped

Closes #2200.
Closes https://linear.app/celestia/issue/PROTOCO-580/flaky-test-testbyzantineprevoteequivocation-in-consensusbyzantine

🤖 Generated with [Claude Code](https://claude.com/claude-code)