### PR TITLE
fix(types): reject part with index/proof mismatch in PartSet.AddPart

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -577,6 +577,14 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 		return false, fmt.Errorf("nil part")
 	}
 
+	// Defense-in-depth: ensure the part's index is bound to its proof's index
+	// before any further processing. Callers are expected to enforce this via
+	// Part.ValidateBasic, but enforcing it at the sink prevents a structurally
+	// valid proof for index j from being installed in slot i (i != j).
+	if int64(part.Index) != part.Proof.Index {
+		return false, ErrInvalidPart{Reason: fmt.Errorf("part index %d != proof index %d", part.Index, part.Proof.Index)}
+	}
+
 	// If part already exists, return false.
 	if ps.partsBitArray.GetIndex(int(part.Index)) {
 		return false, nil

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -211,6 +211,41 @@ func TestWrongProof(t *testing.T) {
 	}
 }
 
+// TestPartSetAddPartRejectsIndexProofMismatch verifies that PartSet.AddPart
+// enforces an index-binding precondition: a part whose Index does not match
+// its Proof.Index must be rejected before any proof verification, and must
+// not be stored. Existing callers (consensus reactor via Part.ValidateBasic,
+// propagation reactor via cb.GetProof(part.Index)) already enforce this
+// upstream, so this is a defense-in-depth check at the sink.
+func TestPartSetAddPartRejectsIndexProofMismatch(t *testing.T) {
+	data := cmtrand.Bytes(testPartSize * 4)
+	partSet, err := NewPartSetFromData(data, testPartSize)
+	require.NoError(t, err)
+
+	// Build an empty sink PartSet to add parts into.
+	sink := NewPartSetFromHeader(partSet.Header(), testPartSize)
+
+	// Take the (valid) proof for slot 1, and try to use it for a part placed
+	// in slot 0. The proof is structurally valid, but its Proof.Index (1)
+	// does not match part.Index (0).
+	src := partSet.GetPart(1)
+	mismatched := &Part{
+		Index: 0,
+		Bytes: src.Bytes,
+		Proof: src.Proof, // Proof.Index == 1
+	}
+
+	added, err := sink.AddPart(mismatched)
+	assert.False(t, added, "AddPart should not accept a part with Index != Proof.Index")
+	require.Error(t, err, "AddPart should return an error for index/proof mismatch")
+	assert.ErrorAs(t, err, &ErrInvalidPart{}, "expected ErrInvalidPart for index/proof mismatch")
+
+	// The part must not be recorded in the bit array.
+	assert.False(t, sink.BitArray().GetIndex(0), "mismatched part must not be stored")
+	assert.False(t, sink.BitArray().GetIndex(1), "mismatched part must not be stored at the proof's index either")
+	assert.EqualValues(t, 0, sink.Count(), "sink must remain empty after rejecting mismatched part")
+}
+
 func TestPartSetHeaderValidateBasic(t *testing.T) {
 	testCases := []struct {
 		testName              string


### PR DESCRIPTION
Closes [PROTOCO-1746](https://linear.app/celestia/issue/PROTOCO-1746)

## Summary

Adds an index-binding precondition to `PartSet.AddPart`: rejects parts where `part.Index != part.Proof.Index`. Existing callers (consensus reactor via `Part.ValidateBasic`, propagation reactor via `cb.GetProof(part.Index)`) already enforce this upstream, so there is no functional change in the happy path. This closes a latent defense-in-depth gap by enforcing the invariant at the sink.

The new guard runs before `Proof.Verify`, returning `ErrInvalidPart` with a descriptive reason that matches the error pattern already used by `Part.ValidateBasic` for the same condition.

## Follow-ups

- `RecoveryPart.ValidateBasic` in `consensus/propagation/types/types.go` could grow the same cross-check.
- The TODO at `consensus/propagation/have_wants.go:474` requires a deeper design decision and is intentionally left out of this change.

## Test plan

- [x] New unit test `TestPartSetAddPartRejectsIndexProofMismatch` in `types/part_set_test.go` constructs a `Part` with `Index = 0` and a structurally valid `Proof` for index 1, then asserts `AddPart` returns `(false, ErrInvalidPart)` and that nothing is recorded in the bit array.
- [x] Test fails on `main` and passes after the fix (red/green TDD).
- [x] `go test ./types/...` passes with no regressions.
- [x] `go test -short ./consensus/... ./blocksync/... ./store/...` passes.
- [x] `go tool golangci-lint run ./types/...` reports 0 issues.