### PR TITLE
fix(consensus): bump ensureVoteTimeout in TestStateOversizedBlock to 5s

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -260,6 +260,12 @@ func TestStateOversizedBlock(t *testing.T) {
 	origTimeout := ensureTimeout
 	ensureTimeout = 2 * time.Second
 	defer func() { ensureTimeout = origTimeout }()
+	// Validating a max-size block under -race on slow CI can push the
+	// prevote→precommit transition past the default 2s vote timeout
+	// (observed at 2.2–2.3s).
+	origVoteTimeout := ensureVoteTimeout
+	ensureVoteTimeout = 5 * time.Second
+	defer func() { ensureVoteTimeout = origVoteTimeout }()
 	const maxBytes = int64(types.BlockPartSizeBytes)
 
 	for _, testCase := range []struct {


### PR DESCRIPTION
## Summary

- `TestStateOversizedBlock/max_size,_correct_block` consistently flakes on CI just past the 2s vote timeout. In the past 24 hours it failed 3 times (3 separate `Test` workflow runs), each with the same panic from `ensureVote`: `Timeout expired while waiting for NewVote event`, with the failing sub-test running for 2.22s, 2.25s, and 2.31s respectively.
- Root cause: validating a max-size block (1 part, ~65 KB) under `-race` on slow CI runners can push the prevote→precommit transition past the global `ensureVoteTimeout = 2s`. The prior fix bumped this timeout from 200ms to 2s ([#2842](https://github.com/celestiaorg/celestia-core/pull/2842)), but 2s is still too tight on the slowest CI machines.
- Fix: locally override `ensureVoteTimeout` to 5s inside `TestStateOversizedBlock`, following the same save/restore pattern already used for `ensureTimeout` in this test. This keeps the global timeout (used by every other consensus test) unchanged.

Closes #2374

## Test plan

- [x] `go test -race -tags deadlock -run TestStateOversizedBlock ./consensus/ -count=10` — all pass locally
- [x] `make lint` — 0 issues
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)