### PR TITLE
test(consensus): bound stopConsensusNet per-switch cleanup time

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -94,14 +94,38 @@ func startConsensusNet(t *testing.T, css []*State, n int) (
 	return reactors, blocksSubs, eventBuses
 }
 
+// stopConsensusNetSwitchTimeout bounds how long we wait for a single Switch
+// to stop during test cleanup. Without this bound, a stuck Reactor.OnStop
+// (e.g. a State whose receiveRoutine never exits) will block sequential
+// cleanup and consume the entire per-test timeout — burning ~14 minutes of
+// CI time before producing a useful failure message.
+const stopConsensusNetSwitchTimeout = 30 * time.Second
+
 func stopConsensusNet(logger log.Logger, reactors []*Reactor, eventBuses []*types.EventBus) {
 	logger.Info("stopConsensusNet", "n", len(reactors))
+	// Stop switches in parallel with a per-switch timeout. Each switch is
+	// independent, so a hang in one must not delay or hide failures in the
+	// others, and an absolute bound on total cleanup time ensures the real
+	// assertion failure is what surfaces in CI logs (not a 15-minute hang).
+	var wg sync.WaitGroup
 	for i, r := range reactors {
-		logger.Info("stopConsensusNet: Stopping Reactor", "i", i)
-		if err := r.Switch.Stop(); err != nil {
-			logger.Error("error trying to stop switch", "error", err)
-		}
+		wg.Add(1)
+		go func(i int, r *Reactor) {
+			defer wg.Done()
+			logger.Info("stopConsensusNet: Stopping Reactor", "i", i)
+			done := make(chan error, 1)
+			go func() { done <- r.Switch.Stop() }()
+			select {
+			case err := <-done:
+				if err != nil {
+					logger.Error("error trying to stop switch", "i", i, "error", err)
+				}
+			case <-time.After(stopConsensusNetSwitchTimeout):
+				logger.Error("stopConsensusNet: timed out stopping switch; leaking goroutines", "i", i, "timeout", stopConsensusNetSwitchTimeout)
+			}
+		}(i, r)
 	}
+	wg.Wait()
 	for i, b := range eventBuses {
 		logger.Info("stopConsensusNet: Stopping eventBus", "i", i)
 		if err := b.Stop(); err != nil {


### PR DESCRIPTION
## Summary

- Stop switches in `stopConsensusNet` in parallel with a 30s per-switch timeout instead of sequentially and unbounded.
- When one validator's `State` ends up in a state where `cs.done` is never closed (`receiveRoutine` exits without `onExit`, or `OnStart` fails after WAL/timeoutTicker start but before `go cs.receiveRoutine(0)`), `Reactor.OnStop` calls `conS.Wait()` and blocks forever.
- The previous sequential unbounded loop in `stopConsensusNet` then blocked on the very first `Switch.Stop()`, consuming the entire 15-minute per-test budget before `panic: test timed out` produced a goroutine dump — see [run 25899504846](https://github.com/celestiaorg/celestia-core/actions/runs/25899504846/job/76119672423), where `TestByzantinePrevoteEquivocation`'s 60s `require.Eventually` was masked by the 14-minute cleanup hang in `stopConsensusNet` at `reactor_test.go:101`.

This is a defensive test-helper change: it does **not** address the underlying root cause of the State getting wedged, but it ensures the real assertion failure surfaces in CI logs instead of a 15-minute panic-dump tarball, and reduces CI time burned per occurrence by ~14 minutes.

The 30s per-switch timeout is generous (a healthy `Switch.Stop()` takes milliseconds on `-race` in CI) and applies independently per switch, so a single stuck consensus state cannot delay or hide failures in the other validators' switches either.

## Test plan

- [x] `go build ./consensus/...`
- [x] `go vet ./consensus/...`
- [x] `go tool golangci-lint run ./consensus/...` → 0 issues
- [x] `go test -run TestByzantinePrevoteEquivocation -count=5 -race -timeout=10m ./consensus/` → ok
- [x] `go test -run "TestReactorBasic|TestReactorWithEvidence|TestReactorVotingPowerChange|TestByzantine" -count=2 -race -timeout=15m ./consensus/` → ok
- [ ] CI is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)