### PR TITLE
fix(consensus): bump ensureVoteTimeout in TestStateOversizedBlock to 5s (backport #3047)

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -260,6 +260,12 @@ func TestStateOversizedBlock(t *testing.T) {
 	origTimeout := ensureTimeout
 	ensureTimeout = 2 * time.Second
 	defer func() { ensureTimeout = origTimeout }()
+	// Validating a max-size block under -race on slow CI can push the
+	// prevote→precommit transition past the default 2s vote timeout
+	// (observed at 2.2–2.3s).
+	origVoteTimeout := ensureVoteTimeout
+	ensureVoteTimeout = 5 * time.Second
+	defer func() { ensureVoteTimeout = origVoteTimeout }()
 	const maxBytes = int64(types.BlockPartSizeBytes)
 
 	for _, testCase := range []struct {


### PR DESCRIPTION
Manual backport of #3047 to \`v0.39.x-celestia\`.

## Summary

- \`TestStateOversizedBlock\` flaked on the v0.39.x-celestia backport branch CI in the past 24h with the same panic as on main: \`Timeout expired while waiting for NewVote event\` (see run [25928141568](https://github.com/celestiaorg/celestia-core/actions/runs/25928141568)).
- Cherry-picks the 6-line fix from #3047 onto v0.39.x-celestia: locally override \`ensureVoteTimeout\` to 5s inside \`TestStateOversizedBlock\`, following the same save/restore pattern already used for \`ensureTimeout\`.
- Original issue #2374 was closed when #3047 merged to main; this backport applies the same fix to v0.39.x-celestia.

## Test plan

- [x] \`go test -race -tags deadlock -run TestStateOversizedBlock ./consensus/ -count=3\` — passes locally
- [x] \`make lint\` — 0 issues
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)