### PR TITLE
feat!: support store compaction after pruning blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -162,6 +162,9 @@ func (cfg *Config) ValidateBasic() error {
 	if err := cfg.Instrumentation.ValidateBasic(); err != nil {
 		return fmt.Errorf("error in [instrumentation] section: %w", err)
 	}
+	if err := cfg.Storage.ValidateBasic(); err != nil {
+		return fmt.Errorf("error in [storage] section: %w", err)
+	}
 	if !cfg.Consensus.CreateEmptyBlocks && cfg.Mempool.Type == MempoolTypeNop {
 		return fmt.Errorf("`nop` mempool does not support create_empty_blocks = false")
 	}
@@ -1318,6 +1321,15 @@ func TestStorageConfig() *StorageConfig {
 	return &StorageConfig{
 		DiscardABCIResponses: false,
 	}
+}
+
+// ValidateBasic performs basic validation, returning an error if any check
+// fails.
+func (cfg *StorageConfig) ValidateBasic() error {
+	if cfg.Compact && cfg.CompactionInterval <= 0 {
+		return fmt.Errorf("compaction_interval must be positive when compact is true, got %d", cfg.CompactionInterval)
+	}
+	return nil
 }
 
 // -----------------------------------------------------------------------------

--- a/config/config.go
+++ b/config/config.go
@@ -1285,6 +1285,21 @@ type StorageConfig struct {
 	// required for `/block_results` RPC queries, and to reindex events in the
 	// command-line tool.
 	DiscardABCIResponses bool `mapstructure:"discard_abci_responses"`
+	// Compaction on pruning - enable or disable in-process compaction.
+	// If the DB backend supports it, this will force the DB to compact
+	// the database levels and save on storage space. Setting this to true
+	// is most beneficial when used in combination with pruning as it will
+	// physically delete the entries marked for deletion.
+	// false by default (forcing compaction is disabled).
+	Compact bool `mapstructure:"compact"`
+	// Compaction interval - number of blocks to try explicit compaction on.
+	// This parameter should be tuned depending on the number of items
+	// you expect to delete between two calls to forced compaction.
+	// If your retain height is 1 block, it is too much of an overhead
+	// to try compaction every block. But it should also not be a very
+	// large multiple of your retain height as it might occur bigger overheads.
+	// 1000 by default.
+	CompactionInterval int64 `mapstructure:"compaction_interval"`
 }
 
 // DefaultStorageConfig returns the default configuration options relating to
@@ -1292,6 +1307,8 @@ type StorageConfig struct {
 func DefaultStorageConfig() *StorageConfig {
 	return &StorageConfig{
 		DiscardABCIResponses: false,
+		Compact:              false,
+		CompactionInterval:   1000,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1298,7 +1298,7 @@ type StorageConfig struct {
 	// If your retain height is 1 block, it is too much of an overhead
 	// to try compaction every block. But it should also not be a very
 	// large multiple of your retain height as it might occur bigger overheads.
-	// 1000 by default.
+	// 10000 by default.
 	CompactionInterval int64 `mapstructure:"compaction_interval"`
 }
 
@@ -1308,7 +1308,7 @@ func DefaultStorageConfig() *StorageConfig {
 	return &StorageConfig{
 		DiscardABCIResponses: false,
 		Compact:              false,
-		CompactionInterval:   1000,
+		CompactionInterval:   10000,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -555,6 +555,19 @@ enable_legacy_block_prop = {{ .Consensus.EnableLegacyBlockProp }}
 # reindex events in the command-line tool.
 discard_abci_responses = {{ .Storage.DiscardABCIResponses}}
 
+# If set to true, CometBFT will force compaction to happen for databases that support this feature.
+# and save on storage space. Setting this to true is most beneficial when used in combination
+# with pruning as it will physically delete the entries marked for deletion.
+# false by default (forcing compaction is disabled).
+compact = {{ .Storage.Compact }}
+
+# To avoid forcing compaction every time, this parameter instructs CometBFT to wait
+# the given amount of blocks to be pruned before triggering compaction.
+# It should be tuned depending on the number of items. If your retain height is 1 block,
+# it is too much of an overhead to try compaction every block. But it should also not be a very
+# large multiple of your retain height as it might occur bigger overheads.
+compaction_interval = {{ .Storage.CompactionInterval }}
+
 #######################################################
 ###   Transaction Indexer Configuration Options     ###
 #######################################################

--- a/node/node.go
+++ b/node/node.go
@@ -316,6 +316,8 @@ func NewNodeWithContext(ctx context.Context,
 
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
+		Compact:              config.Storage.Compact,
+		CompactionInterval:   config.Storage.CompactionInterval,
 	})
 
 	state, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider)

--- a/node/node.go
+++ b/node/node.go
@@ -180,7 +180,7 @@ func BootstrapStateWithGenProvider(ctx context.Context, config *cfg.Config, dbPr
 	if dbProvider == nil {
 		dbProvider = cfg.DefaultDBProvider
 	}
-	blockStore, stateDB, err := initDBs(config, dbProvider)
+	blockStore, stateDB, err := initDBs(config, dbProvider, logger)
 
 	defer func() {
 		if derr := blockStore.Close(); derr != nil {
@@ -309,7 +309,7 @@ func NewNodeWithContext(ctx context.Context,
 	logger log.Logger,
 	options ...Option,
 ) (*Node, error) {
-	blockStore, stateDB, err := initDBs(config, dbProvider)
+	blockStore, stateDB, err := initDBs(config, dbProvider, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -318,6 +318,7 @@ func NewNodeWithContext(ctx context.Context,
 		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
 		Compact:              config.Storage.Compact,
 		CompactionInterval:   config.Storage.CompactionInterval,
+		Logger:               logger.With("module", "state"),
 	})
 
 	state, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider)

--- a/node/setup.go
+++ b/node/setup.go
@@ -118,7 +118,7 @@ func initDBs(config *cfg.Config, dbProvider cfg.DBProvider) (blockStore *store.B
 	if err != nil {
 		return
 	}
-	blockStore = store.NewBlockStore(blockStoreDB)
+	blockStore = store.NewBlockStore(blockStoreDB, store.WithCompaction(config.Storage.Compact, config.Storage.CompactionInterval))
 
 	stateDB, err = dbProvider(&cfg.DBContext{ID: "state", Config: config, Path: config.DBDir()})
 	if err != nil {

--- a/node/setup.go
+++ b/node/setup.go
@@ -112,13 +112,17 @@ type blockSyncReactor interface {
 // If config.BlockstoreDir() differs from config.DBDir(), users must manually
 // migrate their existing blockstore data before changing this configuration.
 // No automatic migration is performed to prevent accidental data inconsistency.
-func initDBs(config *cfg.Config, dbProvider cfg.DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
+func initDBs(config *cfg.Config, dbProvider cfg.DBProvider, logger log.Logger) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
 	var blockStoreDB dbm.DB
 	blockStoreDB, err = dbProvider(&cfg.DBContext{ID: "blockstore", Config: config, Path: config.BlockstoreDir()})
 	if err != nil {
 		return
 	}
-	blockStore = store.NewBlockStore(blockStoreDB, store.WithCompaction(config.Storage.Compact, config.Storage.CompactionInterval))
+	blockStore = store.NewBlockStore(
+		blockStoreDB,
+		store.WithCompaction(config.Storage.Compact, config.Storage.CompactionInterval),
+		store.WithLogger(logger.With("module", "blockstore")),
+	)
 
 	stateDB, err = dbProvider(&cfg.DBContext{ID: "state", Config: config, Path: config.DBDir()})
 	if err != nil {

--- a/node/setup_test.go
+++ b/node/setup_test.go
@@ -11,6 +11,7 @@ import (
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/consensus/propagation"
 	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/libs/trace"
 	"github.com/cometbft/cometbft/mempool/cat"
 	"github.com/cometbft/cometbft/p2p"
@@ -48,7 +49,7 @@ func TestInitDBs(t *testing.T) {
 				return cfg.DefaultDBProvider(ctx)
 			}
 
-			blockStore, stateDB, err := initDBs(config, dbProvider)
+			blockStore, stateDB, err := initDBs(config, dbProvider, log.NewNopLogger())
 			require.NoError(t, err)
 			defer func() {
 				if blockStore != nil {

--- a/state/execution.go
+++ b/state/execution.go
@@ -939,10 +939,13 @@ func (blockExec *BlockExecutor) pruneBlocks(retainHeight int64, state State) (ui
 	}
 
 	prunedStates, err := blockExec.Store().PruneStates(base, retainHeight, prunedHeaderHeight, blockExec.prunedStates)
+	// PruneStates flushes in 1000-entry batches, so partial deletions persist
+	// to disk even on error. Account for them so the compaction-trigger
+	// bucket math stays aligned with what's actually on disk.
+	blockExec.prunedStates += prunedStates
 	if err != nil {
 		return 0, fmt.Errorf("failed to prune state store: %w", err)
 	}
-	blockExec.prunedStates += prunedStates
 	return amountPruned, nil
 }
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -56,6 +56,10 @@ type BlockExecutor struct {
 
 	// tracer optional tracer
 	tracer trace.Tracer
+
+	// running count of state entries pruned, used to decide when to trigger
+	// state-store compaction via PruneStates.
+	prunedStates uint64
 }
 
 type BlockExecutorOption func(executor *BlockExecutor)
@@ -934,10 +938,11 @@ func (blockExec *BlockExecutor) pruneBlocks(retainHeight int64, state State) (ui
 		return 0, fmt.Errorf("failed to prune block store: %w", err)
 	}
 
-	err = blockExec.Store().PruneStates(base, retainHeight, prunedHeaderHeight)
+	prunedStates, err := blockExec.Store().PruneStates(base, retainHeight, prunedHeaderHeight, blockExec.prunedStates)
 	if err != nil {
 		return 0, fmt.Errorf("failed to prune state store: %w", err)
 	}
+	blockExec.prunedStates += prunedStates
 	return amountPruned, nil
 }
 

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -282,22 +282,32 @@ func (_m *Store) LoadValidators(_a0 int64) (*types.ValidatorSet, error) {
 	return r0, r1
 }
 
-// PruneStates provides a mock function with given fields: _a0, _a1, _a2
-func (_m *Store) PruneStates(_a0 int64, _a1 int64, _a2 int64) error {
-	ret := _m.Called(_a0, _a1, _a2)
+// PruneStates provides a mock function with given fields: fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates
+func (_m *Store) PruneStates(fromHeight int64, toHeight int64, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error) {
+	ret := _m.Called(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PruneStates")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, int64, int64) error); ok {
-		r0 = rf(_a0, _a1, _a2)
+	var r0 uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int64, int64, int64, uint64) (uint64, error)); ok {
+		return rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+	}
+	if rf, ok := ret.Get(0).(func(int64, int64, int64, uint64) uint64); ok {
+		r0 = rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(uint64)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(int64, int64, int64, uint64) error); ok {
+		r1 = rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Save provides a mock function with given fields: _a0

--- a/state/store.go
+++ b/state/store.go
@@ -4,12 +4,14 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/cosmos/gogoproto/proto"
 
 	dbm "github.com/cometbft/cometbft-db"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/log"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
 	cmtos "github.com/cometbft/cometbft/libs/os"
 	cmtstate "github.com/cometbft/cometbft/proto/tendermint/state"
@@ -100,6 +102,8 @@ type StoreOptions struct {
 	Compact bool
 
 	CompactionInterval int64
+
+	Logger log.Logger
 }
 
 var _ Store = (*dbStore)(nil)
@@ -114,6 +118,9 @@ func IsEmpty(store dbStore) (bool, error) {
 
 // NewStore creates the dbStore of the state pkg.
 func NewStore(db dbm.DB, options StoreOptions) Store {
+	if options.Logger == nil {
+		options.Logger = log.NewNopLogger()
+	}
 	return dbStore{db, options}
 }
 
@@ -407,8 +414,18 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 		interval := uint64(store.StoreOptions.CompactionInterval)
 		total := previouslyPrunedStates + pruned
 		if total/interval > previouslyPrunedStates/interval {
+			store.StoreOptions.Logger.Info("compacting state store",
+				"states_pruned_total", total,
+				"compaction_interval", store.StoreOptions.CompactionInterval,
+				"retain_height", to,
+			)
+			start := time.Now()
 			// When the range is nil,nil, the database will try to compact ALL levels.
 			err = store.db.Compact(nil, nil)
+			store.StoreOptions.Logger.Error("state store compaction complete",
+				"err", err,
+				"elapsed", time.Since(start),
+			)
 		}
 	}
 

--- a/state/store.go
+++ b/state/store.go
@@ -410,19 +410,19 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 		return pruned, err
 	}
 
-	if store.StoreOptions.Compact && store.StoreOptions.CompactionInterval > 0 {
-		interval := uint64(store.StoreOptions.CompactionInterval)
+	if store.Compact && store.CompactionInterval > 0 {
+		interval := uint64(store.CompactionInterval)
 		total := previouslyPrunedStates + pruned
 		if total/interval > previouslyPrunedStates/interval {
-			store.StoreOptions.Logger.Info("compacting state store",
+			store.Logger.Info("compacting state store",
 				"states_pruned_total", total,
-				"compaction_interval", store.StoreOptions.CompactionInterval,
+				"compaction_interval", store.CompactionInterval,
 				"retain_height", to,
 			)
 			start := time.Now()
 			// When the range is nil,nil, the database will try to compact ALL levels.
 			err = store.db.Compact(nil, nil)
-			store.StoreOptions.Logger.Info("state store compaction complete",
+			store.Logger.Info("state store compaction complete",
 				"err", err,
 				"elapsed(s)", time.Since(start).Seconds(),
 			)

--- a/state/store.go
+++ b/state/store.go
@@ -403,13 +403,13 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 		return pruned, err
 	}
 
-	// We do not want to panic or interrupt consensus on compaction failure
-	if store.StoreOptions.Compact && previouslyPrunedStates+pruned >= uint64(store.StoreOptions.CompactionInterval) {
-		fmt.Println("-------->>>>>> compacting state: ", pruned, " states pruned", pruned, " previouslyPrunedStates", previouslyPrunedStates, " compactionInterval", store.StoreOptions.CompactionInterval)
-		// When the range is nil,nil, the database will try to compact
-		// ALL levels. Another option is to set a predefined range of
-		// specific keys.
-		err = store.db.Compact(nil, nil)
+	if store.StoreOptions.Compact && store.StoreOptions.CompactionInterval > 0 {
+		interval := uint64(store.StoreOptions.CompactionInterval)
+		total := previouslyPrunedStates + pruned
+		if total/interval > previouslyPrunedStates/interval {
+			// When the range is nil,nil, the database will try to compact ALL levels.
+			err = store.db.Compact(nil, nil)
+		}
 	}
 
 	return pruned, err

--- a/state/store.go
+++ b/state/store.go
@@ -424,7 +424,7 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 			err = store.db.Compact(nil, nil)
 			store.StoreOptions.Logger.Info("state store compaction complete",
 				"err", err,
-				"elapsed", time.Since(start),
+				"elapsed(s)", time.Since(start).Seconds(),
 			)
 		}
 	}

--- a/state/store.go
+++ b/state/store.go
@@ -422,7 +422,7 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 			start := time.Now()
 			// When the range is nil,nil, the database will try to compact ALL levels.
 			err = store.db.Compact(nil, nil)
-			store.StoreOptions.Logger.Error("state store compaction complete",
+			store.StoreOptions.Logger.Info("state store compaction complete",
 				"err", err,
 				"elapsed", time.Since(start),
 			)

--- a/state/store.go
+++ b/state/store.go
@@ -74,7 +74,7 @@ type Store interface {
 	// Bootstrap is used for bootstrapping state when not starting from a initial height.
 	Bootstrap(State) error
 	// PruneStates takes the height from which to start pruning and which height stop at
-	PruneStates(int64, int64, int64) error
+	PruneStates(fromHeight, toHeight, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error)
 	// Saves the height at which the store is bootstrapped after out of band statesync
 	SetOfflineStateSyncHeight(height int64) error
 	// Gets the height at which the store is bootstrapped after out of band statesync
@@ -96,6 +96,10 @@ type StoreOptions struct {
 	// the store will maintain only the response object from the latest
 	// height.
 	DiscardABCIResponses bool
+
+	Compact bool
+
+	CompactionInterval int64
 }
 
 var _ Store = (*dbStore)(nil)
@@ -274,21 +278,21 @@ func (store dbStore) Bootstrap(state State) error {
 // encoding not preserving ordering: https://github.com/tendermint/tendermint/issues/4567
 // This will cause some old states to be left behind when doing incremental partial prunes,
 // specifically older checkpoints and LastHeightChanged targets.
-func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64) error {
+func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error) {
 	if from <= 0 || to <= 0 {
-		return fmt.Errorf("from height %v and to height %v must be greater than 0", from, to)
+		return 0, fmt.Errorf("from height %v and to height %v must be greater than 0", from, to)
 	}
 	if from >= to {
-		return fmt.Errorf("from height %v must be lower than to height %v", from, to)
+		return 0, fmt.Errorf("from height %v must be lower than to height %v", from, to)
 	}
 
 	valInfo, err := loadValidatorsInfo(store.db, min(to, evidenceThresholdHeight))
 	if err != nil {
-		return fmt.Errorf("validators at height %v not found: %w", to, err)
+		return 0, fmt.Errorf("validators at height %v not found: %w", to, err)
 	}
 	paramsInfo, err := store.loadConsensusParamsInfo(to)
 	if err != nil {
-		return fmt.Errorf("consensus params at height %v not found: %w", to, err)
+		return 0, fmt.Errorf("consensus params at height %v not found: %w", to, err)
 	}
 
 	keepVals := make(map[int64]bool)
@@ -316,12 +320,12 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 			if err != nil || v.ValidatorSet == nil {
 				vip, err := store.LoadValidators(h)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 
 				pvi, err := vip.ToProto()
 				if err != nil {
-					return err
+					return pruned, err
 				}
 
 				v.ValidatorSet = pvi
@@ -329,17 +333,17 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 
 				bz, err := v.Marshal()
 				if err != nil {
-					return err
+					return pruned, err
 				}
 				err = batch.Set(calcValidatorsKey(h), bz)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 			}
 		} else if h < evidenceThresholdHeight {
 			err = batch.Delete(calcValidatorsKey(h))
 			if err != nil {
-				return err
+				return pruned, err
 			}
 		}
 		// else we keep the validator set because we might need
@@ -348,37 +352,37 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 		if keepParams[h] {
 			p, err := store.loadConsensusParamsInfo(h)
 			if err != nil {
-				return err
+				return pruned, err
 			}
 
 			if p.ConsensusParams.Equal(&cmtproto.ConsensusParams{}) {
 				params, err := store.LoadConsensusParams(h)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 				p.ConsensusParams = params.ToProto()
 
 				p.LastHeightChanged = h
 				bz, err := p.Marshal()
 				if err != nil {
-					return err
+					return pruned, err
 				}
 
 				err = batch.Set(calcConsensusParamsKey(h), bz)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 			}
 		} else {
 			err = batch.Delete(calcConsensusParamsKey(h))
 			if err != nil {
-				return err
+				return pruned, err
 			}
 		}
 
 		err = batch.Delete(calcABCIResponsesKey(h))
 		if err != nil {
-			return err
+			return pruned, err
 		}
 		pruned++
 
@@ -386,7 +390,7 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 		if pruned%1000 == 0 && pruned > 0 {
 			err := batch.Write()
 			if err != nil {
-				return err
+				return pruned, err
 			}
 			batch.Close()
 			batch = store.db.NewBatch()
@@ -396,10 +400,18 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 
 	err = batch.WriteSync()
 	if err != nil {
-		return err
+		return pruned, err
 	}
 
-	return nil
+	// We do not want to panic or interrupt consensus on compaction failure
+	if store.StoreOptions.Compact && previouslyPrunedStates+pruned >= uint64(store.StoreOptions.CompactionInterval) {
+		// When the range is nil,nil, the database will try to compact
+		// ALL levels. Another option is to set a predefined range of
+		// specific keys.
+		err = store.db.Compact(nil, nil)
+	}
+
+	return pruned, err
 }
 
 //------------------------------------------------------------------------

--- a/state/store.go
+++ b/state/store.go
@@ -405,6 +405,7 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 
 	// We do not want to panic or interrupt consensus on compaction failure
 	if store.StoreOptions.Compact && previouslyPrunedStates+pruned >= uint64(store.StoreOptions.CompactionInterval) {
+		fmt.Println("-------->>>>>> compacting state: ", pruned, " states pruned", pruned, " previouslyPrunedStates", previouslyPrunedStates, " compactionInterval", store.StoreOptions.CompactionInterval)
 		// When the range is nil,nil, the database will try to compact
 		// ALL levels. Another option is to set a predefined range of
 		// specific keys.

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -172,7 +172,7 @@ func TestPruneStates(t *testing.T) {
 			}
 
 			// Test assertions
-			err := stateStore.PruneStates(tc.pruneFrom, tc.pruneTo, tc.evidenceThresholdHeight)
+			_, err := stateStore.PruneStates(tc.pruneFrom, tc.pruneTo, tc.evidenceThresholdHeight, 0)
 			if tc.expectErr {
 				require.Error(t, err)
 				return

--- a/store/store.go
+++ b/store/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cosmos/gogoproto/proto"
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -12,6 +13,7 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/evidence"
+	"github.com/cometbft/cometbft/libs/log"
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	cmtstore "github.com/cometbft/cometbft/proto/tendermint/store"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -63,6 +65,8 @@ type BlockStore struct {
 	blocksDeleted      int64
 	compact            bool
 	compactionInterval int64
+
+	logger log.Logger
 }
 
 type BlockStoreOption func(*BlockStore)
@@ -75,6 +79,13 @@ func WithCompaction(compact bool, compactionInterval int64) BlockStoreOption {
 	}
 }
 
+// WithLogger sets the logger used by the BlockStore.
+func WithLogger(logger log.Logger) BlockStoreOption {
+	return func(bs *BlockStore) {
+		bs.logger = logger
+	}
+}
+
 // NewBlockStore returns a new BlockStore with the given DB,
 // initialized to the last height that was committed to the DB.
 func NewBlockStore(db dbm.DB, options ...BlockStoreOption) *BlockStore {
@@ -83,6 +94,7 @@ func NewBlockStore(db dbm.DB, options ...BlockStoreOption) *BlockStore {
 		base:   bs.Base,
 		height: bs.Height,
 		db:     db,
+		logger: log.NewNopLogger(),
 	}
 	bStore.addCaches()
 	for _, option := range options {
@@ -482,7 +494,12 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 	bs.blocksDeleted += int64(pruned)
 
 	if bs.compact && bs.blocksDeleted >= bs.compactionInterval {
-		fmt.Println("----->>> compacting blocks ", bs.blocksDeleted, " blocks deleted", " compaction interval ", bs.compactionInterval)
+		bs.logger.Info("compacting blockstore",
+			"blocks_deleted", bs.blocksDeleted,
+			"compaction_interval", bs.compactionInterval,
+			"retain_height", height,
+		)
+		start := time.Now()
 		// When the range is nil,nil, the database will try to compact
 		// ALL levels. Another option is to set a predefined range of
 		// specific keys.
@@ -493,6 +510,10 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 			// we can trigger compaction in the next pruning iteration
 			bs.blocksDeleted = 0
 		}
+		bs.logger.Error("blockstore compaction complete",
+			"err", err,
+			"elapsed", time.Since(start),
+		)
 	}
 	return pruned, evidencePoint, err
 }

--- a/store/store.go
+++ b/store/store.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -65,6 +67,8 @@ type BlockStore struct {
 	blocksDeleted      int64
 	compact            bool
 	compactionInterval int64
+	compacting         atomic.Bool
+	compactionWg       sync.WaitGroup
 
 	logger log.Logger
 }
@@ -494,28 +498,38 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 	bs.blocksDeleted += int64(pruned)
 
 	if bs.compact && bs.blocksDeleted >= bs.compactionInterval {
-		bs.logger.Info("compacting blockstore",
-			"blocks_deleted", bs.blocksDeleted,
-			"compaction_interval", bs.compactionInterval,
-			"retain_height", height,
+		bs.blocksDeleted = 0
+		bs.triggerCompactionAsync(height)
+	}
+	return pruned, evidencePoint, err
+}
+
+// triggerCompactionAsync launches a background compaction of the underlying
+// database. If a compaction is already in flight, it logs and returns; the
+// caller is responsible for resetting the deletion counter regardless. The
+// goroutine is tracked by compactionWg so Close can wait for it.
+func (bs *BlockStore) triggerCompactionAsync(retainHeight int64) {
+	if !bs.compacting.CompareAndSwap(false, true) {
+		bs.logger.Info("blockstore compaction already in progress, resetting interval counter",
+			"retain_height", retainHeight,
 		)
+		return
+	}
+	bs.compactionWg.Add(1)
+	go func() {
+		defer bs.compactionWg.Done()
+		defer bs.compacting.Store(false)
+		bs.logger.Info("compacting blockstore", "retain_height", retainHeight)
 		start := time.Now()
 		// When the range is nil,nil, the database will try to compact
 		// ALL levels. Another option is to set a predefined range of
 		// specific keys.
-		err = bs.db.Compact(nil, nil)
-		if err == nil {
-			// If there was no error in compaction we reset the counter.
-			// Otherwise we preserve the number of blocks deleted so
-			// we can trigger compaction in the next pruning iteration
-			bs.blocksDeleted = 0
-		}
+		err := bs.db.Compact(nil, nil)
 		bs.logger.Info("blockstore compaction complete",
 			"err", err,
 			"elapsed(s)", time.Since(start).Seconds(),
 		)
-	}
-	return pruned, evidencePoint, err
+	}()
 }
 
 // SaveBlock persists the given block, blockParts, and seenCommit to the underlying db.
@@ -703,6 +717,7 @@ func (bs *BlockStore) SaveSeenCommit(height int64, seenCommit *types.Commit) err
 }
 
 func (bs *BlockStore) Close() error {
+	bs.compactionWg.Wait()
 	return bs.db.Close()
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -497,7 +497,7 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 	}
 	bs.blocksDeleted += int64(pruned)
 
-	if bs.compact && bs.blocksDeleted >= bs.compactionInterval {
+	if bs.compact && bs.compactionInterval > 0 && bs.blocksDeleted >= bs.compactionInterval {
 		bs.blocksDeleted = 0
 		bs.triggerCompactionAsync(height)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -64,6 +64,11 @@ type BlockStore struct {
 	blockCommitCache         *lru.Cache[int64, *types.Commit]
 	blockExtendedCommitCache *lru.Cache[int64, *types.ExtendedCommit]
 
+	// blocksDeleted, compact, and compactionInterval are only read/written
+	// from PruneBlocks, which has a single production caller (the consensus
+	// goroutine via BlockExecutor.ApplyBlock), so no synchronization is
+	// needed for these fields. compacting and compactionWg coordinate with
+	// the background compaction goroutine and are intentionally lock-free.
 	blocksDeleted      int64
 	compact            bool
 	compactionInterval int64
@@ -501,7 +506,7 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 		bs.blocksDeleted = 0
 		bs.triggerCompactionAsync(height)
 	}
-	return pruned, evidencePoint, err
+	return pruned, evidencePoint, nil
 }
 
 // triggerCompactionAsync launches a background compaction of the underlying

--- a/store/store.go
+++ b/store/store.go
@@ -510,7 +510,7 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 			// we can trigger compaction in the next pruning iteration
 			bs.blocksDeleted = 0
 		}
-		bs.logger.Error("blockstore compaction complete",
+		bs.logger.Info("blockstore compaction complete",
 			"err", err,
 			"elapsed", time.Since(start),
 		)

--- a/store/store.go
+++ b/store/store.go
@@ -482,6 +482,7 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 	bs.blocksDeleted += int64(pruned)
 
 	if bs.compact && bs.blocksDeleted >= bs.compactionInterval {
+		fmt.Println("----->>> compacting blocks ", bs.blocksDeleted, " blocks deleted", " compaction interval ", bs.compactionInterval)
 		// When the range is nil,nil, the database will try to compact
 		// ALL levels. Another option is to set a predefined range of
 		// specific keys.

--- a/store/store.go
+++ b/store/store.go
@@ -512,7 +512,7 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 		}
 		bs.logger.Info("blockstore compaction complete",
 			"err", err,
-			"elapsed", time.Since(start),
+			"elapsed(s)", time.Since(start).Seconds(),
 		)
 	}
 	return pruned, evidencePoint, err

--- a/store/store.go
+++ b/store/store.go
@@ -59,11 +59,25 @@ type BlockStore struct {
 	seenCommitCache          *lru.Cache[int64, *types.Commit]
 	blockCommitCache         *lru.Cache[int64, *types.Commit]
 	blockExtendedCommitCache *lru.Cache[int64, *types.ExtendedCommit]
+
+	blocksDeleted      int64
+	compact            bool
+	compactionInterval int64
+}
+
+type BlockStoreOption func(*BlockStore)
+
+// WithCompaction sets the compaction parameters.
+func WithCompaction(compact bool, compactionInterval int64) BlockStoreOption {
+	return func(bs *BlockStore) {
+		bs.compact = compact
+		bs.compactionInterval = compactionInterval
+	}
 }
 
 // NewBlockStore returns a new BlockStore with the given DB,
 // initialized to the last height that was committed to the DB.
-func NewBlockStore(db dbm.DB) *BlockStore {
+func NewBlockStore(db dbm.DB, options ...BlockStoreOption) *BlockStore {
 	bs := LoadBlockStoreState(db)
 	bStore := &BlockStore{
 		base:   bs.Base,
@@ -71,6 +85,9 @@ func NewBlockStore(db dbm.DB) *BlockStore {
 		db:     db,
 	}
 	bStore.addCaches()
+	for _, option := range options {
+		option(bStore)
+	}
 	return bStore
 }
 
@@ -462,7 +479,21 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 	if err != nil {
 		return 0, -1, err
 	}
-	return pruned, evidencePoint, nil
+	bs.blocksDeleted += int64(pruned)
+
+	if bs.compact && bs.blocksDeleted >= bs.compactionInterval {
+		// When the range is nil,nil, the database will try to compact
+		// ALL levels. Another option is to set a predefined range of
+		// specific keys.
+		err = bs.db.Compact(nil, nil)
+		if err == nil {
+			// If there was no error in compaction we reset the counter.
+			// Otherwise we preserve the number of blocks deleted so
+			// we can trigger compaction in the next pruning iteration
+			bs.blocksDeleted = 0
+		}
+	}
+	return pruned, evidencePoint, err
 }
 
 // SaveBlock persists the given block, blockParts, and seenCommit to the underlying db.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1001,9 +1001,7 @@ func (s *slowCompactDB) Compact(_, _ []byte) error {
 func TestAsyncCompaction(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
 	defer os.RemoveAll(config.RootDir)
-	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
+	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{})
 	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	require.NoError(t, err)
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/internal/test"
+	"github.com/cometbft/cometbft/libs/log"
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	cmtstore "github.com/cometbft/cometbft/proto/tendermint/store"
 	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
@@ -970,4 +972,106 @@ func TestSaveTxInfo(t *testing.T) {
 	require.Equal(t, "app", txInfo.Codespace)
 	require.Equal(t, int64(50000), txInfo.GasWanted)
 	require.Equal(t, int64(25000), txInfo.GasUsed)
+}
+
+// slowCompactDB wraps a dbm.DB so that Compact blocks until release is
+// closed. It also counts how many times Compact was called.
+type slowCompactDB struct {
+	dbm.DB
+	compactCount atomic.Int64
+	release      chan struct{}
+}
+
+func newSlowCompactDB(db dbm.DB) *slowCompactDB {
+	return &slowCompactDB{
+		DB:      db,
+		release: make(chan struct{}),
+	}
+}
+
+func (s *slowCompactDB) Compact(_, _ []byte) error {
+	s.compactCount.Add(1)
+	<-s.release
+	return nil
+}
+
+// TestAsyncCompaction verifies that blockstore compaction runs in the
+// background, is single-flight, resets the deletion counter on the skip path,
+// and that Close waits for an in-flight compaction.
+func TestAsyncCompaction(t *testing.T) {
+	config := test.ResetTestRoot("blockchain_reactor_test")
+	defer os.RemoveAll(config.RootDir)
+	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	require.NoError(t, err)
+
+	db := newSlowCompactDB(dbm.NewMemDB())
+	bs := NewBlockStore(db,
+		WithCompaction(true, 50),
+		WithLogger(log.TestingLogger()),
+	)
+
+	for h := int64(1); h <= 1500; h++ {
+		block, partSet, err := state.MakeBlock(h, types.MakeData(test.MakeNTxs(h, 10)), new(types.Commit), nil, state.Validators.GetProposer().Address)
+		require.NoError(t, err)
+		seenCommit := makeTestExtCommit(h, cmttime.Now())
+		bs.SaveBlockWithExtendedCommit(block, partSet, seenCommit)
+	}
+	state.LastBlockTime = time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)
+	state.LastBlockHeight = 1500
+	state.ConsensusParams.Evidence.MaxAgeNumBlocks = 400
+	state.ConsensusParams.Evidence.MaxAgeDuration = 1 * time.Second
+
+	// First prune triggers compaction. PruneBlocks must return promptly even
+	// though Compact is blocked.
+	pruneDone := make(chan struct{})
+	go func() {
+		_, _, perr := bs.PruneBlocks(100, state)
+		require.NoError(t, perr)
+		close(pruneDone)
+	}()
+	select {
+	case <-pruneDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PruneBlocks did not return promptly while compaction was blocked")
+	}
+
+	// Wait for the background goroutine to enter db.Compact.
+	require.Eventually(t, func() bool {
+		return db.compactCount.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond, "compaction goroutine did not start")
+	require.True(t, bs.compacting.Load(), "compacting flag should be set while in flight")
+	require.EqualValues(t, 0, bs.blocksDeleted, "blocksDeleted should be reset on the launch path")
+
+	// Second prune past the threshold while compaction is still in flight.
+	// The deletion counter must reset and no second goroutine must start.
+	_, _, err = bs.PruneBlocks(200, state)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, bs.blocksDeleted, "blocksDeleted should be reset on the skip path")
+	require.Equal(t, int64(1), db.compactCount.Load(),
+		"a second compaction must not start while one is in flight")
+
+	// Close must block until compaction completes.
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- bs.Close()
+	}()
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned before in-flight compaction completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Release compaction; Close should now return cleanly.
+	close(db.release)
+	select {
+	case cerr := <-closeDone:
+		require.NoError(t, cerr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return after compaction was released")
+	}
+	require.Equal(t, int64(1), db.compactCount.Load())
+	require.False(t, bs.compacting.Load(), "compacting flag should be cleared on goroutine exit")
 }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/2606 and PROTOCO-617

The reason the state was growing indefinitely is because of compaction. The blockstore and state were not being compacted after deleted which makes them grow.

This PR, cherry picked from upstream, adds compaction support to the blockstore and state which can be configurable to run every interval. For now, it's disabled by default, only validators who find that they're DBs are very large can use it.

In the upstream change, compaction is ran synchronously. However, given it takes sometime to execute, I chose to make the blockstore compaction async to avoid blocking consensus/blocksync for minutes.

**Pros:**
- compaction keeps the store at a fixed size. I tested it by syncing almost a million block and still the store is fixed size to ~30GB

**Cons:**
- It adds to syncing time. When compaction is triggered, it takes a few second/minutes to finish depending on the store size. So, it's running async to avoid blocking consensus/blocksync. For the state store, compaction is done synchoronously because it's a very small store and takes a fraction of a second to execute.
- During compaction, the disk utilisation increases, so it can impact the block saving time.
- The state pruning is an API breaking change given it changes the `PruneStates()` function signature. Given the comet state store is very small, we can skip compaction there is we want to ship this as part of a non-breaking release.

**Alternative implementations:**
I tried an implementation that prunes only the keys added to the db and does it async. However, it gets very complex and the pruning doesn't function 100% because the store also stores the block hashes which are not consecutive => pruning an interval becomes pruning every key separately.

**FLUP:**
Blocksync/consensus can potential block during compaction if the store size is very large even if the operation is not blocking. The reason being is  the memtable size and the cache levels are set to default both in PebbleDB and LevelDB. So, when they fill up, any block saving operation will block until compaction is done.

The solution to this is to tweek these params at startup to leave enough headroom for blocks to be saved during compaction and not block blocksync/consensus.