### PR TITLE
fix: ensure IsCaughtUp handles peers pruned ahead of pool height

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -270,8 +270,11 @@ func (pool *BlockPool) IsCaughtUp() bool {
 	// and that we're synced to the highest known height.
 	// Note we use maxPeerHeight - 1 because to sync block H requires block H+1
 	// to verify the LastCommit.
+	// maxPeerHeight == 0 with peers present means every peer was filtered out by
+	// updateMaxPeerHeight (peer.base > pool.height) — none can serve us blocks
+	// at our height, so we are not caught up.
 	receivedBlockOrTimedOut := pool.height > 0 || time.Since(pool.startTime) > 5*time.Second
-	ourChainIsLongestAmongPeers := pool.maxPeerHeight == 0 || pool.height >= (pool.maxPeerHeight-1)
+	ourChainIsLongestAmongPeers := pool.maxPeerHeight > 0 && pool.height >= (pool.maxPeerHeight-1)
 	isCaughtUp := receivedBlockOrTimedOut && ourChainIsLongestAmongPeers
 	return isCaughtUp
 }

--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -270,13 +270,35 @@ func (pool *BlockPool) IsCaughtUp() bool {
 	// and that we're synced to the highest known height.
 	// Note we use maxPeerHeight - 1 because to sync block H requires block H+1
 	// to verify the LastCommit.
-	// maxPeerHeight == 0 with peers present means every peer was filtered out by
-	// updateMaxPeerHeight (peer.base > pool.height) — none can serve us blocks
-	// at our height, so we are not caught up.
+	//
+	// maxPeerHeight == 0 happens in two distinct cases:
+	//   1. Fresh network: no peer has produced any blocks yet (all peer
+	//      heights are 0). We are caught up to the network and should switch
+	//      to consensus to participate in producing the first block.
+	//   2. Stalled: peers exist with blocks but updateMaxPeerHeight filtered
+	//      them all out (every peer's base is ahead of pool.height). The
+	//      network is ahead of us but no peer can serve our height, so we
+	//      are not caught up and must stay in blocksync.
 	receivedBlockOrTimedOut := pool.height > 0 || time.Since(pool.startTime) > 5*time.Second
-	ourChainIsLongestAmongPeers := pool.maxPeerHeight > 0 && pool.height >= (pool.maxPeerHeight-1)
+	var ourChainIsLongestAmongPeers bool
+	if pool.maxPeerHeight == 0 {
+		ourChainIsLongestAmongPeers = !pool.anyPeerHasBlocks()
+	} else {
+		ourChainIsLongestAmongPeers = pool.height >= (pool.maxPeerHeight - 1)
+	}
 	isCaughtUp := receivedBlockOrTimedOut && ourChainIsLongestAmongPeers
 	return isCaughtUp
+}
+
+// anyPeerHasBlocks reports whether any peer in the pool advertises a non-zero
+// height. CONTRACT: pool.mtx must be locked.
+func (pool *BlockPool) anyPeerHasBlocks() bool {
+	for _, peer := range pool.peers {
+		if peer.height > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // PeekTwoBlocks returns blocks at pool.height and pool.height+1. We need to

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -628,3 +628,31 @@ func TestBlockPoolMaxPeerHeightRefreshesOnPopRequest(t *testing.T) {
 	require.EqualValues(t, 100, pool.MaxPeerHeight(),
 		"peer B must contribute to maxPeerHeight once pool.height reaches its base")
 }
+
+// TestBlockPoolIsCaughtUpAllPeersPrunedAhead verifies that a node does NOT
+// consider itself caught up when every connected peer advertises a base
+// higher than pool.height. In that case updateMaxPeerHeight() filters all
+// peers out, leaving maxPeerHeight == 0; IsCaughtUp must still return false
+// because peers exist and are in fact ahead of us, just unable to serve.
+//
+// Regression test for premature blocksync -> consensus switch  when the only available
+// peer reports base > pool.height.
+func TestBlockPoolIsCaughtUpAllPeersPrunedAhead(t *testing.T) {
+	const ourHeight = int64(100)
+
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+	pool := NewBlockPool(ourHeight, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	// Every connected peer is pruned ahead of pool.height — none can serve
+	// us blocks at our current height even though their advertised height is
+	// higher than ours.
+	pool.SetPeerRange(p2p.ID("pruned1"), ourHeight+50, ourHeight+200)
+	pool.SetPeerRange(p2p.ID("pruned2"), ourHeight+10, ourHeight+150)
+
+	require.EqualValues(t, 0, pool.MaxPeerHeight(),
+		"all peers pruned ahead of pool.height must be excluded from maxPeerHeight")
+	require.False(t, pool.IsCaughtUp(),
+		"node must not consider itself caught up when no peer can serve blocks at pool.height")
+}

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -656,3 +656,30 @@ func TestBlockPoolIsCaughtUpAllPeersPrunedAhead(t *testing.T) {
 	require.False(t, pool.IsCaughtUp(),
 		"node must not consider itself caught up when no peer can serve blocks at pool.height")
 }
+
+// TestBlockPoolIsCaughtUpFreshNetwork verifies that a node DOES consider
+// itself caught up when every peer advertises height 0 — i.e. the network
+// has not produced any blocks yet. Without this, validators at network
+// genesis would stay in blocksync forever, waiting for blocks no one has
+// produced yet, and the chain would never start.
+//
+// pool.height here is state.InitialHeight (the next block to fetch) while
+// every peer reports a fresh store: base=0, height=0. maxPeerHeight ends up
+// at 0, but the correct answer is "caught up" so consensus can take over.
+func TestBlockPoolIsCaughtUpFreshNetwork(t *testing.T) {
+	const initialHeight = int64(1000)
+
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+	pool := NewBlockPool(initialHeight, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	// Every peer is at network genesis: no blocks produced yet.
+	pool.SetPeerRange(p2p.ID("peer1"), 0, 0)
+	pool.SetPeerRange(p2p.ID("peer2"), 0, 0)
+
+	require.EqualValues(t, 0, pool.MaxPeerHeight(),
+		"peers without blocks contribute 0 to maxPeerHeight")
+	require.True(t, pool.IsCaughtUp(),
+		"node must be considered caught up when no peer has any blocks (fresh network)")
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/3050 and PROTOCO-1763