### PR TITLE
fix(propagation): guard GetProposal against nil compact block

### DIFF
--- a/consensus/propagation/commitment_state.go
+++ b/consensus/propagation/commitment_state.go
@@ -89,7 +89,7 @@ func (p *ProposalCache) AddProposal(cb *proptypes.CompactBlock) (added bool) {
 // this node has it stored or cached.
 func (p *ProposalCache) GetProposal(height int64, round int32) (*types.Proposal, *types.PartSet, bool) {
 	cb, parts, _, has := p.getAllState(height, round, true)
-	if !has {
+	if !has || cb == nil {
 		return nil, nil, false
 	}
 	return &cb.Proposal, parts.Original(), has

--- a/consensus/propagation/commitment_state_test.go
+++ b/consensus/propagation/commitment_state_test.go
@@ -319,3 +319,26 @@ func TestProposalCache_unfinishedHeightsTreatsCatchupAsPending(t *testing.T) {
 	require.True(t, unfinished[0].block.IsComplete(), "block should still be complete")
 	require.True(t, unfinished[0].catchup)
 }
+
+// TestProposalCache_GetProposal_NilCompactBlock guards against the nil pointer
+// panic reported in #3039, where GetProposal dereferenced cb.Proposal when
+// getAllState returned has=true with a nil *CompactBlock. The stored-block
+// branch of getAllState produces exactly that shape (nil cb, non-nil parts,
+// true). GetProposal must report not found instead of panicking.
+func TestProposalCache_GetProposal_NilCompactBlock(t *testing.T) {
+	bs := makeTestBlockStore(t)
+	pc := NewProposalCache(bs)
+
+	// Same shape the stored-block branch of getAllState returns: a cached entry
+	// with a nil compactBlock pointer.
+	pc.proposals[5] = map[int32]*proposalData{
+		0: {compactBlock: nil},
+	}
+
+	require.NotPanics(t, func() {
+		prop, parts, has := pc.GetProposal(5, 0)
+		require.False(t, has)
+		require.Nil(t, prop)
+		require.Nil(t, parts)
+	})
+}


### PR DESCRIPTION
Fixes #3039.

`getAllState` can return `has=true` with a nil `*CompactBlock` (the stored-block branch at `commitment_state.go:190`, where the proposal is not cached but the block is in the BlockStore). `GetProposal` then evaluated `&cb.Proposal` on that nil pointer and panicked, which is the failure observed in the consensus tests:

```
panic: runtime error: invalid memory address or nil pointer dereference
  consensus/propagation.(*ProposalCache).GetProposal
    consensus/propagation/commitment_state.go:95
  consensus.(*State).syncData
    consensus/state.go:2929
```

Treat a nil compact block the same as `has=false` and report not found.

Added a regression test that constructs the same shape `getAllState` returns on its stored-block branch (cached entry with nil `compactBlock`) and asserts `GetProposal` returns `(nil, nil, false)` without panicking. Test fails on `main` with the original panic and passes with this fix.

```
$ go test ./consensus/propagation/ -count=1 -timeout 180s
ok  	github.com/cometbft/cometbft/consensus/propagation	10.035s
```