### PR TITLE
fix: check block part size

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -2570,7 +2570,7 @@ func TestStateOutputsBlockPartsStats(t *testing.T) {
 		Part:   parts.GetPart(0),
 	}
 
-	cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header(), types.BlockPartSizeBytes)
+	cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header(), 10)
 	cs.handleMsg(msgInfo{msg, peer.ID()})
 
 	statsMessage := <-cs.statsMsgQueue

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -56,11 +56,15 @@ type Part struct {
 
 // ValidateBasic performs basic validation.
 func (part *Part) ValidateBasic() error {
-	if len(part.Bytes) > int(BlockPartSizeBytes) {
+	return part.validateBasicWithPartSize(int(BlockPartSizeBytes))
+}
+
+func (part *Part) validateBasicWithPartSize(partSize int) error {
+	if len(part.Bytes) > partSize {
 		return ErrPartTooBig
 	}
 	// All parts except the last one should have the same constant size.
-	if int64(part.Index) < part.Proof.Total-1 && len(part.Bytes) != int(BlockPartSizeBytes) {
+	if int64(part.Index) < part.Proof.Total-1 && len(part.Bytes) != partSize {
 		return ErrPartInvalidSize
 	}
 	if int64(part.Index) != part.Proof.Index {
@@ -565,7 +569,7 @@ func (ps *PartSet) Total() uint32 {
 	return ps.total
 }
 
-// CONTRACT: part is validated using ValidateBasic.
+// AddPart validates and stores a block part if its proof matches this part set.
 func (ps *PartSet) AddPart(part *Part) (bool, error) {
 	// TODO: remove this? would be preferable if this only returned (false, nil)
 	// when its a duplicate block part
@@ -577,12 +581,13 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 		return false, fmt.Errorf("nil part")
 	}
 
-	// Defense-in-depth: ensure the part's index is bound to its proof's index
-	// before any further processing. Callers are expected to enforce this via
-	// Part.ValidateBasic, but enforcing it at the sink prevents a structurally
-	// valid proof for index j from being installed in slot i (i != j).
-	if int64(part.Index) != part.Proof.Index {
-		return false, ErrInvalidPart{Reason: fmt.Errorf("part index %d != proof index %d", part.Index, part.Proof.Index)}
+	// This is the shared sink for legacy block-part gossip and compact-block
+	// recovery. A valid Merkle proof only proves membership in the proposed
+	// PartSetHeader; it does not prove that the part uses this PartSet's
+	// expected boundaries. Keep full Part validation here so every caller
+	// preserves the same block identity invariant.
+	if err := part.validateBasicWithPartSize(ps.partSize); err != nil {
+		return false, err
 	}
 
 	// If part already exists, return false.

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -316,6 +316,57 @@ func TestPart_ValidateBasic(t *testing.T) {
 	}
 }
 
+func TestPartSetAddPartRejectsNonCanonicalParts(t *testing.T) {
+	data := cmtrand.Bytes(int(2*BlockPartSizeBytes) + 123)
+	partSize := int(BlockPartSizeBytes)
+
+	testCases := []struct {
+		name    string
+		chunks  [][]byte
+		wantErr error
+	}{
+		{
+			name: "oversized non-final part",
+			chunks: [][]byte{
+				data[:partSize+1],
+				data[partSize : 2*partSize],
+				data[2*partSize:],
+			},
+			wantErr: ErrPartTooBig,
+		},
+		{
+			name: "undersized non-final part",
+			chunks: [][]byte{
+				data[:partSize-1],
+				data[partSize-1 : 2*partSize-1],
+				data[2*partSize-1:],
+			},
+			wantErr: ErrPartInvalidSize,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, proofs := merkle.ParallelProofsFromByteSlices(tc.chunks)
+			part := &Part{
+				Index: 0,
+				Bytes: tc.chunks[0],
+				Proof: *proofs[0],
+			}
+			require.ErrorIs(t, part.ValidateBasic(), tc.wantErr)
+
+			ps := NewPartSetFromHeader(PartSetHeader{
+				Total: uint32(len(tc.chunks)),
+				Hash:  root,
+			}, BlockPartSizeBytes)
+			added, err := ps.AddPart(part)
+			require.False(t, added)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.False(t, ps.HasPart(0))
+		})
+	}
+}
+
 func TestParSetHeaderProtoBuf(t *testing.T) {
 	testCases := []struct {
 		msg     string


### PR DESCRIPTION
due to layers of modifications and not sufficient testing, we stopped checking the block part size in the propagation reactor and then also in the consensus reactor