### PR TITLE
chore: backport comet refactor (v0.39.x)

### DIFF
--- a/state/validation.go
+++ b/state/validation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/types"
@@ -11,6 +12,14 @@ import (
 
 //-----------------------------------------------------
 // Validate block
+
+// maxBlockTimeTolerance is the maximum allowed difference between a block's time
+// and wall-clock time. Blocks whose time is further than this into the future
+// are rejected, guarding against malformed or malicious timestamps (e.g. a vote
+// timestamp so far in the future that nanosecond arithmetic overflows) from
+// being committed. It is intentionally hardcoded for now; expose it via config
+// only if an application needs to tune it.
+const maxBlockTimeTolerance = 60 * time.Second
 
 func validateBlock(state State, block *types.Block) error {
 	// Validate internal consistency.
@@ -110,7 +119,14 @@ func validateBlock(state State, block *types.Block) error {
 		)
 	}
 
-	// Validate block Time
+	// Validate block Time.
+	// Reject blocks whose time is too far ahead of our wall clock.
+	if now := time.Now(); !block.Time.Before(now.Add(maxBlockTimeTolerance)) {
+		return fmt.Errorf(
+			"block time %v is too far in the future (wall clock %v + tolerance %v)",
+			block.Time, now, maxBlockTimeTolerance,
+		)
+	}
 	switch {
 	case block.Height > state.InitialHeight:
 		if !block.Time.After(state.LastBlockTime) {

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -440,6 +440,18 @@ func TestValidateBlockTime(t *testing.T) {
 		err = blockExec.ValidateBlock(state, block)
 		require.NoError(t, err)
 	})
+
+	t.Run("block time too far in the future", func(t *testing.T) {
+		height := int64(3)
+		block, _, err := makeBlock(state, height, lastCommit)
+		require.NoError(t, err)
+		// A block time well beyond maxBlockTimeTolerance must be rejected,
+		// regardless of the median, to guard against malicious timestamps.
+		block.Time = time.Now().Add(1000 * time.Hour)
+		err = blockExec.ValidateBlock(state, block)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too far in the future")
+	})
 }
 
 func TestValidateBlockInvalidCommit(t *testing.T) {

--- a/types/time/time.go
+++ b/types/time/time.go
@@ -42,7 +42,7 @@ func WeightedMedian(weightedTimes []*WeightedTime, totalVotingPower int64) (res 
 		if weightedTimes[j] == nil {
 			return true
 		}
-		return weightedTimes[i].Time.UnixNano() < weightedTimes[j].Time.UnixNano()
+		return weightedTimes[i].Time.Before(weightedTimes[j].Time)
 	})
 
 	for _, weightedTime := range weightedTimes {

--- a/types/time/time_test.go
+++ b/types/time/time_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWeightedMedian(t *testing.T) {
@@ -53,4 +54,34 @@ func TestWeightedMedian(t *testing.T) {
 	// median always returns value between values of correct processes
 	assert.Equal(t, true, (median.After(t1) || median.Equal(t1)) &&
 		(median.Before(t4) || median.Equal(t4)))
+}
+
+// TestWeightedMedianFarFutureTimes guards against the int64 nanosecond overflow
+// bug: time.Time.UnixNano() is undefined for dates beyond ~2262-04-11, so
+// comparing UnixNano() values sorts such times incorrectly and corrupts the
+// median. WeightedMedian must order times with time.Time.Before, which is
+// correct across the overflow boundary.
+func TestWeightedMedianFarFutureTimes(t *testing.T) {
+	// base sits just inside the representable UnixNano range.
+	base := time.Date(2262, time.April, 11, 0, 0, 0, 0, time.UTC)
+	t1 := base                           // before the overflow boundary
+	t2 := base.Add(48 * time.Hour)       // past the boundary -> UnixNano wraps negative
+	t3 := base.Add(365 * 24 * time.Hour) // well past the boundary
+
+	// Sanity check: these timestamps actually straddle the UnixNano overflow,
+	// so a UnixNano-based comparison would mis-order them.
+	require.True(t, t2.UnixNano() < t1.UnixNano(),
+		"expected UnixNano to overflow past the year-2262 boundary")
+	require.True(t, t1.Before(t2) && t2.Before(t3),
+		"chronological order must be t1 < t2 < t3")
+
+	// totalVotingPower 100, weights 30/40/30 -> the weighted median is t2.
+	m := []*WeightedTime{
+		NewWeightedTime(t3, 30),
+		NewWeightedTime(t1, 30),
+		NewWeightedTime(t2, 40),
+	}
+	median := WeightedMedian(m, 100)
+	require.Equal(t, t2, median,
+		"WeightedMedian must order times correctly across the UnixNano overflow boundary")
 }


### PR DESCRIPTION
Backports [cometbft/cometbft#5718](https://github.com/cometbft/cometbft/pull/5718) to `v0.39.x-celestia`. Companion to #3077 (main).