### PR TITLE
fix(store): properly prune extended commits

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -495,6 +495,10 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 			if err := batch.Delete(calcBlockCommitKey(h)); err != nil {
 				return 0, -1, err
 			}
+			if err := batch.Delete(calcExtCommitKey(h)); err != nil {
+				return 0, -1, err
+			}
+			bs.blockExtendedCommitCache.Remove(h)
 		}
 		if err := batch.Delete(calcSeenCommitKey(h)); err != nil {
 			return 0, -1, err

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -600,7 +600,9 @@ func TestPruneBlocks(t *testing.T) {
 	require.NotNil(t, bs.LoadBlockMeta(1100))
 	require.Nil(t, bs.LoadBlockMeta(1099))
 	require.NotNil(t, bs.LoadBlockCommit(1100))
+	require.NotNil(t, bs.LoadBlockExtendedCommit(1100))
 	require.Nil(t, bs.LoadBlockCommit(1099))
+	require.Nil(t, bs.LoadBlockExtendedCommit(1099))
 
 	for i := int64(1); i < 1200; i++ {
 		require.Nil(t, bs.LoadBlock(i))
@@ -629,7 +631,9 @@ func TestPruneBlocks(t *testing.T) {
 	require.NotNil(t, bs.LoadBlockMeta(1100))
 	require.Nil(t, bs.LoadBlockMeta(1099))
 	require.NotNil(t, bs.LoadBlockCommit(1100))
+	require.NotNil(t, bs.LoadBlockExtendedCommit(1100))
 	require.Nil(t, bs.LoadBlockCommit(1099))
+	require.Nil(t, bs.LoadBlockExtendedCommit(1099))
 
 	// Pruning beyond the current height should error
 	_, _, err = bs.PruneBlocks(1501, state)


### PR DESCRIPTION
## Overview

`BlockStore.PruneBlocks` deleted block meta, hash, commit, seen-commit, and part keys, but **never deleted the extended-commit key** (`calcExtCommitKey`) nor evicted `blockExtendedCommitCache`. Extended commits (vote-extension data) were therefore written but never pruned, causing **unbounded storage growth** on nodes that use vote extensions.

This deletes the extended commit alongside the block commit — gated on the same evidence-retention point (`h < evidencePoint`) so evidence data is preserved — and evicts the LRU cache entry to keep the cache consistent with the DB.

## Testing

Extended `TestPruneBlocks` to assert that the extended commit is retained for heights within the evidence window and pruned for heights below it. Verified the assertions fail before the fix (extended commit for the pruned height was still loadable) and pass after.

## Notes

Backport of upstream [cometbft/cometbft#5276](https://github.com/cometbft/cometbft/pull/5276) (shipped in v0.38.19). Surfaced by the upstream-audit issue.

Closes PROTOCO-1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)