### PR TITLE
ci: notify #protocol-ci Slack channel on CI failures

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -90,3 +90,17 @@ jobs:
                 text:
                   type: "mrkdwn"
                   text: ":skull: Nightly fuzz tests for `${{ env.BRANCH }}` failed with ${{ env.CRASHERS }} crasher(s). See the <${{ env.RUN_URL }}|run details>."
+
+      - name: Notify protocol-ci on failure
+        uses: slackapi/slack-github-action@v3.0.3
+        env:
+          BRANCH: ${{ github.ref_name }}
+          CRASHERS: ${{ needs.fuzz-nightly-test.outputs.crashers-count }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        with:
+          webhook: ${{ secrets.PROTOCOL_CI_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ github.repository }} | Fuzz Tests failed on ${{ env.BRANCH }} with ${{ env.CRASHERS }} crasher(s): ${{ env.RUN_URL }}"
+            }

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         env:
           BRANCH: ${{ github.ref_name }}
           CRASHERS: ${{ needs.fuzz-nightly-test.outputs.crashers-count }}
@@ -92,7 +92,7 @@ jobs:
                   text: ":skull: Nightly fuzz tests for `${{ env.BRANCH }}` failed with ${{ env.CRASHERS }} crasher(s). See the <${{ env.RUN_URL }}|run details>."
 
       - name: Notify protocol-ci on failure
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         env:
           BRANCH: ${{ github.ref_name }}
           CRASHERS: ${{ needs.fuzz-nightly-test.outputs.crashers-count }}

--- a/.github/workflows/notify-protocol-ci.yml
+++ b/.github/workflows/notify-protocol-ci.yml
@@ -17,6 +17,10 @@ on:
     branches:
       - main
 
+# The notifier only calls an external Slack webhook; it needs no GITHUB_TOKEN
+# scopes.
+permissions: {}
+
 jobs:
   notify:
     name: Notify Slack
@@ -24,7 +28,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Slack Notification
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.PROTOCOL_CI_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/notify-protocol-ci.yml
+++ b/.github/workflows/notify-protocol-ci.yml
@@ -1,0 +1,34 @@
+name: Notify protocol-ci on failure
+
+# Posts a message to the #protocol-ci Slack channel when a CI workflow fails on
+# main (post-merge). A single workflow_run-triggered file watches several
+# workflows so we don't have to add a notify job to each one. The repo name is
+# included in the message so #protocol-ci can aggregate failures from
+# celestia-app, celestia-core, and celestia-node.
+on:
+  workflow_run:
+    workflows:
+      - "Test"
+      - "e2e"
+      - "Golang Linter"
+      - "Protobuf Lint"
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.PROTOCOL_CI_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ github.repository }} | ${{ github.event.workflow_run.name }} failed on ${{ github.event.workflow_run.head_branch }}: ${{ github.event.workflow_run.html_url }}"
+            }


### PR DESCRIPTION
## Overview

Routes celestia-core CI failures into the new **#protocol-ci** Slack channel so failures from celestia-app, celestia-core, and celestia-node can be monitored in one place. Each message is prefixed with the repo name, e.g.:

> `celestiaorg/celestia-core | Test failed on main: <link>`

## Changes

- Add `.github/workflows/notify-protocol-ci.yml`: a single `workflow_run`-triggered notifier that watches `Test`, `e2e`, `Golang Linter`, and `Protobuf Lint` and posts to #protocol-ci when any fails on `main`.
- Add a #protocol-ci notification step to `fuzz-nightly.yml`'s failure path (that nightly workflow deliberately doesn't fail itself on crashers, so `workflow_run` can't catch it).

## Notes

- Uses a new repo secret `PROTOCOL_CI_SLACK_WEBHOOK_URL` (incoming webhook for #protocol-ci), so existing notifications to other channels are untouched. The secret has been configured.
- Follow-up (not in this PR): the existing fuzz notifier references `secrets.SLACK_WEBHOOK_URL`, but this repo only has a secret named `SLACK_WEBHOOK` — likely silently failing.

## Security hardening

Addresses CodeQL `actions/unpinned-tag` and `actions/missing-workflow-permissions` alerts:
- Pinned `slackapi/slack-github-action` to its v3.0.3 commit SHA (`45a88b9`).
- Set an empty `permissions: {}` block (the notifier only calls an external Slack webhook).

Closes [PROTOCO-1891](https://linear.app/celestia/issue/PROTOCO-1891/route-ci-failures-from-celestia-appcorenode-to-protocol-ci-slack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
