### PR TITLE
build: align Go toolchain to 1.26.4 (fix govulncheck + Docker release builds)

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,6 +1,6 @@
 # Use a build arg to ensure that both stages use the same,
 # hopefully current, go version.
-ARG GOLANG_BASE_IMAGE=golang:1.25-alpine
+ARG GOLANG_BASE_IMAGE=golang:1.26-alpine
 
 # stage 1 Generate CometBFT Binary
 FROM --platform=$BUILDPLATFORM $GOLANG_BASE_IMAGE as builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,5 +1,5 @@
 # We use Debian instead of Alpine for compatibility.
-FROM golang:1.26.3
+FROM golang:1.26.4
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION
## Overview

Two separate CI jobs are failing on `celestia-core` for the same underlying reason — stale Go toolchain pins. This PR aligns everything to **Go 1.26.4**.

### 1. `Check for Go vulnerabilities` — failing on every branch

go1.26.3 is affected by two Go standard library vulnerabilities, both fixed in go1.26.4:

| ID | Package | Fixed in |
| --- | --- | --- |
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | go1.26.4 |
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | go1.26.4 |

Fix: bump the `go` directive in `go.mod` (the single source of truth — all workflows resolve their Go version via `go-version-file: go.mod`) and the hardcoded version in `test/e2e/docker/Dockerfile`.

### 2. `Release` / `Docker` — failing on release tags (e.g. `v0.40.6`)

The release Docker build failed with:

```
go: go.mod requires go >= 1.26.1 (running go 1.25.11; GOTOOLCHAIN=local)
```

`DOCKER/Dockerfile` pinned its base image to `golang:1.25-alpine` while `go.mod` requires go 1.26.x, and `GOTOOLCHAIN=local` in the image prevents auto-download. This is a latent failure on `main` too — the next release would have failed the same way. Fix: bump the base image to `golang:1.26-alpine`.

## Verification

```
$ GOTOOLCHAIN=go1.26.4 make vulncheck
No vulnerabilities found.

$ GOTOOLCHAIN=go1.26.4 go build ./...                       # OK
$ GOTOOLCHAIN=go1.26.4 make lint                            # 0 issues
$ docker build --target builder -f DOCKER/Dockerfile .      # builder stage succeeds (was the failing step)
```

## Notes

- `DOCKER/Dockerfile.testing` (also `golang:1.25-alpine`) was left untouched: it is only used by a manual `DOCKER/Makefile` target, not referenced by any CI workflow, and is independently broken (uses `apt-get` on an alpine base).
- No associated GitHub or Linear issue — surfaced by the scheduled CI-flake review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)