### PR TITLE
test(consensus): stabilize oversized block vote wait

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -292,7 +292,9 @@ func TestStateOversizedBlock(t *testing.T) {
 			propBlock, propBlockParts := findBlockSizeLimit(t, height, maxBytes, cs1, partSize, testCase.oversized)
 
 			timeoutProposeCh := subscribe(cs1.eventBus, types.EventQueryTimeoutPropose)
-			voteCh := subscribe(cs1.eventBus, types.EventQueryVote)
+			// Only wait for this validator's votes. The peer prevote below is
+			// just input that drives the state machine toward our precommit.
+			voteCh := subscribeToVoter(cs1, cs1.privValidatorPubKey.Address())
 
 			// make the second validator the proposer by incrementing round
 			round++
@@ -351,7 +353,6 @@ func TestStateOversizedBlock(t *testing.T) {
 			require.NoError(t, err)
 
 			signAddVotes(cs1, cmtproto.PrevoteType, propBlock.Hash(), bps.Header(), false, vs2)
-			ensurePrevote(voteCh, height, round)
 			ensurePrecommit(voteCh, height, round)
 			validatePrecommit(t, cs1, round, lockedRound, vss[0], validateHash, validateHash)
 


### PR DESCRIPTION
## Summary

Fixes the flaky `TestStateOversizedBlock/max_size,_correct_block` failure from PR #3111's `tests (00)` CI shard.

The test previously subscribed to all vote events, then waited for the peer prevote before waiting for our precommit on the same one-slot channel. If the local precommit event arrived before the peer prevote was consumed, the helper could discard it as an unexpected vote and then time out waiting for a precommit that had already passed through the subscription.

This changes the test to subscribe only to the local validator's votes. The peer prevote remains the input that drives the state machine, but it no longer competes with the precommit event the test actually asserts.

## Tests

- `go test -mod=readonly -timeout=15m -race -count=50 -run '^TestStateOversizedBlock$' ./consensus`
- `go test -mod=readonly -timeout=15m -race -count=20 -run 'Test(SetProposal|AddProposalBlockPart|TryAddVote|HandleMsgDoesNotLog)' ./consensus`

Failed job investigated: https://github.com/celestiaorg/celestia-core/actions/runs/27372525771/job/80888228034?pr=3111