### PR TITLE
test(consensus): stabilize oversized block vote wait

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -292,7 +292,9 @@ func TestStateOversizedBlock(t *testing.T) {
 			propBlock, propBlockParts := findBlockSizeLimit(t, height, maxBytes, cs1, partSize, testCase.oversized)
 
 			timeoutProposeCh := subscribe(cs1.eventBus, types.EventQueryTimeoutPropose)
-			voteCh := subscribe(cs1.eventBus, types.EventQueryVote)
+			// Only wait for this validator's votes. The peer prevote below is
+			// just input that drives the state machine toward our precommit.
+			voteCh := subscribeToVoter(cs1, cs1.privValidatorPubKey.Address())
 
 			// make the second validator the proposer by incrementing round
 			round++
@@ -351,7 +353,6 @@ func TestStateOversizedBlock(t *testing.T) {
 			require.NoError(t, err)
 
 			signAddVotes(cs1, cmtproto.PrevoteType, propBlock.Hash(), bps.Header(), false, vs2)
-			ensurePrevote(voteCh, height, round)
 			ensurePrecommit(voteCh, height, round)
 			validatePrecommit(t, cs1, round, lockedRound, vss[0], validateHash, validateHash)
 


### PR DESCRIPTION
## Summary

Stabilizes `TestStateOversizedBlock` by subscribing only to the local validator's vote events.

The test previously subscribed to all vote events, then used the same one-slot subscription channel to wait for a peer prevote and the local precommit. If the local precommit event arrived before the peer prevote was consumed, the helper could discard it as unexpected and then time out waiting for a precommit that had already passed through the channel.

The peer prevote is still added to drive the state machine toward precommit, but it no longer competes with the local precommit event the test is actually asserting.

## Tests

- `go test -mod=readonly -timeout=15m -race -count=50 -run '^TestStateOversizedBlock$' ./consensus`