### PR TITLE
refactor(consensus): verify proposal block encoding before signing

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2321,9 +2321,9 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID p2p.ID) (add
 			return added, err
 		}
 
-		// Reject extra bytes appended to the proposal encoding (e.g. proto-ignored
-		// unknown fields): re-encoding the decoded block drops them, so comparing
-		// against the received bytes detects any non-canonical padding.
+		// Make sure the proposal bytes are the canonical encoding of the block:
+		// re encode what we decoded and check it is identical to the bytes we
+		// received, so every node derives the same PartSetHeader for this block.
 		pb, err := block.ToProto()
 		if err != nil {
 			return added, err

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2321,6 +2321,24 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID p2p.ID) (add
 			return added, err
 		}
 
+		// Reject extra bytes appended to the proposal encoding (e.g. proto-ignored
+		// unknown fields): re-encoding the decoded block drops them, so comparing
+		// against the received bytes detects any non-canonical padding.
+		pb, err := block.ToProto()
+		if err != nil {
+			return added, err
+		}
+		reEncodedBz, err := pb.Marshal()
+		if err != nil {
+			return added, err
+		}
+		if !bytes.Equal(bz, reEncodedBz) {
+			return added, fmt.Errorf(
+				"proposal block uses a non-canonical encoding: received %d bytes, reencoded to %d",
+				len(bz), len(reEncodedBz),
+			)
+		}
+
 		cs.rs.ProposalBlock = block
 
 		// NOTE: it's possible to receive complete proposal blocks for future rounds without having the proposal

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -2729,7 +2729,7 @@ func findBlockSizeLimit(t *testing.T, height, maxBytes int64, cs *State, _ uint3
 }
 
 // Asserts that a proposal whose bytes carry proto-ignored
-// junk is rejected before commit, so its PartSetHeader 
+// junk is rejected before commit, so its PartSetHeader
 // stays reproducible to blocksync nodes.
 func TestAddProposalBlockPartRejectsNonCanonicalEncoding(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"testing"
@@ -2725,4 +2726,61 @@ func findBlockSizeLimit(t *testing.T, height, maxBytes int64, cs *State, _ uint3
 	}
 	require.Fail(t, "We shouldn't hit the end of the loop")
 	return nil, nil
+}
+
+// Asserts that a proposal whose bytes carry proto-ignored
+// junk is rejected before commit, so its PartSetHeader 
+// stays reproducible to blocksync nodes.
+func TestAddProposalBlockPartRejectsNonCanonicalEncoding(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs, _ := randState(1)
+
+	cs.mtx.Lock()
+	block, _, err := cs.createProposalBlock(ctx)
+	cs.mtx.Unlock()
+	require.NoError(t, err)
+
+	pb, err := block.ToProto()
+	require.NoError(t, err)
+	canonical, err := pb.Marshal()
+	require.NoError(t, err)
+
+	// Canonical bytes plus an unknown, length-0 field (number 99) the decoder
+	// skips: same block, different bytes.
+	unknownField := append(binary.AppendUvarint(nil, uint64(99<<3|2)), 0x00)
+	poisoned := append(append([]byte{}, canonical...), unknownField...)
+
+	// gossipProposal delivers data to consensus as a sequence of block parts,
+	// just as the gossip layer would. addProposalBlockPart decodes and validates
+	// the block once the final part completes the set.
+	gossipProposal := func(data []byte) error {
+		parts, err := types.NewPartSetFromData(data, types.BlockPartSizeBytes)
+		require.NoError(t, err)
+
+		cs.mtx.Lock()
+		defer cs.mtx.Unlock()
+
+		// Start fresh and expect parts matching this proposal's header.
+		cs.rs.ProposalBlock = nil
+		cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header(), types.BlockPartSizeBytes)
+
+		for i := 0; i < int(parts.Total()); i++ {
+			msg := &BlockPartMessage{Height: cs.rs.Height, Round: cs.rs.Round, Part: parts.GetPart(i)}
+			if _, err := cs.addProposalBlockPart(msg, ""); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// The poisoned proposal is rejected.
+	require.ErrorContains(t, gossipProposal(poisoned), "non-canonical")
+
+	// The canonical proposal is accepted and adopted as the proposal block.
+	require.NoError(t, gossipProposal(canonical))
+	cs.mtx.Lock()
+	require.NotNil(t, cs.rs.ProposalBlock)
+	cs.mtx.Unlock()
 }


### PR DESCRIPTION
## Description 

Fixes https://linear.app/celestia/issue/PROTOCO-1942/medium-non-canonical-proposal-block-bytes-can-poison-block-sync-by

