### PR TITLE
fix: removeTimedoutPeers deadlock in blocksync

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -211,20 +211,19 @@ func (pool *BlockPool) makeRequestersRoutine() {
 
 func (pool *BlockPool) removeTimedoutPeers() {
 	pool.mtx.Lock()
-	defer pool.mtx.Unlock()
 
+	var timedOutPeers []p2p.ID
 	for _, peer := range pool.peers {
 		if !peer.didTimeout && peer.numPending > 0 {
 			curRate := peer.recvMonitor.Status().CurRate
 			// curRate can be 0 on start
 			if curRate != 0 && curRate < minRecvRate {
-				err := errors.New("peer is not sending us data fast enough")
-				pool.sendError(err, peer.id)
 				pool.Logger.Error("SendTimeout", "peer", peer.id,
-					"reason", err,
+					"reason", "peer is not sending us data fast enough",
 					"curRate", fmt.Sprintf("%d KB/s", curRate/1024),
 					"minRate", fmt.Sprintf("%d KB/s", minRecvRate/1024))
 				peer.didTimeout = true
+				timedOutPeers = append(timedOutPeers, peer.id)
 			}
 
 			peer.curRate = curRate
@@ -242,6 +241,12 @@ func (pool *BlockPool) removeTimedoutPeers() {
 	}
 
 	pool.sortPeers()
+	pool.mtx.Unlock()
+
+	err := errors.New("peer is not sending us data fast enough")
+	for _, peerID := range timedOutPeers {
+		pool.sendError(err, peerID)
+	}
 }
 
 // GetStatus returns pool's height, numPending requests and the number of
@@ -774,12 +779,12 @@ func (peer *bpPeer) decrPending(recvSize int) {
 
 func (peer *bpPeer) onTimeout() {
 	peer.pool.mtx.Lock()
-	defer peer.pool.mtx.Unlock()
+	peer.didTimeout = true
+	peer.pool.mtx.Unlock()
 
 	err := errors.New("peer did not send us anything")
 	peer.pool.sendError(err, peer.id)
 	peer.logger.Error("SendTimeout", "reason", err, "timeout", peerTimeout)
-	peer.didTimeout = true
 }
 
 //-------------------------------------

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -236,7 +236,7 @@ func TestBlockPoolTimeout(t *testing.T) {
 // block forever.
 func TestBlockPoolTimeoutDoesNotHoldLock(t *testing.T) {
 	start := int64(42)
-	errorsCh := make(chan peerError)   // unbuffered, intentionally undrained
+	errorsCh := make(chan peerError) // unbuffered, intentionally undrained
 	requestsCh := make(chan BlockRequest)
 
 	pool := NewBlockPool(start, requestsCh, errorsCh)

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -231,6 +231,57 @@ func TestBlockPoolTimeout(t *testing.T) {
 	}
 }
 
+// TestBlockPoolTimeoutDoesNotHoldLock is a regression test for #5839: onTimeout
+// must not hold pool.mtx while sending on errorsCh, otherwise other pool methods
+// block forever.
+func TestBlockPoolTimeoutDoesNotHoldLock(t *testing.T) {
+	start := int64(42)
+	errorsCh := make(chan peerError)   // unbuffered, intentionally undrained
+	requestsCh := make(chan BlockRequest)
+
+	pool := NewBlockPool(start, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+	require.NoError(t, pool.Start())
+	t.Cleanup(func() { _ = pool.Stop() })
+
+	peerID := p2p.ID("timeout-peer")
+	pool.SetPeerRange(peerID, 1, 100)
+
+	pool.mtx.Lock()
+	peer := pool.peers[peerID]
+	pool.mtx.Unlock()
+	require.NotNil(t, peer)
+
+	// Fire the timeout. It will block on the unbuffered, undrained errorsCh.
+	// With the fix, pool.mtx is already released by then; without it, the lock
+	// is held across the blocked send.
+	go peer.onTimeout()
+
+	// Give onTimeout time to acquire the (uncontended) lock and reach the
+	// blocking send on errorsCh.
+	time.Sleep(300 * time.Millisecond)
+
+	// A method that needs pool.mtx must remain serviceable.
+	done := make(chan struct{})
+	go func() {
+		pool.MaxPeerHeight()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good: lock was released before the blocking send.
+	case <-time.After(5 * time.Second):
+		t.Fatal("pool.mtx held across blocked sendError: deadlock regression (#5839)")
+	}
+
+	// Drain the pending error so onTimeout can return and the pool can stop.
+	select {
+	case <-errorsCh:
+	case <-time.After(time.Second):
+	}
+}
+
 func TestBlockPoolRemovePeer(t *testing.T) {
 	peers := make(testPeers, 10)
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
## Description

Fixes https://linear.app/celestia/issue/PROTOCO-1973/blocksync-blockpool-can-deadlock-while-a-node-is-catching-up