### PR TITLE
docs: mention propagation reactor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ celestia-core is a fork of [cometbft/cometbft](https://github.com/cometbft/comet
 1. The GRPC server exposed by CometBFT was modified to expose Celestia-specific APIs:
     - `BlockAPI`
     - `BlobstreamAPI`
+1. A [propagation reactor](./consensus/propagation/) was added to support Celestia's block propagation needs. It gossips compact blocks, tracks which proposal parts peers have or want, and helps recover missing proposal parts during consensus.
 
 
 See [./docs/celestia-architecture](./docs/celestia-architecture/) for architecture decision records (ADRs) on Celestia modifications.


### PR DESCRIPTION
## Overview

Adds the propagation reactor to the README list of Celestia-specific changes from upstream CometBFT.

## Changes

- Mention the propagation reactor in the top-level README.
- Link to the `consensus/propagation` package.
- Briefly describe its role in gossiping compact blocks, tracking proposal parts, and recovering missing proposal parts during consensus.

Closes #2177.