### PR TITLE
test(consensus): deflake TestReactorValidatorSetChanges timeout

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -800,8 +800,11 @@ func timeoutWaitGroup(n int, f func(int)) {
 	}()
 
 	// we're running many nodes in-process, possibly in in a virtual machine,
-	// and spewing debug messages - making a block could take a while,
-	timeout := time.Second * 20
+	// and spewing debug messages - making a block could take a while, so use a
+	// generous timeout. This only bounds the failure case: a passing run
+	// returns as soon as all validators commit, so a larger value adds no
+	// latency to green runs but gives slow CI runners more headroom.
+	timeout := time.Second * 40
 
 	select {
 	case <-done:


### PR DESCRIPTION
## Motivation

`TestReactorValidatorSetChanges/Testing_adding_two_validators_at_once` flaked in CI ([run](https://github.com/celestiaorg/celestia-core/actions/runs/27540223985/job/81399794568), on the merged dependency-bump PR #3122 — code unchanged, so a flake by definition), timing out at **20.08s** against the hard-coded 20s ceiling in the shared `timeoutWaitGroup` helper and panicking with `Timed out waiting for all validators to commit a block`.

## Change

Bump the `timeoutWaitGroup` timeout from 20s to 40s. The `select` returns as soon as all validators commit, so this adds **no latency to passing runs** — it only gives slow/loaded CI runners more headroom before declaring failure. Mirrors the timeout bump applied to `TestByzantinePrevoteEquivocation` in #2810.

## Test plan

- `go test -tags deadlock -run TestReactorValidatorSetChanges ./consensus/` passes (all 4 subtests, ~2.8s locally).
- `go tool golangci-lint run ./consensus/...` → 0 issues.