### PR TITLE
fix(ci): bump Go to 1.26.4 on v0.40.x to fix govulncheck

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,6 +1,6 @@
 # Use a build arg to ensure that both stages use the same,
 # hopefully current, go version.
-ARG GOLANG_BASE_IMAGE=golang:1.25-alpine
+ARG GOLANG_BASE_IMAGE=golang:1.26-alpine
 
 # stage 1 Generate CometBFT Binary
 FROM --platform=$BUILDPLATFORM $GOLANG_BASE_IMAGE as builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,5 +1,5 @@
 # We use Debian instead of Alpine for compatibility.
-FROM golang:1.26.1
+FROM golang:1.26.4
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION
## Problem

The `v0.40.x` branch builds with Go 1.26.1, which govulncheck flags for 11 standard-library vulnerabilities (GO-2026-5039, -5037, -4982, -4980, -4971, -4947, -4946, -4918, -4870, -4866, -4865). As a result the **Check for Go vulnerabilities** job fails on every PR targeting `v0.40.x` (e.g. the recent mergify backports #3140, #3141). `main` is already on 1.26.4 and passes.

## Fix

- Bump `go.mod` to `go 1.26.4`. All CI workflows resolve their Go version via `go-version-file: go.mod`, so this fixes vulncheck and the other Go jobs in one place.
- Bump the release `DOCKER/Dockerfile` base image to `golang:1.26-alpine` to match `main`.
- Bump the e2e `test/e2e/docker/Dockerfile` base image from `golang:1.26.1` to `golang:1.26.4`. It was pinned to 1.26.1, so `go mod download` failed once go.mod required >= 1.26.4. `main` already uses 1.26.4 here.

Verified locally: `make vulncheck` reports 0 vulnerabilities, `make lint` 0 issues, `go build ./...` succeeds.