### PR TITLE
feat(memppol/cat): introduce the new SeenTracker data structure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,7 @@ linters:
             - github.com/celestiaorg/go-square/v3
             - github.com/stretchr/testify/assert
             - github.com/klauspost/reedsolomon
+            - github.com/filecoin-project/go-clock
         test:
           files:
             - $test
@@ -96,6 +97,7 @@ linters:
             - github.com/stretchr/testify/suite
             - github.com/gogo/protobuf/proto
             - google.golang.org/protobuf/encoding/protowire
+            - github.com/filecoin-project/go-clock
     dogsled:
       max-blank-identifiers: 3
     gosec:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cometbft/cometbft-db v1.0.4
 	github.com/cosmos/gogoproto v1.7.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
+	github.com/filecoin-project/go-clock v0.1.0
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-kit/kit v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/filecoin-project/go-clock v0.1.0 h1:SFbYIM75M8NnFm1yMHhN9Ahy3W5bEZV9gd6MPfXbKVU=
+github.com/filecoin-project/go-clock v0.1.0/go.mod h1:4uB/O4PvOjlx1VCMdZ9MyDZXRm//gkj1ELEbxfI1AZs=
 github.com/firefart/nonamedreturns v1.0.6 h1:vmiBcKV/3EqKY3ZiPxCINmpS431OcE1S47AQUwhrg8E=
 github.com/firefart/nonamedreturns v1.0.6/go.mod h1:R8NisJnSIpvPWheCq0mNRXJok6D8h7fagJTF8EMEwCo=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/mempool/cat/cache.go
+++ b/mempool/cat/cache.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/filecoin-project/go-clock"
+
 	tmsync "github.com/cometbft/cometbft/libs/sync"
 	"github.com/cometbft/cometbft/types"
 )
@@ -158,7 +160,7 @@ type SeenTracker struct {
 
 	perPeerLimit   int
 	perSignerLimit int
-	now            func() time.Time
+	clock          clock.Clock
 }
 
 // seenEntry is one gossip tx entry shared by tx-key lookup and the future queue.
@@ -227,7 +229,7 @@ func NewSeenTracker() *SeenTracker {
 		txCountByPeer:     make(map[uint16]int),
 		perPeerLimit:      seenPerPeerLimit,
 		perSignerLimit:    seenPerSignerLimit,
-		now:               func() time.Time { return time.Now().UTC() },
+		clock:             clock.New(),
 	}
 }
 
@@ -264,7 +266,7 @@ func (s *SeenTracker) Add(txKey types.TxKey, peer uint16, signer []byte, sequenc
 		peers: map[uint16]struct{}{
 			peer: {},
 		},
-		addedAt: s.now(),
+		addedAt: s.clock.Now(),
 	}
 	s.txByKey[txKey] = entry
 	s.txCountByPeer[peer]++

--- a/mempool/cat/cache.go
+++ b/mempool/cat/cache.go
@@ -1,6 +1,7 @@
 package cat
 
 import (
+	"sort"
 	"time"
 
 	tmsync "github.com/cometbft/cometbft/libs/sync"
@@ -132,4 +133,449 @@ func (s *SeenTxSet) Reset() {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	s.set = make(map[types.TxKey]timestampedPeerSet)
+}
+
+// seenPerPeerLimit bounds how many txs one peer can keep tracked.
+const seenPerPeerLimit = 10_000
+
+// seenPerSignerLimit bounds future-sequence entries kept for one signer.
+const seenPerSignerLimit = 128
+
+// seenEntryTTL is short because useful out-of-order gossip should resolve quickly.
+//
+//nolint:unused // consumed when SeenTracker is wired into the reactor in a later part.
+const seenEntryTTL = 2 * time.Minute
+
+// SeenTracker tracks peers by tx key and future txs by signer/sequence.
+type SeenTracker struct {
+	mtx tmsync.Mutex
+	// txByKey is the primary lookup for tx keys and the peers that know them.
+	txByKey map[types.TxKey]*seenEntry
+	// futureTxsBySigner queues future-sequence entries waiting for a gap to close.
+	futureTxsBySigner map[string][]*seenEntry
+	// txCountByPeer tracks per-peer entries so one peer cannot pin unbounded tx keys.
+	txCountByPeer map[uint16]int
+
+	perPeerLimit   int
+	perSignerLimit int
+	now            func() time.Time
+}
+
+// seenEntry is one gossip tx entry shared by tx-key lookup and the future queue.
+type seenEntry struct {
+	txKey   types.TxKey
+	peers   map[uint16]struct{}
+	addedAt time.Time
+
+	// futureTxInfo is set only while the tx is queued for future-sequence gap-fill.
+	futureTxInfo *futureTxInfo
+
+	requested bool
+	lastPeer  uint16
+}
+
+// clearFutureMetadata drops signer/sequence state while keeping the tx keyed by peer.
+func (e *seenEntry) clearFutureMetadata() {
+	e.futureTxInfo = nil
+	e.requested = false
+	e.lastPeer = 0
+}
+
+// clone copies mutable fields so callers cannot mutate tracker state.
+func (e *seenEntry) clone() *seenEntry {
+	cp := *e
+	cp.peers = make(map[uint16]struct{}, len(e.peers))
+	for peer := range e.peers {
+		cp.peers[peer] = struct{}{}
+	}
+	if e.futureTxInfo != nil {
+		cp.futureTxInfo = &futureTxInfo{
+			signerKey: e.futureTxInfo.signerKey,
+			signer:    append([]byte(nil), e.futureTxInfo.signer...),
+			sequence:  e.futureTxInfo.sequence,
+		}
+	}
+	return &cp
+}
+
+// peerIDs returns candidate peers for the request path.
+//
+//nolint:unused // consumed when SeenTracker is wired into the reactor in a later part.
+func (e *seenEntry) peerIDs() []uint16 {
+	if len(e.peers) == 0 {
+		return nil
+	}
+	out := make([]uint16, 0, len(e.peers))
+	for peer := range e.peers {
+		out = append(out, peer)
+	}
+	return out
+}
+
+// futureTxInfo is the signer metadata needed to order future txs.
+type futureTxInfo struct {
+	signerKey string
+	signer    []byte
+	sequence  uint64
+}
+
+// NewSeenTracker creates the shared seen-state tracker used by CAT gossip.
+func NewSeenTracker() *SeenTracker {
+	return &SeenTracker{
+		txByKey:           make(map[types.TxKey]*seenEntry),
+		futureTxsBySigner: make(map[string][]*seenEntry),
+		txCountByPeer:     make(map[uint16]int),
+		perPeerLimit:      seenPerPeerLimit,
+		perSignerLimit:    seenPerSignerLimit,
+		now:               func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Add records that a peer claims to have txKey.
+// If signer is present, the same entry is also queued by signer/sequence for
+// future gap-fill. Sequence 0 is valid. It returns false when the peer claim is
+// rejected by admission limits.
+func (s *SeenTracker) Add(txKey types.TxKey, peer uint16, signer []byte, sequence uint64) bool {
+	if peer == 0 {
+		return false
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	entry, exists := s.txByKey[txKey]
+	if exists {
+		if !s.addPeerToEntryLocked(entry, peer) {
+			return false
+		}
+		// if not yet added to the future sequence queue, index
+		if entry.futureTxInfo == nil && len(signer) > 0 {
+			s.indexFutureTxLocked(entry, signer, sequence)
+		}
+		return true
+	}
+
+	if s.txCountByPeer[peer] >= s.perPeerLimit {
+		return false
+	}
+
+	entry = &seenEntry{
+		txKey: txKey,
+		peers: map[uint16]struct{}{
+			peer: {},
+		},
+		addedAt: s.now(),
+	}
+	s.txByKey[txKey] = entry
+	s.txCountByPeer[peer]++
+
+	if len(signer) > 0 {
+		s.indexFutureTxLocked(entry, signer, sequence)
+	}
+	return true
+}
+
+// addPeerToEntryLocked adds another peer to an existing tx without letting that
+// peer exceed its own admission limit.
+func (s *SeenTracker) addPeerToEntryLocked(entry *seenEntry, peer uint16) bool {
+	if _, has := entry.peers[peer]; has {
+		return true
+	}
+	if s.txCountByPeer[peer] >= s.perPeerLimit {
+		return false
+	}
+	entry.peers[peer] = struct{}{}
+	s.txCountByPeer[peer]++
+	return true
+}
+
+// indexFutureTxLocked queues an entry by signer/sequence. If the signer
+// queue is full, only the lowest sequences stay queued; overflow remains peer-only.
+func (s *SeenTracker) indexFutureTxLocked(entry *seenEntry, signer []byte, sequence uint64) {
+	signerKey := string(signer)
+	queue := s.futureTxsBySigner[signerKey]
+
+	insertIdx := sort.Search(len(queue), func(i int) bool {
+		return queue[i].futureTxInfo.sequence >= sequence
+	})
+
+	// very last entry of the queue
+	wouldAppendToQueue := insertIdx == len(queue)
+	if len(queue) >= s.perSignerLimit && wouldAppendToQueue {
+		return
+	}
+
+	entry.futureTxInfo = &futureTxInfo{
+		signerKey: signerKey,
+		signer:    append([]byte(nil), signer...),
+		sequence:  sequence,
+	}
+
+	// insert future tx into the queue
+	queue = append(queue, nil)
+	copy(queue[insertIdx+1:], queue[insertIdx:])
+	queue[insertIdx] = entry
+
+	// if queue is over limit, trim from the end (highest sequence)
+	for len(queue) > s.perSignerLimit {
+		queue[len(queue)-1].clearFutureMetadata()
+		queue = queue[:len(queue)-1]
+	}
+	s.futureTxsBySigner[signerKey] = queue
+}
+
+// ClearSequence removes a tx from the future-sequence queue but keeps the
+// peer-has-tx entry around.
+func (s *SeenTracker) ClearSequence(txKey types.TxKey) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok || entry.futureTxInfo == nil {
+		return
+	}
+	s.removeFromFutureQueueLocked(entry)
+	entry.clearFutureMetadata()
+}
+
+// RemoveKey drops a tx from every tracker index.
+func (s *SeenTracker) RemoveKey(txKey types.TxKey) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok {
+		return
+	}
+	s.removeEntryLocked(entry)
+}
+
+// removeEntryLocked removes the whole entry and fixes peer accounting.
+func (s *SeenTracker) removeEntryLocked(entry *seenEntry) {
+	if entry.futureTxInfo != nil {
+		s.removeFromFutureQueueLocked(entry)
+	}
+	for peer := range entry.peers {
+		s.decrementPeerTxCountLocked(peer)
+	}
+	delete(s.txByKey, entry.txKey)
+}
+
+// removeFromFutureQueueLocked removes entry from its signer's future tx queue.
+// The tx can still remain in txByKey as peer-has-tx state.
+func (s *SeenTracker) removeFromFutureQueueLocked(entry *seenEntry) {
+	signerKey := entry.futureTxInfo.signerKey
+	queue := s.futureTxsBySigner[signerKey]
+	for i, candidate := range queue {
+		if candidate == entry {
+			queue = append(queue[:i], queue[i+1:]...)
+			break
+		}
+	}
+	if len(queue) == 0 {
+		delete(s.futureTxsBySigner, signerKey)
+		return
+	}
+	s.futureTxsBySigner[signerKey] = queue
+}
+
+// RemovePeer removes a peer from all seen entries. Entries stay alive if some
+// other peer still claims to have the tx.
+func (s *SeenTracker) RemovePeer(peer uint16) {
+	if peer == 0 {
+		return
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for _, entry := range s.txByKey {
+		if _, has := entry.peers[peer]; has {
+			delete(entry.peers, peer)
+			s.decrementPeerTxCountLocked(peer)
+		}
+		if entry.lastPeer == peer {
+			entry.requested = false
+			entry.lastPeer = 0
+		}
+		if len(entry.peers) == 0 {
+			s.removeEntryLocked(entry)
+		}
+	}
+	delete(s.txCountByPeer, peer)
+}
+
+// Prune expires old gossip state from all indexes.
+func (s *SeenTracker) Prune(cutoff time.Time) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for _, entry := range s.txByKey {
+		if entry.addedAt.Before(cutoff) {
+			s.removeEntryLocked(entry)
+		}
+	}
+}
+
+// Has reports whether peer is known to have txKey.
+func (s *SeenTracker) Has(txKey types.TxKey, peer uint16) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok {
+		return false
+	}
+	_, has := entry.peers[peer]
+	return has
+}
+
+// Get returns a copy of the tracked tx entry, if any.
+func (s *SeenTracker) Get(txKey types.TxKey) *seenEntry {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok {
+		return nil
+	}
+	return entry.clone()
+}
+
+// Pending returns a copy of the future-sequence metadata for txKey, or nil if
+// the tx is not currently queued for future gap-fill.
+func (s *SeenTracker) Pending(txKey types.TxKey) *futureTxInfo {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok || entry.futureTxInfo == nil {
+		return nil
+	}
+	return &futureTxInfo{
+		signerKey: entry.futureTxInfo.signerKey,
+		signer:    append([]byte(nil), entry.futureTxInfo.signer...),
+		sequence:  entry.futureTxInfo.sequence,
+	}
+}
+
+// PrunePending drops future-sequence metadata for entries added before cutoff
+// while keeping the peer-has-tx entry alive.
+func (s *SeenTracker) PrunePending(cutoff time.Time) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for _, entry := range s.txByKey {
+		if entry.futureTxInfo == nil || !entry.addedAt.Before(cutoff) {
+			continue
+		}
+		s.removeFromFutureQueueLocked(entry)
+		entry.clearFutureMetadata()
+	}
+}
+
+// Peers returns a copy of the peers known to have txKey.
+func (s *SeenTracker) Peers(txKey types.TxKey) map[uint16]struct{} {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok {
+		return nil
+	}
+	out := make(map[uint16]struct{}, len(entry.peers))
+	for peer := range entry.peers {
+		out[peer] = struct{}{}
+	}
+	return out
+}
+
+// Len returns the number of unique tx keys being tracked.
+func (s *SeenTracker) Len() int {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return len(s.txByKey)
+}
+
+// Reset clears all seen state. It is mostly used by tests.
+func (s *SeenTracker) Reset() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.txByKey = make(map[types.TxKey]*seenEntry)
+	s.futureTxsBySigner = make(map[string][]*seenEntry)
+	s.txCountByPeer = make(map[uint16]int)
+}
+
+// PendingForSigner returns that signer's future txs in sequence order.
+func (s *SeenTracker) PendingForSigner(signer []byte) []*seenEntry {
+	if len(signer) == 0 {
+		return nil
+	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	queue := s.futureTxsBySigner[string(signer)]
+	if len(queue) == 0 {
+		return nil
+	}
+	out := make([]*seenEntry, len(queue))
+	for i, entry := range queue {
+		out[i] = entry.clone()
+	}
+	return out
+}
+
+// SignersWithPending lists signers that still have future txs queued.
+func (s *SeenTracker) SignersWithPending() [][]byte {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if len(s.futureTxsBySigner) == 0 {
+		return nil
+	}
+	out := make([][]byte, 0, len(s.futureTxsBySigner))
+	for signerKey := range s.futureTxsBySigner {
+		out = append(out, []byte(signerKey))
+	}
+	return out
+}
+
+// MarkRequested remembers which peer we last asked for this tx.
+func (s *SeenTracker) MarkRequested(txKey types.TxKey, peer uint16) {
+	if peer == 0 {
+		return
+	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok {
+		return
+	}
+	entry.requested = true
+	entry.lastPeer = peer
+}
+
+// MarkRequestFailed clears the in-flight request and stops using that peer for
+// this tx unless another peer also announced it.
+func (s *SeenTracker) MarkRequestFailed(txKey types.TxKey, peer uint16) {
+	if peer == 0 {
+		return
+	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	entry, ok := s.txByKey[txKey]
+	if !ok {
+		return
+	}
+	if entry.lastPeer == peer {
+		entry.requested = false
+		entry.lastPeer = 0
+	}
+	if _, has := entry.peers[peer]; has {
+		delete(entry.peers, peer)
+		s.decrementPeerTxCountLocked(peer)
+	}
+	if len(entry.peers) == 0 {
+		s.removeEntryLocked(entry)
+	}
+}
+
+// decrementPeerTxCountLocked records that peer is tracking one fewer tx.
+func (s *SeenTracker) decrementPeerTxCountLocked(peer uint16) {
+	if peer == 0 {
+		return
+	}
+	s.txCountByPeer[peer]--
+	if s.txCountByPeer[peer] <= 0 {
+		delete(s.txCountByPeer, peer)
+	}
 }

--- a/mempool/cat/cache.go
+++ b/mempool/cat/cache.go
@@ -183,10 +183,8 @@ func (e *seenEntry) clearFutureMetadata() {
 	e.lastPeer = 0
 }
 
-// clone copies every field explicitly so callers cannot mutate tracker state.
-// Fields are listed by hand (rather than `cp := *e`) so that adding a new
-// map/slice/pointer field forces a deliberate decision here instead of silently
-// sharing it between the clone and the tracker.
+// clone deep-copies the entry so callers cannot mutate tracker state. Fields are
+// listed explicitly so a newly added map/slice/pointer can't be silently shared.
 func (e *seenEntry) clone() *seenEntry {
 	cp := &seenEntry{
 		txKey:     e.txKey,
@@ -195,9 +193,11 @@ func (e *seenEntry) clone() *seenEntry {
 		requested: e.requested,
 		lastPeer:  e.lastPeer,
 	}
+
 	for peer := range e.peers {
 		cp.peers[peer] = struct{}{}
 	}
+
 	if e.futureTxInfo != nil {
 		cp.futureTxInfo = &futureTxInfo{
 			signerKey: e.futureTxInfo.signerKey,
@@ -205,6 +205,7 @@ func (e *seenEntry) clone() *seenEntry {
 			sequence:  e.futureTxInfo.sequence,
 		}
 	}
+
 	return cp
 }
 
@@ -215,10 +216,12 @@ func (e *seenEntry) peerIDs() []uint16 {
 	if len(e.peers) == 0 {
 		return nil
 	}
+
 	out := make([]uint16, 0, len(e.peers))
 	for peer := range e.peers {
 		out = append(out, peer)
 	}
+
 	return out
 }
 
@@ -285,17 +288,21 @@ func (s *SeenTracker) Add(txKey types.TxKey, peer uint16, signer []byte, sequenc
 	return true
 }
 
-// addPeerToEntryLocked adds another peer to an existing tx without letting that
-// peer exceed its own admission limit.
+// addPeerToEntryLocked attaches peer to an already-tracked tx. It returns false
+// if peer is at perPeerLimit. Re-adding a peer already on the entry always
+// succeeds and does not count against the limit.
 func (s *SeenTracker) addPeerToEntryLocked(entry *seenEntry, peer uint16) bool {
 	if _, has := entry.peers[peer]; has {
 		return true
 	}
+
 	if s.txCountByPeer[peer] >= s.perPeerLimit {
 		return false
 	}
+
 	entry.peers[peer] = struct{}{}
 	s.txCountByPeer[peer]++
+
 	return true
 }
 
@@ -339,10 +346,12 @@ func (s *SeenTracker) indexFutureTxLocked(entry *seenEntry, signer []byte, seque
 func (s *SeenTracker) ClearSequence(txKey types.TxKey) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	entry, ok := s.txByKey[txKey]
 	if !ok || entry.futureTxInfo == nil {
 		return
 	}
+
 	s.removeFromFutureQueueLocked(entry)
 	entry.clearFutureMetadata()
 }
@@ -351,10 +360,12 @@ func (s *SeenTracker) ClearSequence(txKey types.TxKey) {
 func (s *SeenTracker) RemoveKey(txKey types.TxKey) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	entry, ok := s.txByKey[txKey]
 	if !ok {
 		return
 	}
+
 	s.removeEntryLocked(entry)
 }
 
@@ -363,9 +374,11 @@ func (s *SeenTracker) removeEntryLocked(entry *seenEntry) {
 	if entry.futureTxInfo != nil {
 		s.removeFromFutureQueueLocked(entry)
 	}
+
 	for peer := range entry.peers {
 		s.decrementPeerTxCountLocked(peer)
 	}
+
 	delete(s.txByKey, entry.txKey)
 }
 
@@ -374,12 +387,14 @@ func (s *SeenTracker) removeEntryLocked(entry *seenEntry) {
 func (s *SeenTracker) removeFromFutureQueueLocked(entry *seenEntry) {
 	signerKey := entry.futureTxInfo.signerKey
 	queue := s.futureTxsBySigner[signerKey]
+
 	for i, candidate := range queue {
 		if candidate == entry {
 			queue = append(queue[:i], queue[i+1:]...)
 			break
 		}
 	}
+
 	if len(queue) == 0 {
 		delete(s.futureTxsBySigner, signerKey)
 		return
@@ -396,6 +411,7 @@ func (s *SeenTracker) RemovePeer(peer uint16) {
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	for _, entry := range s.txByKey {
 		if _, has := entry.peers[peer]; has {
 			delete(entry.peers, peer)
@@ -416,6 +432,7 @@ func (s *SeenTracker) RemovePeer(peer uint16) {
 func (s *SeenTracker) Prune(cutoff time.Time) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	for _, entry := range s.txByKey {
 		if entry.addedAt.Before(cutoff) {
 			s.removeEntryLocked(entry)
@@ -427,11 +444,14 @@ func (s *SeenTracker) Prune(cutoff time.Time) {
 func (s *SeenTracker) Has(txKey types.TxKey, peer uint16) bool {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	entry, ok := s.txByKey[txKey]
 	if !ok {
 		return false
 	}
+
 	_, has := entry.peers[peer]
+
 	return has
 }
 
@@ -439,27 +459,28 @@ func (s *SeenTracker) Has(txKey types.TxKey, peer uint16) bool {
 func (s *SeenTracker) Get(txKey types.TxKey) *seenEntry {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	entry, ok := s.txByKey[txKey]
 	if !ok {
 		return nil
 	}
+
 	return entry.clone()
 }
 
-// Pending returns a copy of the future-sequence metadata for txKey, or nil if
-// the tx is not currently queued for future gap-fill.
-func (s *SeenTracker) Pending(txKey types.TxKey) *futureTxInfo {
+// PendingSequence reports the signer/sequence under which txKey is queued for
+// future gap-fill; ok is false if it is unknown or tracked only by peer. The
+// returned signer is a copy.
+func (s *SeenTracker) PendingSequence(txKey types.TxKey) (signer []byte, sequence uint64, ok bool) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	entry, ok := s.txByKey[txKey]
-	if !ok || entry.futureTxInfo == nil {
-		return nil
+
+	entry, found := s.txByKey[txKey]
+	if !found || entry.futureTxInfo == nil {
+		return nil, 0, false
 	}
-	return &futureTxInfo{
-		signerKey: entry.futureTxInfo.signerKey,
-		signer:    append([]byte(nil), entry.futureTxInfo.signer...),
-		sequence:  entry.futureTxInfo.sequence,
-	}
+
+	return append([]byte(nil), entry.futureTxInfo.signer...), entry.futureTxInfo.sequence, true
 }
 
 // PrunePending drops future-sequence metadata for entries added before cutoff
@@ -467,6 +488,7 @@ func (s *SeenTracker) Pending(txKey types.TxKey) *futureTxInfo {
 func (s *SeenTracker) PrunePending(cutoff time.Time) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	for _, entry := range s.txByKey {
 		if entry.futureTxInfo == nil || !entry.addedAt.Before(cutoff) {
 			continue
@@ -480,14 +502,17 @@ func (s *SeenTracker) PrunePending(cutoff time.Time) {
 func (s *SeenTracker) Peers(txKey types.TxKey) map[uint16]struct{} {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	entry, ok := s.txByKey[txKey]
 	if !ok {
 		return nil
 	}
+
 	out := make(map[uint16]struct{}, len(entry.peers))
 	for peer := range entry.peers {
 		out[peer] = struct{}{}
 	}
+
 	return out
 }
 
@@ -495,6 +520,7 @@ func (s *SeenTracker) Peers(txKey types.TxKey) map[uint16]struct{} {
 func (s *SeenTracker) Len() int {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	return len(s.txByKey)
 }
 
@@ -502,6 +528,7 @@ func (s *SeenTracker) Len() int {
 func (s *SeenTracker) Reset() {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	s.txByKey = make(map[types.TxKey]*seenEntry)
 	s.futureTxsBySigner = make(map[string][]*seenEntry)
 	s.txCountByPeer = make(map[uint16]int)
@@ -512,16 +539,20 @@ func (s *SeenTracker) PendingForSigner(signer []byte) []*seenEntry {
 	if len(signer) == 0 {
 		return nil
 	}
+
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	queue := s.futureTxsBySigner[string(signer)]
 	if len(queue) == 0 {
 		return nil
 	}
+
 	out := make([]*seenEntry, len(queue))
 	for i, entry := range queue {
 		out[i] = entry.clone()
 	}
+
 	return out
 }
 
@@ -529,13 +560,16 @@ func (s *SeenTracker) PendingForSigner(signer []byte) []*seenEntry {
 func (s *SeenTracker) SignersWithPending() [][]byte {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	if len(s.futureTxsBySigner) == 0 {
 		return nil
 	}
+
 	out := make([][]byte, 0, len(s.futureTxsBySigner))
 	for signerKey := range s.futureTxsBySigner {
 		out = append(out, []byte(signerKey))
 	}
+
 	return out
 }
 
@@ -544,12 +578,15 @@ func (s *SeenTracker) MarkRequested(txKey types.TxKey, peer uint16) {
 	if peer == 0 {
 		return
 	}
+
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	entry, ok := s.txByKey[txKey]
 	if !ok {
 		return
 	}
+
 	entry.requested = true
 	entry.lastPeer = peer
 }
@@ -560,16 +597,20 @@ func (s *SeenTracker) MarkRequestFailed(txKey types.TxKey, peer uint16) {
 	if peer == 0 {
 		return
 	}
+
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
 	entry, ok := s.txByKey[txKey]
 	if !ok {
 		return
 	}
+
 	if entry.lastPeer == peer {
 		entry.requested = false
 		entry.lastPeer = 0
 	}
+
 	if _, has := entry.peers[peer]; has {
 		delete(entry.peers, peer)
 		s.decrementPeerTxCountLocked(peer)

--- a/mempool/cat/cache.go
+++ b/mempool/cat/cache.go
@@ -183,10 +183,18 @@ func (e *seenEntry) clearFutureMetadata() {
 	e.lastPeer = 0
 }
 
-// clone copies mutable fields so callers cannot mutate tracker state.
+// clone copies every field explicitly so callers cannot mutate tracker state.
+// Fields are listed by hand (rather than `cp := *e`) so that adding a new
+// map/slice/pointer field forces a deliberate decision here instead of silently
+// sharing it between the clone and the tracker.
 func (e *seenEntry) clone() *seenEntry {
-	cp := *e
-	cp.peers = make(map[uint16]struct{}, len(e.peers))
+	cp := &seenEntry{
+		txKey:     e.txKey,
+		peers:     make(map[uint16]struct{}, len(e.peers)),
+		addedAt:   e.addedAt,
+		requested: e.requested,
+		lastPeer:  e.lastPeer,
+	}
 	for peer := range e.peers {
 		cp.peers[peer] = struct{}{}
 	}
@@ -197,7 +205,7 @@ func (e *seenEntry) clone() *seenEntry {
 			sequence:  e.futureTxInfo.sequence,
 		}
 	}
-	return &cp
+	return cp
 }
 
 // peerIDs returns candidate peers for the request path.

--- a/mempool/cat/cache_test.go
+++ b/mempool/cat/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-clock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cometbft/cometbft/types"
@@ -222,7 +223,6 @@ func TestSeenTrackerLimits(t *testing.T) {
 func TestSeenTrackerRemovePeerAndPrune(t *testing.T) {
 	var (
 		baseTime        = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
-		now             = baseTime
 		signer          = []byte("signer")
 		oldKey          = types.Tx("old").Key()
 		freshKey        = types.Tx("fresh").Key()
@@ -230,8 +230,10 @@ func TestSeenTrackerRemovePeerAndPrune(t *testing.T) {
 		peer2    uint16 = 2
 	)
 
+	mockClock := clock.NewMock()
+	mockClock.Set(baseTime)
 	tracker := NewSeenTracker()
-	tracker.now = func() time.Time { return now }
+	tracker.clock = mockClock
 
 	tracker.Add(oldKey, peer1, signer, 1)
 	tracker.Add(oldKey, peer2, nil, 0)
@@ -248,7 +250,7 @@ func TestSeenTrackerRemovePeerAndPrune(t *testing.T) {
 	require.Equal(t, 1, tracker.txCountByPeer[peer2])
 	require.NotNil(t, tracker.PendingForSigner(signer))
 
-	now = baseTime.Add(3 * time.Minute)
+	mockClock.Set(baseTime.Add(3 * time.Minute))
 	tracker.Add(freshKey, peer2, nil, 0)
 	tracker.Prune(baseTime.Add(time.Minute))
 
@@ -266,19 +268,20 @@ func TestSeenTrackerRemovePeerAndPrune(t *testing.T) {
 func TestSeenTrackerPrunesPendingWithoutDroppingPeerCache(t *testing.T) {
 	var (
 		baseTime        = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
-		now             = baseTime
 		txKey           = types.Tx("pending-prune").Key()
 		signer          = []byte("signer")
 		peer     uint16 = 1
 	)
 
+	mockClock := clock.NewMock()
+	mockClock.Set(baseTime)
 	tracker := NewSeenTracker()
-	tracker.now = func() time.Time { return now }
+	tracker.clock = mockClock
 
 	require.True(t, tracker.Add(txKey, peer, signer, 1))
 	require.NotNil(t, tracker.Pending(txKey))
 
-	now = baseTime.Add(3 * time.Minute)
+	mockClock.Set(baseTime.Add(3 * time.Minute))
 	tracker.PrunePending(baseTime.Add(time.Minute))
 
 	require.Nil(t, tracker.Pending(txKey))

--- a/mempool/cat/cache_test.go
+++ b/mempool/cat/cache_test.go
@@ -3,6 +3,7 @@ package cat
 import (
 	"encoding/binary"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -59,4 +60,247 @@ func TestSeenTxSetMaxSize(t *testing.T) {
 	seenSet.Add(extraKey, 2)
 	require.True(t, seenSet.Has(extraKey, 2))
 	require.Equal(t, maxSeenTxSetSize, seenSet.Len())
+}
+
+func TestSeenTrackerTracksPeersByTx(t *testing.T) {
+	var (
+		txKey        = types.Tx("tx1").Key()
+		peer1 uint16 = 1
+		peer2 uint16 = 2
+	)
+
+	tracker := NewSeenTracker()
+	require.Nil(t, tracker.Peers(txKey))
+
+	require.False(t, tracker.Add(txKey, 0, nil, 0))
+	require.True(t, tracker.Add(txKey, peer1, nil, 0))
+	require.True(t, tracker.Add(txKey, peer1, nil, 0))
+	require.True(t, tracker.Add(txKey, peer2, nil, 0))
+
+	require.Equal(t, 1, tracker.Len())
+	require.True(t, tracker.Has(txKey, peer1))
+	require.True(t, tracker.Has(txKey, peer2))
+	require.Equal(t, map[uint16]struct{}{peer1: {}, peer2: {}}, tracker.Peers(txKey))
+
+	entry := tracker.Get(txKey)
+	require.NotNil(t, entry)
+	require.Nil(t, entry.futureTxInfo)
+
+	delete(entry.peers, peer1)
+	require.True(t, tracker.Has(txKey, peer1), "Get should return a copy")
+
+	peers := tracker.Peers(txKey)
+	delete(peers, peer2)
+	require.True(t, tracker.Has(txKey, peer2), "Peers should return a copy")
+
+	tracker.RemoveKey(txKey)
+	require.Equal(t, 0, tracker.Len())
+	require.Nil(t, tracker.Peers(txKey))
+	require.Empty(t, tracker.txCountByPeer)
+}
+
+func TestSeenTrackerIndexesFutureTxsBySigner(t *testing.T) {
+	var (
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+		peer2  uint16 = 2
+	)
+
+	tracker := NewSeenTracker()
+	keySeq2 := types.Tx("seq2").Key()
+	keySeq0 := types.Tx("seq0").Key()
+	keySeq1 := types.Tx("seq1").Key()
+
+	tracker.Add(keySeq2, peer1, signer, 2)
+	tracker.Add(keySeq0, peer1, signer, 0)
+	tracker.Add(keySeq1, peer2, signer, 1)
+
+	entries := tracker.PendingForSigner(signer)
+	require.Len(t, entries, 3)
+	require.Equal(t, []uint64{0, 1, 2}, seenTrackerSequences(entries))
+	require.Equal(t, []types.TxKey{keySeq0, keySeq1, keySeq2}, seenTrackerKeys(entries))
+
+	firstEntry := tracker.Get(keySeq0)
+	require.NotNil(t, firstEntry)
+	require.NotNil(t, firstEntry.futureTxInfo)
+	require.Equal(t, signer, firstEntry.futureTxInfo.signer)
+	require.Equal(t, uint64(0), firstEntry.futureTxInfo.sequence)
+
+	signers := tracker.SignersWithPending()
+	require.Len(t, signers, 1)
+	require.Equal(t, signer, signers[0])
+}
+
+func TestSeenTrackerUpgradesPeerOnlyEntryWithSignerSequence(t *testing.T) {
+	var (
+		txKey         = types.Tx("upgrade").Key()
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+		peer2  uint16 = 2
+	)
+
+	tracker := NewSeenTracker()
+	tracker.Add(txKey, peer1, nil, 0)
+	require.Nil(t, tracker.PendingForSigner(signer))
+
+	tracker.Add(txKey, peer2, signer, 0)
+
+	entry := tracker.Get(txKey)
+	require.NotNil(t, entry)
+	require.Equal(t, map[uint16]struct{}{peer1: {}, peer2: {}}, tracker.Peers(txKey))
+
+	require.NotNil(t, entry.futureTxInfo)
+	require.Equal(t, signer, entry.futureTxInfo.signer)
+	require.Equal(t, uint64(0), entry.futureTxInfo.sequence)
+
+	entries := tracker.PendingForSigner(signer)
+	require.Len(t, entries, 1)
+	require.Equal(t, txKey, entries[0].txKey)
+}
+
+func TestSeenTrackerClearSequenceKeepsPeerCache(t *testing.T) {
+	var (
+		txKey         = types.Tx("future").Key()
+		signer        = []byte("signer")
+		peer   uint16 = 1
+	)
+
+	tracker := NewSeenTracker()
+	tracker.Add(txKey, peer, signer, 5)
+
+	tracker.ClearSequence(txKey)
+
+	entry := tracker.Get(txKey)
+	require.NotNil(t, entry)
+	require.Nil(t, entry.futureTxInfo)
+	require.True(t, tracker.Has(txKey, peer))
+	require.Nil(t, tracker.PendingForSigner(signer))
+}
+
+func TestSeenTrackerLimits(t *testing.T) {
+	var (
+		signer        = []byte("signer")
+		peer   uint16 = 1
+	)
+
+	tracker := NewSeenTracker()
+	tracker.perPeerLimit = 2
+
+	key1 := types.Tx("peer-limit-1").Key()
+	key2 := types.Tx("peer-limit-2").Key()
+	key3 := types.Tx("peer-limit-3").Key()
+	require.True(t, tracker.Add(key1, peer, nil, 0))
+	require.True(t, tracker.Add(key2, peer, nil, 0))
+	require.False(t, tracker.Add(key3, peer, nil, 0))
+
+	require.Equal(t, 2, tracker.Len())
+	require.True(t, tracker.Has(key1, peer))
+	require.True(t, tracker.Has(key2, peer))
+	require.False(t, tracker.Has(key3, peer))
+	require.Equal(t, 2, tracker.txCountByPeer[peer])
+
+	tracker = NewSeenTracker()
+	tracker.perSignerLimit = 2
+
+	keySeq5 := types.Tx("signer-limit-5").Key()
+	keySeq7 := types.Tx("signer-limit-7").Key()
+	keySeq6 := types.Tx("signer-limit-6").Key()
+	tracker.Add(keySeq5, peer, signer, 5)
+	tracker.Add(keySeq7, peer, signer, 7)
+	tracker.Add(keySeq6, peer, signer, 6)
+
+	entries := tracker.PendingForSigner(signer)
+	require.Len(t, entries, 2)
+	require.Equal(t, []uint64{5, 6}, seenTrackerSequences(entries))
+
+	demoted := tracker.Get(keySeq7)
+	require.NotNil(t, demoted)
+	require.Nil(t, demoted.futureTxInfo)
+	require.True(t, tracker.Has(keySeq7, peer))
+}
+
+func TestSeenTrackerRemovePeerAndPrune(t *testing.T) {
+	var (
+		baseTime        = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+		now             = baseTime
+		signer          = []byte("signer")
+		oldKey          = types.Tx("old").Key()
+		freshKey        = types.Tx("fresh").Key()
+		peer1    uint16 = 1
+		peer2    uint16 = 2
+	)
+
+	tracker := NewSeenTracker()
+	tracker.now = func() time.Time { return now }
+
+	tracker.Add(oldKey, peer1, signer, 1)
+	tracker.Add(oldKey, peer2, nil, 0)
+	tracker.MarkRequested(oldKey, peer1)
+
+	tracker.RemovePeer(peer1)
+
+	entry := tracker.Get(oldKey)
+	require.NotNil(t, entry)
+	require.False(t, entry.requested)
+	require.Equal(t, uint16(0), entry.lastPeer)
+	require.False(t, tracker.Has(oldKey, peer1))
+	require.True(t, tracker.Has(oldKey, peer2))
+	require.Equal(t, 1, tracker.txCountByPeer[peer2])
+	require.NotNil(t, tracker.PendingForSigner(signer))
+
+	now = baseTime.Add(3 * time.Minute)
+	tracker.Add(freshKey, peer2, nil, 0)
+	tracker.Prune(baseTime.Add(time.Minute))
+
+	require.Nil(t, tracker.Get(oldKey))
+	require.NotNil(t, tracker.Get(freshKey))
+	require.Nil(t, tracker.PendingForSigner(signer))
+	require.Equal(t, 1, tracker.txCountByPeer[peer2])
+
+	tracker.MarkRequested(freshKey, peer2)
+	tracker.MarkRequestFailed(freshKey, peer2)
+	require.Equal(t, 0, tracker.Len())
+	require.Empty(t, tracker.txCountByPeer)
+}
+
+func TestSeenTrackerPrunesPendingWithoutDroppingPeerCache(t *testing.T) {
+	var (
+		baseTime        = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+		now             = baseTime
+		txKey           = types.Tx("pending-prune").Key()
+		signer          = []byte("signer")
+		peer     uint16 = 1
+	)
+
+	tracker := NewSeenTracker()
+	tracker.now = func() time.Time { return now }
+
+	require.True(t, tracker.Add(txKey, peer, signer, 1))
+	require.NotNil(t, tracker.Pending(txKey))
+
+	now = baseTime.Add(3 * time.Minute)
+	tracker.PrunePending(baseTime.Add(time.Minute))
+
+	require.Nil(t, tracker.Pending(txKey))
+	require.True(t, tracker.Has(txKey, peer))
+	entry := tracker.Get(txKey)
+	require.NotNil(t, entry)
+	require.Nil(t, entry.futureTxInfo)
+	require.Nil(t, tracker.PendingForSigner(signer))
+}
+
+func seenTrackerSequences(entries []*seenEntry) []uint64 {
+	out := make([]uint64, len(entries))
+	for i, entry := range entries {
+		out[i] = entry.futureTxInfo.sequence
+	}
+	return out
+}
+
+func seenTrackerKeys(entries []*seenEntry) []types.TxKey {
+	out := make([]types.TxKey, len(entries))
+	for i, entry := range entries {
+		out[i] = entry.txKey
+	}
+	return out
 }

--- a/mempool/cat/cache_test.go
+++ b/mempool/cat/cache_test.go
@@ -2,6 +2,7 @@ package cat
 
 import (
 	"encoding/binary"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,10 +41,15 @@ func TestSeenTxSet(t *testing.T) {
 }
 
 func TestSeenTxSetMaxSize(t *testing.T) {
+	// Filling the map to maxSeenTxSetSize (10M entries) takes seconds; skip under -short.
+	if testing.Short() {
+		t.Skip("allocates maxSeenTxSetSize entries")
+	}
+
 	seenSet := NewSeenTxSet()
 
 	// Pre-fill the map to exactly maxSeenTxSetSize by inserting dummy entries directly.
-	for i := 0; i < maxSeenTxSetSize; i++ {
+	for i := range maxSeenTxSetSize {
 		var key types.TxKey
 		binary.BigEndian.PutUint64(key[:8], uint64(i))
 		seenSet.set[key] = timestampedPeerSet{peers: map[uint16]struct{}{1: {}}}
@@ -63,233 +69,653 @@ func TestSeenTxSetMaxSize(t *testing.T) {
 	require.Equal(t, maxSeenTxSetSize, seenSet.Len())
 }
 
-func TestSeenTrackerTracksPeersByTx(t *testing.T) {
+func TestNewSeenTracker(t *testing.T) {
+	tracker := NewSeenTracker()
+	require.Equal(t, seenPerPeerLimit, tracker.perPeerLimit)
+	require.Equal(t, seenPerSignerLimit, tracker.perSignerLimit)
+	require.NotNil(t, tracker.clock)
+	require.Equal(t, 0, tracker.Len())
+}
+
+func TestSeenTrackerAdd(t *testing.T) {
 	var (
-		txKey        = types.Tx("tx1").Key()
+		txKey        = types.Tx("tx").Key()
 		peer1 uint16 = 1
 		peer2 uint16 = 2
 	)
 
+	t.Run("peer 0 rejected", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.False(t, tracker.Add(txKey, 0, nil, 0))
+		require.Equal(t, 0, tracker.Len())
+	})
+
+	t.Run("new tx is indexed", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.True(t, tracker.Has(txKey, peer1))
+		require.Equal(t, 1, tracker.Len())
+		require.Equal(t, 1, tracker.txCountByPeer[peer1])
+	})
+
+	t.Run("duplicate entry, should be idempotent", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.Equal(t, 1, tracker.Len())
+		require.Equal(t, 1, tracker.txCountByPeer[peer1])
+	})
+
+	t.Run("two peers", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.True(t, tracker.Add(txKey, peer2, nil, 0))
+		require.Equal(t, 1, tracker.Len())
+		require.Equal(t, map[uint16]struct{}{peer1: {}, peer2: {}}, tracker.Peers(txKey))
+	})
+
+	t.Run("per-peer limit on new tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.perPeerLimit = 1
+		require.True(t, tracker.Add(types.Tx("a").Key(), peer1, nil, 0))
+		require.False(t, tracker.Add(types.Tx("b").Key(), peer1, nil, 0))
+		require.Equal(t, 1, tracker.Len())
+	})
+
+	t.Run("per-peer limit joining existing tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.perPeerLimit = 1
+		shared := types.Tx("shared").Key()
+		require.True(t, tracker.Add(types.Tx("a").Key(), peer1, nil, 0)) // peer1 now at limit
+		require.True(t, tracker.Add(shared, peer2, nil, 0))
+		require.False(t, tracker.Add(shared, peer1, nil, 0)) // peer1 cannot join
+		require.False(t, tracker.Has(shared, peer1))
+	})
+}
+
+func TestSeenTrackerHas(t *testing.T) {
+	var (
+		txKey        = types.Tx("tx").Key()
+		peer1 uint16 = 1
+		peer2 uint16 = 2
+	)
+
+	t.Run("unknown tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.False(t, tracker.Has(txKey, peer1))
+	})
+
+	t.Run("known peer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.True(t, tracker.Has(txKey, peer1))
+	})
+
+	t.Run("unknown peer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.False(t, tracker.Has(txKey, peer2))
+	})
+}
+
+func TestSeenTrackerGet(t *testing.T) {
+	var (
+		txKey         = types.Tx("tx").Key()
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+	)
+
+	t.Run("unknown tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.Nil(t, tracker.Get(txKey))
+	})
+
+	t.Run("returns a copy", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, signer, 3))
+
+		entry := tracker.Get(txKey)
+		require.NotNil(t, entry)
+		require.Equal(t, txKey, entry.txKey)
+
+		// Mutating the returned entry must not affect tracker state.
+		delete(entry.peers, peer1)
+		entry.futureTxInfo.sequence = 99
+		require.True(t, tracker.Has(txKey, peer1))
+		_, seq, ok := tracker.PendingSequence(txKey)
+		require.True(t, ok)
+		require.Equal(t, uint64(3), seq)
+	})
+}
+
+func TestSeenTrackerPeers(t *testing.T) {
+	var (
+		txKey        = types.Tx("tx").Key()
+		peer1 uint16 = 1
+	)
+
+	t.Run("unknown tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.Nil(t, tracker.Peers(txKey))
+	})
+
+	t.Run("returns a copy", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+
+		peers := tracker.Peers(txKey)
+		delete(peers, peer1)
+		require.True(t, tracker.Has(txKey, peer1))
+	})
+}
+
+func TestSeenTrackerLen(t *testing.T) {
+	var peer1 uint16 = 1
+
 	tracker := NewSeenTracker()
-	require.Nil(t, tracker.Peers(txKey))
-
-	require.False(t, tracker.Add(txKey, 0, nil, 0))
-	require.True(t, tracker.Add(txKey, peer1, nil, 0))
-	require.True(t, tracker.Add(txKey, peer1, nil, 0))
-	require.True(t, tracker.Add(txKey, peer2, nil, 0))
-
-	require.Equal(t, 1, tracker.Len())
-	require.True(t, tracker.Has(txKey, peer1))
-	require.True(t, tracker.Has(txKey, peer2))
-	require.Equal(t, map[uint16]struct{}{peer1: {}, peer2: {}}, tracker.Peers(txKey))
-
-	entry := tracker.Get(txKey)
-	require.NotNil(t, entry)
-	require.Nil(t, entry.futureTxInfo)
-
-	delete(entry.peers, peer1)
-	require.True(t, tracker.Has(txKey, peer1), "Get should return a copy")
-
-	peers := tracker.Peers(txKey)
-	delete(peers, peer2)
-	require.True(t, tracker.Has(txKey, peer2), "Peers should return a copy")
-
-	tracker.RemoveKey(txKey)
 	require.Equal(t, 0, tracker.Len())
-	require.Nil(t, tracker.Peers(txKey))
-	require.Empty(t, tracker.txCountByPeer)
-}
-
-func TestSeenTrackerIndexesFutureTxsBySigner(t *testing.T) {
-	var (
-		signer        = []byte("signer")
-		peer1  uint16 = 1
-		peer2  uint16 = 2
-	)
-
-	tracker := NewSeenTracker()
-	keySeq2 := types.Tx("seq2").Key()
-	keySeq0 := types.Tx("seq0").Key()
-	keySeq1 := types.Tx("seq1").Key()
-
-	tracker.Add(keySeq2, peer1, signer, 2)
-	tracker.Add(keySeq0, peer1, signer, 0)
-	tracker.Add(keySeq1, peer2, signer, 1)
-
-	entries := tracker.PendingForSigner(signer)
-	require.Len(t, entries, 3)
-	require.Equal(t, []uint64{0, 1, 2}, seenTrackerSequences(entries))
-	require.Equal(t, []types.TxKey{keySeq0, keySeq1, keySeq2}, seenTrackerKeys(entries))
-
-	firstEntry := tracker.Get(keySeq0)
-	require.NotNil(t, firstEntry)
-	require.NotNil(t, firstEntry.futureTxInfo)
-	require.Equal(t, signer, firstEntry.futureTxInfo.signer)
-	require.Equal(t, uint64(0), firstEntry.futureTxInfo.sequence)
-
-	signers := tracker.SignersWithPending()
-	require.Len(t, signers, 1)
-	require.Equal(t, signer, signers[0])
-}
-
-func TestSeenTrackerUpgradesPeerOnlyEntryWithSignerSequence(t *testing.T) {
-	var (
-		txKey         = types.Tx("upgrade").Key()
-		signer        = []byte("signer")
-		peer1  uint16 = 1
-		peer2  uint16 = 2
-	)
-
-	tracker := NewSeenTracker()
-	tracker.Add(txKey, peer1, nil, 0)
-	require.Nil(t, tracker.PendingForSigner(signer))
-
-	tracker.Add(txKey, peer2, signer, 0)
-
-	entry := tracker.Get(txKey)
-	require.NotNil(t, entry)
-	require.Equal(t, map[uint16]struct{}{peer1: {}, peer2: {}}, tracker.Peers(txKey))
-
-	require.NotNil(t, entry.futureTxInfo)
-	require.Equal(t, signer, entry.futureTxInfo.signer)
-	require.Equal(t, uint64(0), entry.futureTxInfo.sequence)
-
-	entries := tracker.PendingForSigner(signer)
-	require.Len(t, entries, 1)
-	require.Equal(t, txKey, entries[0].txKey)
-}
-
-func TestSeenTrackerClearSequenceKeepsPeerCache(t *testing.T) {
-	var (
-		txKey         = types.Tx("future").Key()
-		signer        = []byte("signer")
-		peer   uint16 = 1
-	)
-
-	tracker := NewSeenTracker()
-	tracker.Add(txKey, peer, signer, 5)
-
-	tracker.ClearSequence(txKey)
-
-	entry := tracker.Get(txKey)
-	require.NotNil(t, entry)
-	require.Nil(t, entry.futureTxInfo)
-	require.True(t, tracker.Has(txKey, peer))
-	require.Nil(t, tracker.PendingForSigner(signer))
-}
-
-func TestSeenTrackerLimits(t *testing.T) {
-	var (
-		signer        = []byte("signer")
-		peer   uint16 = 1
-	)
-
-	tracker := NewSeenTracker()
-	tracker.perPeerLimit = 2
-
-	key1 := types.Tx("peer-limit-1").Key()
-	key2 := types.Tx("peer-limit-2").Key()
-	key3 := types.Tx("peer-limit-3").Key()
-	require.True(t, tracker.Add(key1, peer, nil, 0))
-	require.True(t, tracker.Add(key2, peer, nil, 0))
-	require.False(t, tracker.Add(key3, peer, nil, 0))
-
+	require.True(t, tracker.Add(types.Tx("a").Key(), peer1, nil, 0))
+	require.True(t, tracker.Add(types.Tx("b").Key(), peer1, nil, 0))
 	require.Equal(t, 2, tracker.Len())
-	require.True(t, tracker.Has(key1, peer))
-	require.True(t, tracker.Has(key2, peer))
-	require.False(t, tracker.Has(key3, peer))
-	require.Equal(t, 2, tracker.txCountByPeer[peer])
-
-	tracker = NewSeenTracker()
-	tracker.perSignerLimit = 2
-
-	keySeq5 := types.Tx("signer-limit-5").Key()
-	keySeq7 := types.Tx("signer-limit-7").Key()
-	keySeq6 := types.Tx("signer-limit-6").Key()
-	tracker.Add(keySeq5, peer, signer, 5)
-	tracker.Add(keySeq7, peer, signer, 7)
-	tracker.Add(keySeq6, peer, signer, 6)
-
-	entries := tracker.PendingForSigner(signer)
-	require.Len(t, entries, 2)
-	require.Equal(t, []uint64{5, 6}, seenTrackerSequences(entries))
-
-	demoted := tracker.Get(keySeq7)
-	require.NotNil(t, demoted)
-	require.Nil(t, demoted.futureTxInfo)
-	require.True(t, tracker.Has(keySeq7, peer))
 }
 
-func TestSeenTrackerRemovePeerAndPrune(t *testing.T) {
+func TestSeenTrackerReset(t *testing.T) {
+	var peer1 uint16 = 1
+
+	tracker := NewSeenTracker()
+	require.True(t, tracker.Add(types.Tx("a").Key(), peer1, []byte("signer"), 1))
+
+	tracker.Reset()
+	require.Equal(t, 0, tracker.Len())
+	require.Empty(t, tracker.txCountByPeer)
+	require.Nil(t, tracker.SignersWithPending())
+}
+
+func TestSeenTrackerRemoveKey(t *testing.T) {
+	var (
+		txKey         = types.Tx("tx").Key()
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+	)
+
+	t.Run("unknown tx is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.RemoveKey(txKey) // must not panic
+		require.Equal(t, 0, tracker.Len())
+	})
+
+	t.Run("clears every index", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, signer, 1))
+
+		tracker.RemoveKey(txKey)
+		require.Equal(t, 0, tracker.Len())
+		require.Nil(t, tracker.Peers(txKey))
+		require.Empty(t, tracker.txCountByPeer)
+		require.Nil(t, tracker.PendingForSigner(signer))
+	})
+}
+
+func TestSeenTrackerRemovePeer(t *testing.T) {
+	var (
+		txKey        = types.Tx("tx").Key()
+		peer1 uint16 = 1
+		peer2 uint16 = 2
+	)
+
+	t.Run("peer 0 is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		tracker.RemovePeer(0)
+		require.True(t, tracker.Has(txKey, peer1))
+	})
+
+	t.Run("entry survives while another peer remains", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.True(t, tracker.Add(txKey, peer2, nil, 0))
+
+		tracker.RemovePeer(peer1)
+		require.False(t, tracker.Has(txKey, peer1))
+		require.True(t, tracker.Has(txKey, peer2))
+		require.Equal(t, 1, tracker.Len())
+		require.Zero(t, tracker.txCountByPeer[peer1])
+	})
+
+	t.Run("entry removed with last peer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+
+		tracker.RemovePeer(peer1)
+		require.Equal(t, 0, tracker.Len())
+		require.Empty(t, tracker.txCountByPeer)
+	})
+
+	t.Run("clears in-flight request from that peer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.True(t, tracker.Add(txKey, peer2, nil, 0))
+		tracker.MarkRequested(txKey, peer1)
+
+		tracker.RemovePeer(peer1)
+		entry := tracker.Get(txKey)
+		require.NotNil(t, entry)
+		require.False(t, entry.requested)
+		require.Equal(t, uint16(0), entry.lastPeer)
+	})
+}
+
+func TestSeenTrackerPrune(t *testing.T) {
 	var (
 		baseTime        = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
-		signer          = []byte("signer")
 		oldKey          = types.Tx("old").Key()
 		freshKey        = types.Tx("fresh").Key()
 		peer1    uint16 = 1
-		peer2    uint16 = 2
 	)
 
-	mockClock := clock.NewMock()
-	mockClock.Set(baseTime)
-	tracker := NewSeenTracker()
-	tracker.clock = mockClock
-
-	tracker.Add(oldKey, peer1, signer, 1)
-	tracker.Add(oldKey, peer2, nil, 0)
-	tracker.MarkRequested(oldKey, peer1)
-
-	tracker.RemovePeer(peer1)
-
-	entry := tracker.Get(oldKey)
-	require.NotNil(t, entry)
-	require.False(t, entry.requested)
-	require.Equal(t, uint16(0), entry.lastPeer)
-	require.False(t, tracker.Has(oldKey, peer1))
-	require.True(t, tracker.Has(oldKey, peer2))
-	require.Equal(t, 1, tracker.txCountByPeer[peer2])
-	require.NotNil(t, tracker.PendingForSigner(signer))
+	tracker, mockClock := newClockTracker(baseTime)
+	require.True(t, tracker.Add(oldKey, peer1, nil, 0))
 
 	mockClock.Set(baseTime.Add(3 * time.Minute))
-	tracker.Add(freshKey, peer2, nil, 0)
+	require.True(t, tracker.Add(freshKey, peer1, nil, 0))
+
 	tracker.Prune(baseTime.Add(time.Minute))
 
 	require.Nil(t, tracker.Get(oldKey))
 	require.NotNil(t, tracker.Get(freshKey))
-	require.Nil(t, tracker.PendingForSigner(signer))
-	require.Equal(t, 1, tracker.txCountByPeer[peer2])
+	require.Equal(t, 1, tracker.txCountByPeer[peer1])
+}
 
-	tracker.MarkRequested(freshKey, peer2)
-	tracker.MarkRequestFailed(freshKey, peer2)
+func TestSeenTrackerMarkRequested(t *testing.T) {
+	var (
+		txKey        = types.Tx("tx").Key()
+		peer1 uint16 = 1
+	)
+
+	t.Run("peer 0 is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		tracker.MarkRequested(txKey, 0)
+		require.False(t, tracker.Get(txKey).requested)
+	})
+
+	t.Run("unknown tx is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.MarkRequested(txKey, peer1) // must not panic
+		require.Nil(t, tracker.Get(txKey))
+	})
+
+	t.Run("records the peer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		tracker.MarkRequested(txKey, peer1)
+
+		entry := tracker.Get(txKey)
+		require.True(t, entry.requested)
+		require.Equal(t, peer1, entry.lastPeer)
+	})
+}
+
+func TestSeenTrackerMarkRequestFailed(t *testing.T) {
+	var (
+		txKey        = types.Tx("tx").Key()
+		peer1 uint16 = 1
+		peer2 uint16 = 2
+	)
+
+	t.Run("peer 0 is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		tracker.MarkRequestFailed(txKey, 0)
+		require.True(t, tracker.Has(txKey, peer1))
+	})
+
+	t.Run("unknown tx is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.MarkRequestFailed(txKey, peer1) // must not panic
+		require.Equal(t, 0, tracker.Len())
+	})
+
+	t.Run("drops the peer and clears its request", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		require.True(t, tracker.Add(txKey, peer2, nil, 0))
+		tracker.MarkRequested(txKey, peer1)
+
+		tracker.MarkRequestFailed(txKey, peer1)
+		entry := tracker.Get(txKey)
+		require.NotNil(t, entry)
+		require.False(t, entry.requested)
+		require.Equal(t, uint16(0), entry.lastPeer)
+		require.False(t, tracker.Has(txKey, peer1))
+		require.True(t, tracker.Has(txKey, peer2))
+	})
+
+	t.Run("removes entry when last peer fails", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+
+		tracker.MarkRequestFailed(txKey, peer1)
+		require.Equal(t, 0, tracker.Len())
+		require.Empty(t, tracker.txCountByPeer)
+	})
+}
+
+func TestSeenTrackerAddIndexesFutureTx(t *testing.T) {
+	var (
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+		peer2  uint16 = 2
+	)
+
+	t.Run("indexes by signer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		txKey := types.Tx("tx").Key()
+		seq := uint64(7)
+		require.True(t, tracker.Add(txKey, peer1, signer, seq))
+
+		gotSigner, gotSeq, ok := tracker.PendingSequence(txKey)
+		require.True(t, ok)
+		require.Equal(t, signer, gotSigner)
+		require.Equal(t, seq, gotSeq)
+	})
+
+	t.Run("sequence 0 is valid", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		txKey := types.Tx("tx").Key()
+		zeroSeq := uint64(0)
+		require.True(t, tracker.Add(txKey, peer1, signer, zeroSeq))
+		_, gotSeq, ok := tracker.PendingSequence(txKey)
+		require.True(t, ok)
+		require.Equal(t, zeroSeq, gotSeq)
+	})
+
+	t.Run("empty signer not indexed", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		txKey := types.Tx("tx").Key()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		_, _, ok := tracker.PendingSequence(txKey)
+		require.False(t, ok)
+		require.Nil(t, tracker.SignersWithPending())
+	})
+
+	t.Run("ordered by sequence", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		keySeq2 := types.Tx("seq2").Key()
+		keySeq0 := types.Tx("seq0").Key()
+		keySeq1 := types.Tx("seq1").Key()
+		require.True(t, tracker.Add(keySeq2, peer1, signer, 2))
+		require.True(t, tracker.Add(keySeq0, peer1, signer, 0))
+		require.True(t, tracker.Add(keySeq1, peer2, signer, 1))
+
+		entries := tracker.PendingForSigner(signer)
+		require.Equal(t, []uint64{0, 1, 2}, seenTrackerSequences(entries))
+		require.Equal(t, []types.TxKey{keySeq0, keySeq1, keySeq2}, seenTrackerKeys(entries))
+	})
+
+	t.Run("add signer and seq to an indexed tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		txKey := types.Tx("tx").Key()
+
+		// First seen without a signer: tracked by peer only, not queued by sequence.
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		_, _, ok := tracker.PendingSequence(txKey)
+		require.False(t, ok)
+
+		// Seen again with a signer: the same tx is now also queued by sequence,
+		// while keeping the peer that was already recorded.
+		require.True(t, tracker.Add(txKey, peer2, signer, 4))
+		_, seq, ok := tracker.PendingSequence(txKey)
+		require.True(t, ok)
+		require.Equal(t, uint64(4), seq)
+		require.Equal(t, map[uint16]struct{}{peer1: {}, peer2: {}}, tracker.Peers(txKey))
+	})
+
+	t.Run("per-signer limit keeps lowest sequences", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.perSignerLimit = 2
+		keySeq5 := types.Tx("seq5").Key()
+		keySeq7 := types.Tx("seq7").Key()
+		keySeq6 := types.Tx("seq6").Key()
+		require.True(t, tracker.Add(keySeq5, peer1, signer, 5))
+		require.True(t, tracker.Add(keySeq7, peer1, signer, 7))
+		require.True(t, tracker.Add(keySeq6, peer1, signer, 6))
+
+		entries := tracker.PendingForSigner(signer)
+		require.Equal(t, []uint64{5, 6}, seenTrackerSequences(entries))
+
+		// The demoted tx survives as peer-only state.
+		demoted := tracker.Get(keySeq7)
+		require.NotNil(t, demoted)
+		require.Nil(t, demoted.futureTxInfo)
+		require.True(t, tracker.Has(keySeq7, peer1))
+	})
+
+	t.Run("per-signer limit rejects higher sequence when full", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.perSignerLimit = 2
+		keySeq5 := types.Tx("seq5").Key()
+		keySeq6 := types.Tx("seq6").Key()
+		keySeq9 := types.Tx("seq9").Key()
+		require.True(t, tracker.Add(keySeq5, peer1, signer, 5))
+		require.True(t, tracker.Add(keySeq6, peer1, signer, 6))
+		// Queue is full with [5,6]; a higher sequence must stay peer-only rather
+		// than displace a lower one.
+		require.True(t, tracker.Add(keySeq9, peer1, signer, 9))
+
+		require.Equal(t, []uint64{5, 6}, seenTrackerSequences(tracker.PendingForSigner(signer)))
+		require.Nil(t, tracker.Get(keySeq9).futureTxInfo)
+		require.True(t, tracker.Has(keySeq9, peer1))
+	})
+
+	t.Run("does not re-index an already-indexed key", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		txKey := types.Tx("tx").Key()
+		signerA := []byte("signer-a")
+		signerB := []byte("signer-b")
+		require.True(t, tracker.Add(txKey, peer1, signerA, 1))
+
+		// Re-adding the same key with a different signer keeps the original
+		// signer/sequence; only the peer is added.
+		require.True(t, tracker.Add(txKey, peer2, signerB, 2))
+
+		gotSigner, seq, ok := tracker.PendingSequence(txKey)
+		require.True(t, ok)
+		require.Equal(t, signerA, gotSigner)
+		require.Equal(t, uint64(1), seq)
+		require.NotNil(t, tracker.PendingForSigner(signerA))
+		require.Nil(t, tracker.PendingForSigner(signerB))
+		require.Equal(t, map[uint16]struct{}{peer1: {}, peer2: {}}, tracker.Peers(txKey))
+	})
+}
+
+func TestSeenTrackerPendingSequence(t *testing.T) {
+	var (
+		txKey         = types.Tx("tx").Key()
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+	)
+
+	t.Run("unknown tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		_, _, ok := tracker.PendingSequence(txKey)
+		require.False(t, ok)
+	})
+
+	t.Run("peer-only tx", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		_, _, ok := tracker.PendingSequence(txKey)
+		require.False(t, ok)
+	})
+
+	t.Run("returns a copy of the signer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, signer, 2))
+
+		gotSigner, _, ok := tracker.PendingSequence(txKey)
+		require.True(t, ok)
+		// Mutating the returned signer must not affect tracker state.
+		gotSigner[0] = 'x'
+		stillSigner, seq, _ := tracker.PendingSequence(txKey)
+		require.Equal(t, signer, stillSigner)
+		require.Equal(t, uint64(2), seq)
+	})
+}
+
+func TestSeenTrackerPendingForSigner(t *testing.T) {
+	var (
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+	)
+
+	t.Run("empty signer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.Nil(t, tracker.PendingForSigner(nil))
+	})
+
+	t.Run("unknown signer", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.Nil(t, tracker.PendingForSigner(signer))
+	})
+
+	t.Run("returns deep copies", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		txKey := types.Tx("tx").Key()
+		require.True(t, tracker.Add(txKey, peer1, signer, 1))
+
+		entries := tracker.PendingForSigner(signer)
+		require.Len(t, entries, 1)
+		delete(entries[0].peers, peer1)
+		require.True(t, tracker.Has(txKey, peer1))
+	})
+}
+
+func TestSeenTrackerSignersWithPending(t *testing.T) {
+	var peer1 uint16 = 1
+
+	t.Run("none", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.Nil(t, tracker.SignersWithPending())
+	})
+
+	t.Run("lists signers", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		signerA := []byte("signer-a")
+		signerB := []byte("signer-b")
+		require.True(t, tracker.Add(types.Tx("a").Key(), peer1, signerA, 0))
+		require.True(t, tracker.Add(types.Tx("b").Key(), peer1, signerB, 0))
+
+		require.ElementsMatch(t, [][]byte{signerA, signerB}, tracker.SignersWithPending())
+	})
+}
+
+func TestSeenTrackerClearSequence(t *testing.T) {
+	var (
+		txKey         = types.Tx("tx").Key()
+		signer        = []byte("signer")
+		peer1  uint16 = 1
+	)
+
+	t.Run("unknown tx is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		tracker.ClearSequence(txKey) // must not panic
+	})
+
+	t.Run("peer-only tx is a no-op", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, nil, 0))
+		tracker.ClearSequence(txKey)
+		require.True(t, tracker.Has(txKey, peer1))
+	})
+
+	t.Run("drops future tx state, keeps peer cache", func(t *testing.T) {
+		tracker := NewSeenTracker()
+		require.True(t, tracker.Add(txKey, peer1, signer, 5))
+
+		tracker.ClearSequence(txKey)
+		_, _, ok := tracker.PendingSequence(txKey)
+		require.False(t, ok)
+		require.True(t, tracker.Has(txKey, peer1))
+		require.Nil(t, tracker.PendingForSigner(signer))
+	})
+}
+
+func TestSeenTrackerPrunePending(t *testing.T) {
+	var (
+		baseTime        = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+		oldKey          = types.Tx("old").Key()
+		freshKey        = types.Tx("fresh").Key()
+		signer          = []byte("signer")
+		peer1    uint16 = 1
+	)
+
+	tracker, mockClock := newClockTracker(baseTime)
+	require.True(t, tracker.Add(oldKey, peer1, signer, 1))
+
+	mockClock.Set(baseTime.Add(3 * time.Minute))
+	require.True(t, tracker.Add(freshKey, peer1, signer, 2))
+
+	tracker.PrunePending(baseTime.Add(time.Minute))
+
+	// Old future metadata is dropped, but the peer cache survives.
+	_, _, oldOK := tracker.PendingSequence(oldKey)
+	require.False(t, oldOK)
+	require.True(t, tracker.Has(oldKey, peer1))
+	// Fresh future metadata is kept.
+	_, _, freshOK := tracker.PendingSequence(freshKey)
+	require.True(t, freshOK)
+	require.Equal(t, []types.TxKey{freshKey}, seenTrackerKeys(tracker.PendingForSigner(signer)))
+}
+
+func TestSeenTrackerConcurrent(t *testing.T) {
+	const peers = 8
+	tracker := NewSeenTracker()
+	keys := []types.TxKey{types.Tx("a").Key(), types.Tx("b").Key()}
+
+	// Phase 1: concurrent Adds on shared keys. Adds are additive, so regardless
+	// of interleaving every key ends up known by every peer.
+	var wg sync.WaitGroup
+	for g := range peers {
+		wg.Add(1)
+		go func(peer uint16) {
+			defer wg.Done()
+			for range 100 {
+				for _, k := range keys {
+					tracker.Add(k, peer, []byte{byte(peer)}, uint64(peer))
+					tracker.Get(k) // clone must not alias the entry others mutate
+				}
+			}
+		}(uint16(g + 1))
+	}
+	wg.Wait()
+
+	require.Equal(t, len(keys), tracker.Len())
+	for _, k := range keys {
+		require.Len(t, tracker.Peers(k), peers) // exact: all peers present
+	}
+	for p := uint16(1); p <= peers; p++ {
+		require.Equal(t, len(keys), tracker.txCountByPeer[p]) // exact count
+	}
+
+	// Phase 2: each peer concurrently removes itself; tracker must end empty.
+	for g := range peers {
+		wg.Add(1)
+		go func(peer uint16) { defer wg.Done(); tracker.RemovePeer(peer) }(uint16(g + 1))
+	}
+	wg.Wait()
+
 	require.Equal(t, 0, tracker.Len())
 	require.Empty(t, tracker.txCountByPeer)
 }
 
-func TestSeenTrackerPrunesPendingWithoutDroppingPeerCache(t *testing.T) {
-	var (
-		baseTime        = time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
-		txKey           = types.Tx("pending-prune").Key()
-		signer          = []byte("signer")
-		peer     uint16 = 1
-	)
-
+// newClockTracker returns a tracker driven by a controllable mock clock set to now.
+func newClockTracker(now time.Time) (*SeenTracker, *clock.Mock) {
 	mockClock := clock.NewMock()
-	mockClock.Set(baseTime)
+	mockClock.Set(now)
 	tracker := NewSeenTracker()
 	tracker.clock = mockClock
-
-	require.True(t, tracker.Add(txKey, peer, signer, 1))
-	require.NotNil(t, tracker.Pending(txKey))
-
-	mockClock.Set(baseTime.Add(3 * time.Minute))
-	tracker.PrunePending(baseTime.Add(time.Minute))
-
-	require.Nil(t, tracker.Pending(txKey))
-	require.True(t, tracker.Has(txKey, peer))
-	entry := tracker.Get(txKey)
-	require.NotNil(t, entry)
-	require.Nil(t, entry.futureTxInfo)
-	require.Nil(t, tracker.PendingForSigner(signer))
+	return tracker, mockClock
 }
 
 func seenTrackerSequences(entries []*seenEntry) []uint64 {


### PR DESCRIPTION
Part 1 of fixing https://linear.app/celestia/issue/PROTOCO-1995/cat-pendingseentracker-lacks-per-peer-bounds-for-future-seentx-entries

In this PR we introduce a new SeenTracker data structure that attempts to resolve the OOM described in the issue. Furthermore it tries to simplify+unify two caches that are currently fragmented.

No wiring has been done. In the next PR we will wire this into the pool and reactor and remove the old caches that reactor currently references.