### PR TITLE
test(consensus): backport TestStateOversizedBlock flake fixes to v0.40.x

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -260,6 +260,12 @@ func TestStateOversizedBlock(t *testing.T) {
 	origTimeout := ensureTimeout
 	ensureTimeout = 2 * time.Second
 	defer func() { ensureTimeout = origTimeout }()
+	// Validating a max-size block under -race on slow CI can push the
+	// prevote→precommit transition past the default 2s vote timeout
+	// (observed at 2.2–2.3s).
+	origVoteTimeout := ensureVoteTimeout
+	ensureVoteTimeout = 5 * time.Second
+	defer func() { ensureVoteTimeout = origVoteTimeout }()
 	const maxBytes = int64(types.BlockPartSizeBytes)
 
 	for _, testCase := range []struct {

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -292,7 +292,9 @@ func TestStateOversizedBlock(t *testing.T) {
 			propBlock, propBlockParts := findBlockSizeLimit(t, height, maxBytes, cs1, partSize, testCase.oversized)
 
 			timeoutProposeCh := subscribe(cs1.eventBus, types.EventQueryTimeoutPropose)
-			voteCh := subscribe(cs1.eventBus, types.EventQueryVote)
+			// Only wait for this validator's votes. The peer prevote below is
+			// just input that drives the state machine toward our precommit.
+			voteCh := subscribeToVoter(cs1, cs1.privValidatorPubKey.Address())
 
 			// make the second validator the proposer by incrementing round
 			round++
@@ -351,7 +353,6 @@ func TestStateOversizedBlock(t *testing.T) {
 			require.NoError(t, err)
 
 			signAddVotes(cs1, cmtproto.PrevoteType, propBlock.Hash(), bps.Header(), false, vs2)
-			ensurePrevote(voteCh, height, round)
 			ensurePrecommit(voteCh, height, round)
 			validatePrecommit(t, cs1, round, lockedRound, vss[0], validateHash, validateHash)
 


### PR DESCRIPTION
## Problem

`TestStateOversizedBlock/max_size,_correct_block` flakes on `v0.40.x` CI with `panic: Timeout expired while waiting for NewVote event` (e.g. [run on #3142](https://github.com/celestiaorg/celestia-core/actions/runs/28112705021/attempts/1)). The failure is unrelated to the PRs it appears on — it's a timing-sensitive consensus test.

`main` already fixed this flake but the fixes were never backported to `v0.40.x`.

## Fix

Backport two commits, both touching only `consensus/state_test.go`:

- #3047 — locally bump `ensureVoteTimeout` to 5s; validating a max-size block under `-race` on slow CI can push the prevote→precommit transition past the 2s default.
- #3116 — subscribe only to the local validator's votes so the local precommit event isn't discarded while waiting for the peer prevote.

## Test plan

- `go test -race -tags deadlock -run '^TestStateOversizedBlock$' ./consensus/ -count=10` — all pass
- `go tool golangci-lint run consensus/...` — 0 issues