### PR TITLE
docs: fix GenesisChunked description typo

### DIFF
--- a/spec/rpc/README.md
+++ b/spec/rpc/README.md
@@ -802,7 +802,7 @@ curl -X POST https://localhost:26657 -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\
 
 ### GenesisChunked
 
-Get the genesis document in a chunks to support easily transfering larger documents.
+Get the genesis document in chunks to support easily transferring larger documents.
 
 #### Parameters
 


### PR DESCRIPTION
Fix a small typo and grammar issue in the `GenesisChunked` RPC documentation.

The description previously said "in a chunks" and "transfering". This updates it to "in chunks" and "transferring".
