### PR TITLE
chore: set seenPerPeerLimit and seenPerSignerLimit to 1000

### DIFF
--- a/mempool/cat/cache.go
+++ b/mempool/cat/cache.go
@@ -11,10 +11,10 @@ import (
 )
 
 // seenPerPeerLimit bounds how many txs one peer can keep tracked.
-const seenPerPeerLimit = 10_000
+const seenPerPeerLimit = 1000
 
 // seenPerSignerLimit bounds future-sequence entries kept for one signer.
-const seenPerSignerLimit = 128
+const seenPerSignerLimit = 1000
 
 // seenEntryTTL is short because useful out-of-order gossip should resolve quickly.
 const seenEntryTTL = 2 * time.Minute


### PR DESCRIPTION
Fixes https://linear.app/celestia/issue/PROTOCO-2058/update-cat-cache-limits-to-be-set-to-1000