### PR TITLE
fix(mempool/cat): race between request timeout and pending-seen gap-fill causing duplicate WantTx 

### DIFF
--- a/mempool/cat/cache.go
+++ b/mempool/cat/cache.go
@@ -42,33 +42,20 @@ type SeenEntry struct {
 
 	// pendingTxInfo is set only while the tx is queued for future-sequence gap-fill.
 	pendingTxInfo *PendingTxInfo
-
-	// requested is true while a WantTx for this tx is in flight, mirroring the
-	// requestScheduler. The gap-fill scan checks it alongside requests.ForTx to
-	// skip txs already being fetched.
-	requested bool
-	// lastPeer is the peer that in-flight WantTx went to. It exists so a timeout
-	// or disconnect only clears requested when it concerns that exact peer — not
-	// some other peer that also advertised the tx.
-	lastPeer uint16
 }
 
 // clearPendingTxMetadata drops signer/sequence state while keeping the tx keyed by peer.
 func (e *SeenEntry) clearPendingTxMetadata() {
 	e.pendingTxInfo = nil
-	e.requested = false
-	e.lastPeer = 0
 }
 
 // clone deep-copies the entry so callers cannot mutate tracker state. Fields are
 // listed explicitly so a newly added map/slice/pointer can't be silently shared.
 func (e *SeenEntry) clone() *SeenEntry {
 	cp := &SeenEntry{
-		txKey:     e.txKey,
-		peers:     make(map[uint16]struct{}, len(e.peers)),
-		addedAt:   e.addedAt,
-		requested: e.requested,
-		lastPeer:  e.lastPeer,
+		txKey:   e.txKey,
+		peers:   make(map[uint16]struct{}, len(e.peers)),
+		addedAt: e.addedAt,
 	}
 
 	for peer := range e.peers {
@@ -308,10 +295,6 @@ func (s *SeenTracker) RemovePeer(peer uint16) {
 			delete(entry.peers, peer)
 			s.decrementPeerTxCountLocked(peer)
 		}
-		if entry.lastPeer == peer {
-			entry.requested = false
-			entry.lastPeer = 0
-		}
 		if len(entry.peers) == 0 {
 			s.removeEntryLocked(entry)
 		}
@@ -465,8 +448,9 @@ func (s *SeenTracker) SignersWithPendingTxs() [][]byte {
 	return out
 }
 
-// MarkRequested remembers which peer we last asked for this tx.
-func (s *SeenTracker) MarkRequested(txKey types.TxKey, peer uint16) {
+// RemovePeerFromTx forgets that peer has txKey, e.g. after it was asked for
+// the tx and never delivered. Drops the entry if no other peer has the tx.
+func (s *SeenTracker) RemovePeerFromTx(txKey types.TxKey, peer uint16) {
 	if peer == 0 {
 		return
 	}
@@ -477,30 +461,6 @@ func (s *SeenTracker) MarkRequested(txKey types.TxKey, peer uint16) {
 	entry, ok := s.txByKey[txKey]
 	if !ok {
 		return
-	}
-
-	entry.requested = true
-	entry.lastPeer = peer
-}
-
-// MarkRequestFailed clears the in-flight request and stops using that peer for
-// this tx unless another peer also announced it.
-func (s *SeenTracker) MarkRequestFailed(txKey types.TxKey, peer uint16) {
-	if peer == 0 {
-		return
-	}
-
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
-	entry, ok := s.txByKey[txKey]
-	if !ok {
-		return
-	}
-
-	if entry.lastPeer == peer {
-		entry.requested = false
-		entry.lastPeer = 0
 	}
 
 	if _, has := entry.peers[peer]; has {

--- a/mempool/cat/cache_test.go
+++ b/mempool/cat/cache_test.go
@@ -233,18 +233,6 @@ func TestSeenTrackerRemovePeer(t *testing.T) {
 		require.Empty(t, tracker.txCountByPeer)
 	})
 
-	t.Run("clears in-flight request from that peer", func(t *testing.T) {
-		tracker := NewSeenTracker()
-		require.True(t, tracker.AddPeer(txKey, peer1))
-		require.True(t, tracker.AddPeer(txKey, peer2))
-		tracker.MarkRequested(txKey, peer1)
-
-		tracker.RemovePeer(peer1)
-		entry := tracker.Get(txKey)
-		require.NotNil(t, entry)
-		require.False(t, entry.requested)
-		require.Equal(t, uint16(0), entry.lastPeer)
-	})
 }
 
 func TestSeenTrackerPrune(t *testing.T) {
@@ -268,37 +256,7 @@ func TestSeenTrackerPrune(t *testing.T) {
 	require.Equal(t, 1, tracker.txCountByPeer[peer1])
 }
 
-func TestSeenTrackerMarkRequested(t *testing.T) {
-	var (
-		txKey        = types.Tx("tx").Key()
-		peer1 uint16 = 1
-	)
-
-	t.Run("peer 0 is a no-op", func(t *testing.T) {
-		tracker := NewSeenTracker()
-		require.True(t, tracker.AddPeer(txKey, peer1))
-		tracker.MarkRequested(txKey, 0)
-		require.False(t, tracker.Get(txKey).requested)
-	})
-
-	t.Run("unknown tx is a no-op", func(t *testing.T) {
-		tracker := NewSeenTracker()
-		tracker.MarkRequested(txKey, peer1) // must not panic
-		require.Nil(t, tracker.Get(txKey))
-	})
-
-	t.Run("records the peer", func(t *testing.T) {
-		tracker := NewSeenTracker()
-		require.True(t, tracker.AddPeer(txKey, peer1))
-		tracker.MarkRequested(txKey, peer1)
-
-		entry := tracker.Get(txKey)
-		require.True(t, entry.requested)
-		require.Equal(t, peer1, entry.lastPeer)
-	})
-}
-
-func TestSeenTrackerMarkRequestFailed(t *testing.T) {
+func TestSeenTrackerRemovePeerFromTx(t *testing.T) {
 	var (
 		txKey        = types.Tx("tx").Key()
 		peer1 uint16 = 1
@@ -308,36 +266,33 @@ func TestSeenTrackerMarkRequestFailed(t *testing.T) {
 	t.Run("peer 0 is a no-op", func(t *testing.T) {
 		tracker := NewSeenTracker()
 		require.True(t, tracker.AddPeer(txKey, peer1))
-		tracker.MarkRequestFailed(txKey, 0)
+		tracker.RemovePeerFromTx(txKey, 0)
 		require.True(t, tracker.Has(txKey, peer1))
 	})
 
 	t.Run("unknown tx is a no-op", func(t *testing.T) {
 		tracker := NewSeenTracker()
-		tracker.MarkRequestFailed(txKey, peer1) // must not panic
+		tracker.RemovePeerFromTx(txKey, peer1) // must not panic
 		require.Equal(t, 0, tracker.Len())
 	})
 
-	t.Run("drops the peer and clears its request", func(t *testing.T) {
+	t.Run("drops the peer but keeps the others", func(t *testing.T) {
 		tracker := NewSeenTracker()
 		require.True(t, tracker.AddPeer(txKey, peer1))
 		require.True(t, tracker.AddPeer(txKey, peer2))
-		tracker.MarkRequested(txKey, peer1)
 
-		tracker.MarkRequestFailed(txKey, peer1)
+		tracker.RemovePeerFromTx(txKey, peer1)
 		entry := tracker.Get(txKey)
 		require.NotNil(t, entry)
-		require.False(t, entry.requested)
-		require.Equal(t, uint16(0), entry.lastPeer)
 		require.False(t, tracker.Has(txKey, peer1))
 		require.True(t, tracker.Has(txKey, peer2))
 	})
 
-	t.Run("removes entry when last peer fails", func(t *testing.T) {
+	t.Run("removes entry when last peer is dropped", func(t *testing.T) {
 		tracker := NewSeenTracker()
 		require.True(t, tracker.AddPeer(txKey, peer1))
 
-		tracker.MarkRequestFailed(txKey, peer1)
+		tracker.RemovePeerFromTx(txKey, peer1)
 		require.Equal(t, 0, tracker.Len())
 		require.Empty(t, tracker.txCountByPeer)
 	})

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -561,7 +561,10 @@ func (memR *Reactor) broadcastSeenTxWithHeight(txKey types.TxKey, height int64, 
 	}
 }
 
-// requesting it from another peer if the first peer does not respond.
+// requestTx reserves the tx in the request scheduler, then sends a WantTx to
+// the peer. Reserving first means concurrent requesters can't double-send:
+// whoever reserves first sends, everyone else no-ops. Returns true only if
+// the WantTx was actually sent.
 func (memR *Reactor) requestTx(txKey types.TxKey, peer p2p.Peer) bool {
 	if peer == nil {
 		// we have disconnected from the peer
@@ -569,6 +572,11 @@ func (memR *Reactor) requestTx(txKey types.TxKey, peer p2p.Peer) bool {
 	}
 
 	peerID := memR.ids.GetIDForPeer(peer.ID())
+	if !memR.requests.Add(txKey, peerID, memR.onRequestTimeout) {
+		memR.Logger.Trace("tx already requested or peer at capacity", "txKey", txKey, "peerID", peer.ID())
+		return false
+	}
+
 	memR.Logger.Trace("requesting tx", "txKey", txKey, "peerID", peer.ID())
 	msg := &protomem.Message{
 		Sum: &protomem.Message_WantTx{
@@ -582,18 +590,13 @@ func (memR *Reactor) requestTx(txKey types.TxKey, peer p2p.Peer) bool {
 			Message:   msg,
 		},
 	)
-	if success {
-		memR.mempool.metrics.RequestedTxs.Add(1)
-		requested := memR.requests.Add(txKey, peerID, memR.onRequestTimeout)
-		if !requested {
-			memR.Logger.Error("have already marked a tx as requested", "txKey", txKey, "peerID", peer.ID())
-		} else {
-			memR.mempool.seenTracker.MarkRequested(txKey, peerID)
-		}
-
-		schema.WriteMempoolPeerState(memR.traceClient, string(peer.ID()), schema.WantTx, txKey[:], schema.Upload)
+	if !success {
+		memR.requests.Remove(txKey)
+		return false
 	}
-	return success
+	memR.mempool.metrics.RequestedTxs.Add(1)
+	schema.WriteMempoolPeerState(memR.traceClient, string(peer.ID()), schema.WantTx, txKey[:], schema.Upload)
+	return true
 }
 
 // tryAddNewTx attempts to add a tx to the mempool and traces the result.
@@ -726,7 +729,7 @@ func (memR *Reactor) processPendingSeenForSigner(signer []byte) {
 		}
 
 		// Skip if already being requested, but count it
-		if memR.requests.ForTx(entry.txKey) != 0 || entry.requested {
+		if memR.requests.ForTx(entry.txKey) != 0 {
 			nextSeq++
 			requested++
 			continue
@@ -751,7 +754,15 @@ func (memR *Reactor) tryRequestQueuedTx(entry *SeenEntry) bool {
 			continue
 		}
 		peer := memR.ids.GetPeer(peerID)
-		if peer != nil && memR.requestTx(entry.txKey, peer) {
+		if peer == nil {
+			continue
+		}
+		if memR.requestTx(entry.txKey, peer) {
+			return true
+		}
+		// requestTx also fails when another goroutine reserved this tx
+		// first; if so, trying more peers would fail the same way.
+		if memR.requests.ForTx(entry.txKey) != 0 {
 			return true
 		}
 	}
@@ -762,7 +773,9 @@ func (memR *Reactor) tryRequestQueuedTx(entry *SeenEntry) bool {
 }
 
 func (memR *Reactor) onRequestTimeout(txKey types.TxKey, peerID uint16) {
-	memR.mempool.seenTracker.MarkRequestFailed(txKey, peerID)
+	// The peer failed to respond in time, so stop treating it as a source
+	// for this tx unless it announces it again.
+	memR.mempool.seenTracker.RemovePeerFromTx(txKey, peerID)
 	memR.findNewPeerToRequestTx(txKey)
 }
 

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -935,8 +935,6 @@ func TestReactorRequestsQueuedTxAfterSequenceBecomesAvailable(t *testing.T) {
 	sourcePeer.AssertExpectations(t)
 	entries := reactor.mempool.seenTracker.PendingTxsForSigner(signer)
 	require.Len(t, entries, 1)
-	require.True(t, entries[0].requested)
-	require.Equal(t, reactor.ids.GetIDForPeer(sourcePeer.ID()), entries[0].lastPeer)
 	require.EqualValues(t, reactor.ids.GetIDForPeer(sourcePeer.ID()), reactor.requests.ForTx(targetKey))
 }
 
@@ -1108,11 +1106,11 @@ func TestProcessPendingSeenForSignerRequestsConsecutiveSequences(t *testing.T) {
 
 	peer.AssertExpectations(t)
 
-	// All entries should be marked as requested
+	// All entries should have an in-flight request
 	entries := reactor.mempool.seenTracker.PendingTxsForSigner(signer)
 	require.Len(t, entries, 3)
 	for _, entry := range entries {
-		require.True(t, entry.requested, "entry for seq %d should be marked requested", entry.pendingTxInfo.sequence)
+		require.NotZero(t, reactor.requests.ForTx(entry.txKey), "entry for seq %d should be requested", entry.pendingTxInfo.sequence)
 	}
 }
 
@@ -1169,12 +1167,7 @@ func TestProcessPendingSeenForSignerStopsAtGap(t *testing.T) {
 	peer.AssertExpectations(t)
 
 	// Entry for sequence 8 should NOT be requested
-	entries := reactor.mempool.seenTracker.PendingTxsForSigner(signer)
-	for _, entry := range entries {
-		if entry.pendingTxInfo.sequence == 8 {
-			require.False(t, entry.requested, "entry for seq 8 should NOT be requested due to gap")
-		}
-	}
+	require.Zero(t, reactor.requests.ForTx(key8), "entry for seq 8 should NOT be requested due to gap")
 }
 
 func TestProcessPendingSeenForSignerSkipsAlreadyInMempool(t *testing.T) {
@@ -1263,7 +1256,7 @@ func TestProcessPendingSeenForSignerRespectsMaxBuffer(t *testing.T) {
 	entries := reactor.mempool.seenTracker.PendingTxsForSigner(signer)
 	requestedCount := 0
 	for _, entry := range entries {
-		if entry.requested {
+		if reactor.requests.ForTx(entry.txKey) != 0 {
 			requestedCount++
 		}
 	}
@@ -1298,7 +1291,7 @@ func TestProcessPendingSeenForSignerSkipsAlreadyRequested(t *testing.T) {
 	reactor.mempool.seenTracker.AddPendingTx(key6, peerID, signer, 6)
 
 	// Mark sequence 5 as already requested
-	reactor.mempool.seenTracker.MarkRequested(key5, peerID)
+	require.True(t, reactor.requests.Add(key5, peerID, nil))
 
 	// Only sequence 6 should be newly requested
 	peer.On("TrySend", p2p.Envelope{
@@ -1313,6 +1306,139 @@ func TestProcessPendingSeenForSignerSkipsAlreadyRequested(t *testing.T) {
 	reactor.processPendingSeenForSigner(signer)
 
 	peer.AssertExpectations(t)
+}
+
+func TestRequestTxReservesBeforeSending(t *testing.T) {
+	app := newSequenceTrackingApp()
+	cc := proxy.NewLocalClientCreator(app)
+	pool, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	reactor, err := NewReactor(pool, &ReactorOptions{})
+	require.NoError(t, err)
+
+	peerA := genPeer()
+	peerB := genPeer()
+	_, err = reactor.InitPeer(peerA)
+	require.NoError(t, err)
+	_, err = reactor.InitPeer(peerB)
+	require.NoError(t, err)
+
+	tx := newDefaultTx("tx")
+	key := tx.Key()
+
+	peerA.On("TrySend", p2p.Envelope{
+		ChannelID: MempoolWantsChannel,
+		Message: &protomem.Message{
+			Sum: &protomem.Message_WantTx{
+				WantTx: &protomem.WantTx{TxKey: key[:]},
+			},
+		},
+	}).Return(true).Once()
+
+	require.True(t, reactor.requestTx(key, peerA))
+
+	// While the WantTx to peerA is outstanding, requesting the same key
+	// again must not send another WantTx, whatever peer it targets.
+	require.False(t, reactor.requestTx(key, peerB))
+	require.False(t, reactor.requestTx(key, peerA))
+
+	require.EqualValues(t, reactor.ids.GetIDForPeer(peerA.ID()), reactor.requests.ForTx(key))
+	peerA.AssertExpectations(t)
+	peerB.AssertNotCalled(t, "TrySend", mock.Anything)
+}
+
+func TestRequestTimeoutDropsUnresponsivePeerAndAsksAnother(t *testing.T) {
+	app := newSequenceTrackingApp()
+	cc := proxy.NewLocalClientCreator(app)
+	pool, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	reactor, err := NewReactor(pool, &ReactorOptions{MaxGossipDelay: 100 * time.Millisecond})
+	require.NoError(t, err)
+
+	peerA := genPeer()
+	peerB := genPeer()
+	_, err = reactor.InitPeer(peerA)
+	require.NoError(t, err)
+	_, err = reactor.InitPeer(peerB)
+	require.NoError(t, err)
+	peerAID := reactor.ids.GetIDForPeer(peerA.ID())
+	peerBID := reactor.ids.GetIDForPeer(peerB.ID())
+
+	tx := newDefaultTx("tx")
+	key := tx.Key()
+
+	// both peers have announced the tx
+	reactor.mempool.PeerHasTx(peerAID, key)
+	reactor.mempool.PeerHasTx(peerBID, key)
+
+	wantEnvelope := p2p.Envelope{
+		ChannelID: MempoolWantsChannel,
+		Message: &protomem.Message{
+			Sum: &protomem.Message_WantTx{
+				WantTx: &protomem.WantTx{TxKey: key[:]},
+			},
+		},
+	}
+
+	peerA.On("TrySend", wantEnvelope).Return(true).Once()
+	peerB.On("TrySend", wantEnvelope).Return(true).Once()
+
+	require.True(t, reactor.requestTx(key, peerA))
+
+	// peerA never responds: after MaxGossipDelay the request must move to peerB
+	require.Eventually(t, func() bool {
+		return reactor.requests.ForTx(key) == peerBID
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// the unresponsive peer is no longer considered a source for this tx
+	require.False(t, reactor.mempool.seenTracker.Has(key, peerAID))
+	require.True(t, reactor.mempool.seenTracker.Has(key, peerBID))
+
+	peerA.AssertExpectations(t)
+	peerB.AssertExpectations(t)
+}
+
+func TestRequestTxRollsBackReservationOnFailedSend(t *testing.T) {
+	app := newSequenceTrackingApp()
+	cc := proxy.NewLocalClientCreator(app)
+	pool, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	reactor, err := NewReactor(pool, &ReactorOptions{})
+	require.NoError(t, err)
+
+	peerA := genPeer()
+	peerB := genPeer()
+	_, err = reactor.InitPeer(peerA)
+	require.NoError(t, err)
+	_, err = reactor.InitPeer(peerB)
+	require.NoError(t, err)
+
+	tx := newDefaultTx("tx")
+	key := tx.Key()
+
+	wantEnvelope := p2p.Envelope{
+		ChannelID: MempoolWantsChannel,
+		Message: &protomem.Message{
+			Sum: &protomem.Message_WantTx{
+				WantTx: &protomem.WantTx{TxKey: key[:]},
+			},
+		},
+	}
+
+	peerA.On("TrySend", wantEnvelope).Return(false).Once()
+	require.False(t, reactor.requestTx(key, peerA))
+	require.Zero(t, reactor.requests.ForTx(key))
+
+	// With the reservation rolled back, the tx can be requested from
+	// another peer.
+	peerB.On("TrySend", wantEnvelope).Return(true).Once()
+	require.True(t, reactor.requestTx(key, peerB))
+	require.EqualValues(t, reactor.ids.GetIDForPeer(peerB.ID()), reactor.requests.ForTx(key))
+	peerA.AssertExpectations(t)
+	peerB.AssertExpectations(t)
 }
 
 func TestTryRequestQueuedTxRespectsPerPeerLimit(t *testing.T) {

--- a/mempool/cat/requests.go
+++ b/mempool/cat/requests.go
@@ -55,6 +55,12 @@ func (r *requestScheduler) Add(key types.TxKey, peer uint16, onTimeout func(key 
 		return false
 	}
 
+	// the per-peer limit is enforced here, under the lock, so concurrent
+	// requesters can't race a peer past it
+	if len(r.requestsByPeer[peer]) >= maxRequestsPerPeer {
+		return false
+	}
+
 	timer := time.AfterFunc(r.responseTime, func() {
 		r.mtx.Lock()
 		delete(r.requestsByTx, key)
@@ -127,6 +133,23 @@ func (r *requestScheduler) ClearAllRequestsFrom(peer uint16) requestSet {
 	}
 	delete(r.requestsByPeer, peer)
 	return requests
+}
+
+// Remove drops an in-flight request and stops its timer, e.g. to roll back
+// a reservation whose WantTx failed to send.
+func (r *requestScheduler) Remove(key types.TxKey) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	peer, ok := r.requestsByTx[key]
+	if !ok {
+		return
+	}
+	if timer, ok := r.requestsByPeer[peer][key]; ok {
+		timer.Stop()
+		delete(r.requestsByPeer[peer], key)
+	}
+	delete(r.requestsByTx, key)
 }
 
 func (r *requestScheduler) MarkReceived(peer uint16, key types.TxKey) bool {

--- a/mempool/cat/requests.go
+++ b/mempool/cat/requests.go
@@ -43,6 +43,16 @@ func newRequestScheduler(responseTime, globalTimeout time.Duration) *requestSche
 	}
 }
 
+// deletePeerRequest removes key from the peer's request set, dropping the
+// set itself once empty so requestsByPeer doesn't accumulate idle peer
+// entries. Caller must hold r.mtx.
+func (r *requestScheduler) deletePeerRequest(peer uint16, key types.TxKey) {
+	delete(r.requestsByPeer[peer], key)
+	if len(r.requestsByPeer[peer]) == 0 {
+		delete(r.requestsByPeer, peer)
+	}
+}
+
 func (r *requestScheduler) Add(key types.TxKey, peer uint16, onTimeout func(key types.TxKey, peer uint16)) bool {
 	if peer == 0 {
 		return false
@@ -86,7 +96,7 @@ func (r *requestScheduler) Add(key types.TxKey, peer uint16, onTimeout func(key 
 		time.AfterFunc(r.globalTimeout, func() {
 			r.mtx.Lock()
 			defer r.mtx.Unlock()
-			delete(r.requestsByPeer[peer], key)
+			r.deletePeerRequest(peer, key)
 		})
 	})
 	if _, ok := r.requestsByPeer[peer]; !ok {
@@ -153,7 +163,7 @@ func (r *requestScheduler) Remove(key types.TxKey) {
 	}
 	if timer, ok := r.requestsByPeer[peer][key]; ok {
 		timer.Stop()
-		delete(r.requestsByPeer[peer], key)
+		r.deletePeerRequest(peer, key)
 	}
 	delete(r.requestsByTx, key)
 }

--- a/mempool/cat/requests.go
+++ b/mempool/cat/requests.go
@@ -63,6 +63,12 @@ func (r *requestScheduler) Add(key types.TxKey, peer uint16, onTimeout func(key 
 
 	timer := time.AfterFunc(r.responseTime, func() {
 		r.mtx.Lock()
+		// The request may have been fulfilled by another peer while this callback 
+		// was waiting on the lock;
+		if r.requestsByTx[key] != peer {
+			r.mtx.Unlock()
+			return
+		}
 		delete(r.requestsByTx, key)
 		r.mtx.Unlock()
 
@@ -167,7 +173,12 @@ func (r *requestScheduler) MarkReceived(peer uint16, key types.TxKey) bool {
 	}
 
 	delete(r.requestsByPeer[peer], key)
-	delete(r.requestsByTx, key)
+	// A late response only clears the request if it still belongs to
+	// this peer; after a timeout the tx may have been re-requested from
+	// someone else, and that request is still in flight.
+	if r.requestsByTx[key] == peer {
+		delete(r.requestsByTx, key)
+	}
 	return true
 }
 

--- a/mempool/cat/requests.go
+++ b/mempool/cat/requests.go
@@ -63,8 +63,8 @@ func (r *requestScheduler) Add(key types.TxKey, peer uint16, onTimeout func(key 
 
 	timer := time.AfterFunc(r.responseTime, func() {
 		r.mtx.Lock()
-		// The request may have been fulfilled by another peer while this callback 
-		// was waiting on the lock;
+		// The request may have been fulfilled by another peer while this callback
+		// was waiting on the lock; if so, skip the timeout logic.
 		if r.requestsByTx[key] != peer {
 			r.mtx.Unlock()
 			return

--- a/mempool/cat/requests_test.go
+++ b/mempool/cat/requests_test.go
@@ -68,6 +68,37 @@ func TestRequestSchedulerRerequest(t *testing.T) {
 	require.True(t, requests.MarkReceived(peerA, key))
 }
 
+func TestRequestSchedulerLateResponseDoesNotClobberRerequest(t *testing.T) {
+	var (
+		requests        = newRequestScheduler(10*time.Millisecond, 1*time.Minute)
+		tx              = types.Tx("tx")
+		key             = tx.Key()
+		peerA    uint16 = 1
+		peerB    uint16 = 2
+	)
+	t.Cleanup(requests.Close)
+
+	rerequested := make(chan struct{})
+	require.True(t, requests.Add(key, peerA, func(cbKey types.TxKey, _ uint16) {
+		require.True(t, requests.Add(cbKey, peerB, nil))
+		close(rerequested)
+	}))
+
+	// peerA times out and the tx is re-requested from peerB
+	<-rerequested
+	require.Equal(t, peerB, requests.ForTx(key))
+
+	// peerA responds late, while peerB's request is still in flight. It is
+	// recognized as a response to the earlier request, but must not clear
+	// peerB's reservation.
+	require.True(t, requests.MarkReceived(peerA, key))
+	require.Equal(t, peerB, requests.ForTx(key))
+
+	// peerB's request concludes normally
+	require.True(t, requests.MarkReceived(peerB, key))
+	require.Zero(t, requests.ForTx(key))
+}
+
 func TestRequestSchedulerNonResponsivePeer(t *testing.T) {
 	var (
 		requests        = newRequestScheduler(10*time.Millisecond, time.Millisecond)

--- a/mempool/cat/requests_test.go
+++ b/mempool/cat/requests_test.go
@@ -139,6 +139,52 @@ func TestRequestSchedulerConcurrencyAddsAndReads(t *testing.T) {
 	}
 }
 
+func TestRequestSchedulerRemove(t *testing.T) {
+	requests := newRequestScheduler(time.Minute, time.Minute)
+	t.Cleanup(requests.Close)
+
+	var peerA uint16 = 1
+	key := types.Tx("tx").Key()
+
+	// removing an unknown key is a no-op
+	requests.Remove(key)
+
+	require.True(t, requests.Add(key, peerA, nil))
+	requests.Remove(key)
+
+	require.Zero(t, requests.ForTx(key))
+	require.False(t, requests.Has(peerA, key))
+	require.Equal(t, 0, requests.CountForPeer(peerA))
+
+	// the key can be reserved again after removal
+	require.True(t, requests.Add(key, peerA, nil))
+}
+
+func TestRequestSchedulerPerPeerLimit(t *testing.T) {
+	requests := newRequestScheduler(time.Minute, time.Minute)
+	t.Cleanup(requests.Close)
+
+	var peerA uint16 = 1
+	var peerB uint16 = 2
+
+	keys := make([]types.TxKey, maxRequestsPerPeer)
+	for i := 0; i < maxRequestsPerPeer; i++ {
+		keys[i] = types.Tx(fmt.Sprintf("tx-%d", i)).Key()
+		require.True(t, requests.Add(keys[i], peerA, nil))
+	}
+
+	// peerA is at capacity so you can no longer reserve the request spot
+	overflow := types.Tx("overflow").Key()
+	require.False(t, requests.Add(overflow, peerA, nil))
+	// but the same tx can still be requested from another peer
+	require.True(t, requests.Add(overflow, peerB, nil))
+
+	// receiving a response frees a slot
+	require.True(t, requests.MarkReceived(peerA, keys[0]))
+	extra := types.Tx("extra").Key()
+	require.True(t, requests.Add(extra, peerA, nil))
+}
+
 func TestRequestSchedulerCountForPeer(t *testing.T) {
 	requests := newRequestScheduler(time.Minute, time.Minute)
 	t.Cleanup(requests.Close)


### PR DESCRIPTION
Fixes https://linear.app/celestia/issue/PROTOCO-2054/refactor-fragmented-request-management-in-cat

This refactor prevents duplicate wants by making the scheduler first reserve the request before requesting it so another process can't request it in parallel. 