### PR TITLE
test(node): fix flaky TestNodePrivValidatorGRPCServer port collision

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -533,6 +533,7 @@ func state(nVals int, height int64) (sm.State, dbm.DB, []types.PrivValidator) {
 func TestNodePrivValidatorGRPCServer(t *testing.T) {
 	config := test.ResetTestRoot("node_privval_grpc_test")
 	defer os.RemoveAll(config.RootDir)
+	testFreeConfig(t, config)
 
 	addr := testFreeAddr(t)
 	config.PrivValidatorGRPCListenAddr = addr


### PR DESCRIPTION
## Problem

`TestNodePrivValidatorGRPCServer` intermittently fails in CI (observed in `test-group-03`) with:

```
failed to listen on 127.0.0.1:36657: listen tcp 127.0.0.1:36657: bind: address already in use
```

The test only overrode `PrivValidatorGRPCListenAddr`, so the node's RPC server still bound the hardcoded ports from `TestRPCConfig` (`127.0.0.1:36657` / `:36658`). That collides with other node tests, causing flaky failures.

## Fix

Call `testFreeConfig(t, config)` to bind the P2P and RPC servers to free ports — matching every other test in `node/node_test.go`.

No issue tracker entry exists; this addresses an observed CI flake.