### PR TITLE
fix(mempool/cat): failed WantTx send rollback deleting another peer rerequest

### DIFF
--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -625,7 +625,8 @@ func (memR *Reactor) requestTx(txKey types.TxKey, peer p2p.Peer) bool {
 		},
 	)
 	if !success {
-		memR.requests.Remove(txKey)
+		// The request may have been reassigned while TrySend was in flight.
+		memR.requests.Remove(txKey, peerID)
 		return false
 	}
 	memR.mempool.metrics.RequestedTxs.Add(1)

--- a/mempool/cat/requests.go
+++ b/mempool/cat/requests.go
@@ -151,14 +151,13 @@ func (r *requestScheduler) ClearAllRequestsFrom(peer uint16) requestSet {
 	return requests
 }
 
-// Remove drops an in-flight request and stops its timer, e.g. to roll back
-// a reservation whose WantTx failed to send.
-func (r *requestScheduler) Remove(key types.TxKey) {
+// Remove drops the request for key if it still belongs to peer. This prevents
+// a late rollback from removing a newer request for the same transaction.
+func (r *requestScheduler) Remove(key types.TxKey, peer uint16) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
-	peer, ok := r.requestsByTx[key]
-	if !ok {
+	if owner, ok := r.requestsByTx[key]; !ok || owner != peer {
 		return
 	}
 	if timer, ok := r.requestsByPeer[peer][key]; ok {

--- a/mempool/cat/requests_test.go
+++ b/mempool/cat/requests_test.go
@@ -175,13 +175,20 @@ func TestRequestSchedulerRemove(t *testing.T) {
 	t.Cleanup(requests.Close)
 
 	var peerA uint16 = 1
+	var peerB uint16 = 2
 	key := types.Tx("tx").Key()
 
 	// removing an unknown key is a no-op
-	requests.Remove(key)
+	requests.Remove(key, peerA)
 
 	require.True(t, requests.Add(key, peerA, nil))
-	requests.Remove(key)
+
+	// removing with the wrong peer is a no-op: the request still belongs to peerA
+	requests.Remove(key, peerB)
+	require.Equal(t, peerA, requests.ForTx(key))
+	require.True(t, requests.Has(peerA, key))
+
+	requests.Remove(key, peerA)
 
 	require.Zero(t, requests.ForTx(key))
 	require.False(t, requests.Has(peerA, key))
@@ -189,6 +196,29 @@ func TestRequestSchedulerRemove(t *testing.T) {
 
 	// the key can be reserved again after removal
 	require.True(t, requests.Add(key, peerA, nil))
+}
+
+func TestRequestSchedulerRemoveDoesNotRemoveAnotherPeersRequest(t *testing.T) {
+	requests := newRequestScheduler(time.Minute, time.Minute)
+	t.Cleanup(requests.Close)
+
+	var peerA uint16 = 1
+	var peerB uint16 = 2
+	key := types.Tx("tx").Key()
+
+	// peerA reserves the request, then disconnects before its send completes
+	require.True(t, requests.Add(key, peerA, nil))
+	requests.ClearAllRequestsFrom(peerA)
+
+	// the tx is re-requested from peerB
+	require.True(t, requests.Add(key, peerB, nil))
+
+	// peerA's failed send now rolls back its reservation. It must not touch
+	// peerB's request.
+	requests.Remove(key, peerA)
+
+	require.Equal(t, peerB, requests.ForTx(key))
+	require.True(t, requests.Has(peerB, key))
 }
 
 func TestRequestSchedulerPerPeerLimit(t *testing.T) {


### PR DESCRIPTION
Fixes https://linear.app/celestia/issue/PROTOCO-2154/failed-send-rollback-can-delete-a-reassigned-request