### PR TITLE
fix(mempool/cat): retry tx requests rejected by the per peer request limit

### DIFF
--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -458,19 +458,16 @@ func (memR *Reactor) Receive(e p2p.Envelope) {
 			return
 		}
 
-		// We don't have the transaction, nor are we requesting it so we send the node
-		// a want msg. Enforce the per-peer request limit so a single peer cannot
-		// drive unbounded outstanding requests via the direct SeenTx path.
-		if memR.requests.CountForPeer(peerID) >= maxRequestsPerPeer {
+		// requestTx enforces peer limits atomically. If no request is active,
+		// queue the announcement for retry.
+		if !memR.requestTx(txKey, e.Src) && memR.requests.ForTx(txKey) == 0 {
 			memR.Logger.Debug(
-				"not requesting tx from peer: at capacity",
+				"tx not requested, queueing SeenTx for retry",
 				"peer", peerID,
 				"txKey", txKey,
-				"maxRequestsPerPeer", maxRequestsPerPeer,
 			)
-			return
+			memR.mempool.seenTracker.AddPendingTx(txKey, peerID, msg.Signer, msg.Sequence)
 		}
-		memR.requestTx(txKey, e.Src)
 
 	// A peer is requesting a transaction that we have claimed to have. Find the specified
 	// transaction and broadcast it to the peer. We may no longer have the transaction
@@ -879,18 +876,20 @@ func (memR *Reactor) findNewPeerToRequestTx(txKey types.TxKey) {
 
 	peerIDs := memR.mempool.seenTracker.PeersForTx(txKey)
 	for peerID := range peerIDs {
-		if memR.requests.Has(peerID, txKey) {
-			continue
-		}
-		if memR.requests.CountForPeer(peerID) >= maxRequestsPerPeer {
-			continue
-		}
 		peer := memR.ids.GetPeer(peerID)
-		if peer != nil {
+		if peer == nil {
+			continue
+		}
+		if memR.requestTx(txKey, peer) {
 			memR.mempool.metrics.RerequestedTxs.Add(1)
-			memR.requestTx(txKey, peer)
 			return
 		}
+		if memR.requests.ForTx(txKey) != 0 {
+			// another goroutine reserved this tx first; nothing left to do
+			return
+		}
+		// this candidate couldn't take the request (e.g. no free request
+		// slot); try the remaining candidates
 	}
 
 	// No other free peer has the transaction we are looking for.

--- a/mempool/cat/reactor_test.go
+++ b/mempool/cat/reactor_test.go
@@ -1698,6 +1698,107 @@ func TestTryRequestQueuedTxFallsBackToAlternativePeer(t *testing.T) {
 	peer3.AssertExpectations(t)
 }
 
+// TestReactorSeenTxAtPeerCapacityIsQueued verifies that SeenTx is queued when
+// the peer has no free request slots.
+func TestReactorSeenTxAtPeerCapacityIsQueued(t *testing.T) {
+	app := newSequenceTrackingApp()
+	cc := proxy.NewLocalClientCreator(app)
+	pool, cleanup := newMempoolWithApp(cc)
+	t.Cleanup(cleanup)
+
+	reactor, err := NewReactor(pool, &ReactorOptions{})
+	require.NoError(t, err)
+
+	signer := []byte("test-signer")
+	app.SetSequence(string(signer), 1)
+
+	peer := genPeer()
+	_, err = reactor.InitPeer(peer)
+	require.NoError(t, err)
+	peerID := reactor.ids.GetIDForPeer(peer.ID())
+
+	// fill the peer to capacity with fake requests
+	fillKeys := make([]types.TxKey, maxRequestsPerPeer)
+	for i := 0; i < maxRequestsPerPeer; i++ {
+		fillKeys[i] = types.Tx(fmt.Sprintf("fill-tx-%d", i)).Key()
+		require.True(t, reactor.requests.Add(fillKeys[i], peerID, nil))
+	}
+
+	// the peer announces a requestable tx (sequence matches the expected one)
+	tx := newDefaultTx("hello")
+	key := tx.Key()
+	reactor.Receive(p2p.Envelope{
+		ChannelID: MempoolDataChannel,
+		Message:   &protomem.SeenTx{TxKey: key[:], Signer: signer, Sequence: 1},
+		Src:       peer,
+	})
+
+	// no slot was free so nothing was sent, but the announcement must be
+	// queued for retry rather than dropped
+	peer.AssertNotCalled(t, "TrySend", mock.Anything)
+	require.Zero(t, reactor.requests.ForTx(key))
+	pending := pool.seenTracker.PendingTxsForSigner(signer)
+	require.Len(t, pending, 1)
+	require.Equal(t, key, pending[0].txKey)
+
+	// a slot frees up and the next pending scan sends the request
+	require.True(t, reactor.requests.MarkReceived(peerID, fillKeys[0]))
+	peer.On("TrySend", p2p.Envelope{
+		ChannelID: MempoolWantsChannel,
+		Message: &protomem.Message{
+			Sum: &protomem.Message_WantTx{
+				WantTx: &protomem.WantTx{TxKey: key[:]},
+			},
+		},
+	}).Return(true).Once()
+
+	reactor.processPendingSeenForSigner(signer)
+
+	require.Equal(t, peerID, reactor.requests.ForTx(key))
+	peer.AssertExpectations(t)
+}
+
+// TestReactorFindNewPeerSkipsFullPeer verifies that another peer is tried when
+// the first has no free request slots.
+func TestReactorFindNewPeerSkipsFullPeer(t *testing.T) {
+	reactor, pool := setupReactor(t)
+
+	peers := genPeers(2)
+	fullPeer, freePeer := peers[0], peers[1]
+	for _, peer := range peers {
+		_, err := reactor.InitPeer(peer)
+		require.NoError(t, err)
+	}
+	fullPeerID := reactor.ids.GetIDForPeer(fullPeer.ID())
+	freePeerID := reactor.ids.GetIDForPeer(freePeer.ID())
+
+	// fill one peer to capacity with fake requests
+	for i := 0; i < maxRequestsPerPeer; i++ {
+		require.True(t, reactor.requests.Add(types.Tx(fmt.Sprintf("fill-tx-%d", i)).Key(), fullPeerID, nil))
+	}
+
+	// both peers are known sources for the tx
+	tx := newDefaultTx("hello")
+	key := tx.Key()
+	pool.PeerHasTx(fullPeerID, key)
+	pool.PeerHasTx(freePeerID, key)
+
+	freePeer.On("TrySend", p2p.Envelope{
+		ChannelID: MempoolWantsChannel,
+		Message: &protomem.Message{
+			Sum: &protomem.Message_WantTx{
+				WantTx: &protomem.WantTx{TxKey: key[:]},
+			},
+		},
+	}).Return(true).Once()
+
+	reactor.findNewPeerToRequestTx(key)
+
+	require.Equal(t, freePeerID, reactor.requests.ForTx(key))
+	fullPeer.AssertNotCalled(t, "TrySend", mock.Anything)
+	freePeer.AssertExpectations(t)
+}
+
 func TestTxsWithTooManyTxsBansPeer(t *testing.T) {
 	config := cfg.TestConfig()
 	reactors := makeAndConnectReactors(t, config, 2)


### PR DESCRIPTION
Fixes https://linear.app/celestia/issue/PROTOCO-2155/capacity-races-can-silently-discard-transaction-fetches
