### PR TITLE
fix(mempool): reject abusive Txs messages before unmarshalling

### DIFF
--- a/internal/protowire/protowire.go
+++ b/internal/protowire/protowire.go
@@ -1,0 +1,127 @@
+// Package protowire provides a minimal, allocation-free reader for walking
+// raw protobuf wire bytes. Every read is bounds-checked and advances a cursor.
+package protowire
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Wire types (the low 3 bits of a field tag).
+const (
+	WireVarint  = 0
+	WireFixed64 = 1
+	WireBytes   = 2
+	WireFixed32 = 5
+)
+
+var (
+	// ErrVarintOverflow is returned when a varint does not terminate within
+	// the 10 bytes that can hold a 64-bit value.
+	ErrVarintOverflow = errors.New("varint overflow")
+	// ErrTruncatedVarint is returned when the buffer ends mid-varint.
+	ErrTruncatedVarint = errors.New("truncated varint")
+	// ErrOutOfBounds is returned when a length prefix or fixed-width field
+	// would run past the end of the buffer.
+	ErrOutOfBounds = errors.New("length out of bounds")
+	// ErrIllegalFieldNumber is returned when a tag decodes to a field number
+	// that is not a legal protobuf field number (>= 1).
+	ErrIllegalFieldNumber = errors.New("illegal field number")
+	// ErrUnsupportedWireType is returned when a tag carries a wire type the
+	// cursor does not know how to skip.
+	ErrUnsupportedWireType = errors.New("unsupported wire type")
+)
+
+// WireCursor walks a protobuf buffer left to right. Every read is bounds-checked
+// and advances the cursor; a read past the end returns an error rather than
+// panicking.
+type WireCursor struct {
+	buf []byte
+	pos int
+}
+
+// NewWireCursor returns a cursor positioned at the start of buf.
+func NewWireCursor(buf []byte) WireCursor {
+	return WireCursor{buf: buf}
+}
+
+// AtEnd reports whether the cursor has consumed the whole buffer.
+func (c *WireCursor) AtEnd() bool { return c.pos >= len(c.buf) }
+
+// ReadVarint decodes a base-128 varint at the cursor and advances past it.
+func (c *WireCursor) ReadVarint() (uint64, error) {
+	var v uint64
+	for shift := uint(0); ; shift += 7 {
+		if shift >= 64 {
+			return 0, ErrVarintOverflow
+		}
+		if c.pos >= len(c.buf) {
+			return 0, ErrTruncatedVarint
+		}
+		b := c.buf[c.pos]
+		c.pos++
+		v |= uint64(b&0x7f) << shift
+		if b < 0x80 {
+			return v, nil
+		}
+	}
+}
+
+// ReadTag decodes a field tag, splitting it into field number and wire type.
+func (c *WireCursor) ReadTag() (fieldNum, wireType int, err error) {
+	v, err := c.ReadVarint()
+	if err != nil {
+		return 0, 0, err
+	}
+	fieldNum = int(int32(v >> 3))
+	wireType = int(v & 0x7)
+	if fieldNum <= 0 {
+		return 0, 0, fmt.Errorf("%w: %d", ErrIllegalFieldNumber, fieldNum)
+	}
+	return fieldNum, wireType, nil
+}
+
+// ReadLengthDelimited reads a length-prefixed run of bytes (wire type 2) and
+// returns it as a sub-slice of the underlying buffer, advancing past it.
+func (c *WireCursor) ReadLengthDelimited() ([]byte, error) {
+	length, err := c.ReadVarint()
+	if err != nil {
+		return nil, err
+	}
+	start := c.pos
+	end := start + int(length)
+	if end < start || end > len(c.buf) {
+		return nil, ErrOutOfBounds
+	}
+	c.pos = end
+	return c.buf[start:end], nil
+}
+
+// SkipField advances the cursor past the body of a field with the given wire
+// type, used to ignore fields the caller does not care about.
+func (c *WireCursor) SkipField(wireType int) error {
+	switch wireType {
+	case WireVarint:
+		_, err := c.ReadVarint()
+		return err
+	case WireFixed64:
+		return c.advance(8)
+	case WireBytes:
+		_, err := c.ReadLengthDelimited()
+		return err
+	case WireFixed32:
+		return c.advance(4)
+	default:
+		return fmt.Errorf("%w: %d", ErrUnsupportedWireType, wireType)
+	}
+}
+
+// advance moves the cursor forward by n bytes, bounds-checked.
+func (c *WireCursor) advance(n int) error {
+	end := c.pos + n
+	if end < c.pos || end > len(c.buf) {
+		return ErrOutOfBounds
+	}
+	c.pos = end
+	return nil
+}

--- a/internal/protowire/protowire_test.go
+++ b/internal/protowire/protowire_test.go
@@ -1,0 +1,108 @@
+package protowire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWireCursor_ReadVarint(t *testing.T) {
+	// 300 encodes as 0xac 0x02 in base-128 varint.
+	c := NewWireCursor([]byte{0xac, 0x02})
+	v, err := c.ReadVarint()
+	require.NoError(t, err)
+	require.Equal(t, uint64(300), v)
+	require.True(t, c.AtEnd())
+}
+
+func TestWireCursor_ReadVarint_Truncated(t *testing.T) {
+	c := NewWireCursor([]byte{0xff})
+	_, err := c.ReadVarint()
+	require.ErrorIs(t, err, ErrTruncatedVarint)
+}
+
+func TestWireCursor_ReadVarint_Overflow(t *testing.T) {
+	// 11 continuation bytes never terminate within 64 bits.
+	c := NewWireCursor([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+	_, err := c.ReadVarint()
+	require.ErrorIs(t, err, ErrVarintOverflow)
+}
+
+func TestWireCursor_ReadTag(t *testing.T) {
+	// Field 1, wire type 2 (length-delimited) => tag byte 0x0a.
+	c := NewWireCursor([]byte{0x0a})
+	fieldNum, wireType, err := c.ReadTag()
+	require.NoError(t, err)
+	require.Equal(t, 1, fieldNum)
+	require.Equal(t, WireBytes, wireType)
+}
+
+func TestWireCursor_ReadTag_IllegalFieldNumber(t *testing.T) {
+	// Tag 0x00 => field number 0, which is illegal.
+	c := NewWireCursor([]byte{0x00})
+	_, _, err := c.ReadTag()
+	require.ErrorIs(t, err, ErrIllegalFieldNumber)
+}
+
+func TestWireCursor_ReadTag_FieldNumberTruncatesTo32Bit(t *testing.T) {
+	// Tag varint 8a 80 80 80 80 01 decodes to wire = 2^35 + 10, so
+	// wire>>3 == 2^32 + 1 and wire&7 == 2 (WireBytes). int32(2^32+1) == 1.
+	c := NewWireCursor([]byte{0x8a, 0x80, 0x80, 0x80, 0x80, 0x01})
+	fieldNum, wireType, err := c.ReadTag()
+	require.NoError(t, err)
+	require.Equal(t, 1, fieldNum, "high bits above 32 must be truncated, matching int32(wire>>3)")
+	require.Equal(t, WireBytes, wireType)
+
+	// Tag varint 80 80 80 80 40 decodes to wire>>3 == 2^31, and
+	// int32(2^31) is negative => illegal tag, exactly as gogoproto rejects it.
+	c = NewWireCursor([]byte{0x80, 0x80, 0x80, 0x80, 0x40})
+	_, _, err = c.ReadTag()
+	require.ErrorIs(t, err, ErrIllegalFieldNumber)
+}
+
+func TestWireCursor_ReadLengthDelimited(t *testing.T) {
+	c := NewWireCursor([]byte{0x03, 'a', 'b', 'c'})
+	b, err := c.ReadLengthDelimited()
+	require.NoError(t, err)
+	require.Equal(t, []byte("abc"), b)
+	require.True(t, c.AtEnd())
+}
+
+func TestWireCursor_ReadLengthDelimited_OutOfBounds(t *testing.T) {
+	// Declares length 5 but only 1 byte follows.
+	c := NewWireCursor([]byte{0x05, 'a'})
+	_, err := c.ReadLengthDelimited()
+	require.ErrorIs(t, err, ErrOutOfBounds)
+}
+
+func TestWireCursor_SkipField(t *testing.T) {
+	testCases := []struct {
+		name     string
+		buf      []byte
+		wireType int
+	}{
+		{"varint", []byte{0xac, 0x02}, WireVarint},
+		{"fixed64", []byte{1, 2, 3, 4, 5, 6, 7, 8}, WireFixed64},
+		{"bytes", []byte{0x02, 'x', 'y'}, WireBytes},
+		{"fixed32", []byte{1, 2, 3, 4}, WireFixed32},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewWireCursor(tc.buf)
+			require.NoError(t, c.SkipField(tc.wireType))
+			require.True(t, c.AtEnd())
+		})
+	}
+}
+
+func TestWireCursor_SkipField_Unsupported(t *testing.T) {
+	c := NewWireCursor([]byte{0x00})
+	// Wire type 3 (start group) is not supported.
+	require.ErrorIs(t, c.SkipField(3), ErrUnsupportedWireType)
+}
+
+func TestWireCursor_SkipField_OutOfBounds(t *testing.T) {
+	// Fixed64 needs 8 bytes; only 2 are present.
+	c := NewWireCursor([]byte{1, 2})
+	require.ErrorIs(t, c.SkipField(WireFixed64), ErrOutOfBounds)
+}

--- a/mempool/cat/filter.go
+++ b/mempool/cat/filter.go
@@ -1,0 +1,125 @@
+package cat
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cometbft/cometbft/internal/protowire"
+	"github.com/cometbft/cometbft/mempool"
+)
+
+// Field numbers within tendermint.mempool.Message and tendermint.mempool.Txs.
+// Both are 1: Txs is the first member of the Message oneof, and the repeated
+// tx entries are the only field of Txs.
+const (
+	fieldMessageTxs = 1 // Message.sum: `Txs txs = 1`
+	fieldTxsEntry   = 1 // Txs: `repeated bytes txs = 1`
+)
+
+var (
+	// ErrEmptyTxEntry is returned when a Txs message carries an entry with no
+	// payload. An empty entry costs almost nothing on the wire but still forces
+	// an allocation when unmarshalled, which is the heap amplification vector
+	// this filter exists to close.
+	ErrEmptyTxEntry = errors.New("mempool message contains an empty transaction entry")
+	// ErrTooManyTxEntries is returned when a Txs message carries more entries
+	// than mempool.MaxTxsPerMessage.
+	ErrTooManyTxEntries = fmt.Errorf("mempool message contains more than %d transaction entries", mempool.MaxTxsPerMessage)
+	// ErrTxTooLarge is returned when a single transaction entry exceeds the
+	// configured maximum transaction size.
+	ErrTxTooLarge = errors.New("transaction exceeds max tx size")
+)
+
+// filterTxsMsgBytesFn returns a p2p RecvMessagePrecheck that rejects abusive
+// Txs messages before they are unmarshalled.
+func filterTxsMsgBytesFn(maxTxSize int) func([]byte) error {
+	return func(msgBytes []byte) error {
+		return filterTxsMsgBytes(msgBytes, maxTxSize)
+	}
+}
+
+// filterTxsMsgBytes walks the raw wire bytes of a tendermint.mempool.Message
+// and rejects Txs submessages that could not have come from an honest peer.
+// Without this check, a small count-packed payload unmarshals into a
+// disproportionately large in-memory structure.
+//
+// Messages that carry no Txs submessage (SeenTx, WantTx) pass through, as does
+// a Txs submessage with no entries: it allocates nothing, so the reactor's own
+// check owns that rejection and keeps the error attributed to the right place.
+//
+// Rules:
+//
+//  1. Well-formed: every varint, tag and length prefix must stay inside the
+//     buffer. Truncated, overflowing or out-of-bounds encodings are rejected.
+//  2. No empty entries: every transaction must carry at least one byte.
+//  3. Per-tx bound: no entry may exceed maxTxSize. A non-positive maxTxSize
+//     disables this check.
+//  4. Entry count: no more than mempool.MaxTxsPerMessage entries, mirroring the
+//     reactor's post-unmarshal check.
+func filterTxsMsgBytes(msgBytes []byte, maxTxSize int) error {
+	msg := protowire.NewWireCursor(msgBytes)
+	for !msg.AtEnd() {
+		fieldNum, wireType, err := msg.ReadTag()
+		if err != nil {
+			return err
+		}
+
+		// Anything that is not the Txs submessage is skipped, so unknown or
+		// future fields do not break the scan.
+		if fieldNum != fieldMessageTxs || wireType != protowire.WireBytes {
+			if err := msg.SkipField(wireType); err != nil {
+				return err
+			}
+			continue
+		}
+
+		txsBytes, err := msg.ReadLengthDelimited()
+		if err != nil {
+			return err
+		}
+		if err := scanTxsSubmessage(txsBytes, maxTxSize); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// scanTxsSubmessage walks a Txs submessage (`repeated bytes txs = 1`) and
+// validates each entry against the limits.
+func scanTxsSubmessage(txsBytes []byte, maxTxSize int) error {
+	txs := protowire.NewWireCursor(txsBytes)
+	count := 0
+	for !txs.AtEnd() {
+		fieldNum, wireType, err := txs.ReadTag()
+		if err != nil {
+			return err
+		}
+
+		if fieldNum != fieldTxsEntry || wireType != protowire.WireBytes {
+			if err := txs.SkipField(wireType); err != nil {
+				return err
+			}
+			continue
+		}
+
+		tx, err := txs.ReadLengthDelimited()
+		if err != nil {
+			return err
+		}
+
+		if len(tx) == 0 {
+			return ErrEmptyTxEntry
+		}
+		if maxTxSize > 0 && len(tx) > maxTxSize {
+			return fmt.Errorf("%w: %d > %d", ErrTxTooLarge, len(tx), maxTxSize)
+		}
+
+		count++
+		if count > mempool.MaxTxsPerMessage {
+			return ErrTooManyTxEntries
+		}
+	}
+
+	return nil
+}

--- a/mempool/cat/filter_test.go
+++ b/mempool/cat/filter_test.go
@@ -1,0 +1,168 @@
+package cat
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/mempool"
+	protomem "github.com/cometbft/cometbft/proto/tendermint/mempool"
+)
+
+const testMaxTxSize = 1024
+
+func mustMarshalMempoolMsg(t *testing.T, msg *protomem.Message) []byte {
+	t.Helper()
+	bz, err := msg.Marshal()
+	require.NoError(t, err)
+	return bz
+}
+
+func txsMsgBytes(t *testing.T, txs ...[]byte) []byte {
+	t.Helper()
+	return mustMarshalMempoolMsg(t, &protomem.Message{
+		Sum: &protomem.Message_Txs{Txs: &protomem.Txs{Txs: txs}},
+	})
+}
+
+func TestFilterTxsMsgBytes(t *testing.T) {
+	testCases := []struct {
+		name    string
+		msgB    []byte
+		wantErr error
+	}{
+		{
+			name: "single valid tx",
+			msgB: txsMsgBytes(t, []byte("a valid transaction")),
+		},
+		{
+			name: "tx of exactly max size",
+			msgB: txsMsgBytes(t, bytes.Repeat([]byte("x"), testMaxTxSize)),
+		},
+		{
+			name:    "tx over max size",
+			msgB:    txsMsgBytes(t, bytes.Repeat([]byte("x"), testMaxTxSize+1)),
+			wantErr: ErrTxTooLarge,
+		},
+		{
+			// The heap amplification vector: an empty entry costs ~2 bytes on
+			// the wire but forces an allocation when unmarshalled.
+			name:    "single empty tx entry",
+			msgB:    txsMsgBytes(t, []byte{}),
+			wantErr: ErrEmptyTxEntry,
+		},
+		{
+			name:    "many empty tx entries",
+			msgB:    txsMsgBytes(t, make([][]byte, 10_000)...),
+			wantErr: ErrEmptyTxEntry,
+		},
+		{
+			name:    "more entries than MaxTxsPerMessage",
+			msgB:    txsMsgBytes(t, []byte("tx one"), []byte("tx two")),
+			wantErr: ErrTooManyTxEntries,
+		},
+		{
+			// SeenTx and WantTx share the mempool channels with Txs and must
+			// pass through untouched.
+			name: "SeenTx passes through",
+			msgB: mustMarshalMempoolMsg(t, &protomem.Message{
+				Sum: &protomem.Message_SeenTx{SeenTx: &protomem.SeenTx{TxKey: bytes.Repeat([]byte{1}, 32)}},
+			}),
+		},
+		{
+			name: "WantTx passes through",
+			msgB: mustMarshalMempoolMsg(t, &protomem.Message{
+				Sum: &protomem.Message_WantTx{WantTx: &protomem.WantTx{TxKey: bytes.Repeat([]byte{1}, 32)}},
+			}),
+		},
+		{
+			name: "empty buffer passes through",
+			msgB: nil,
+		},
+		{
+			// A Txs submessage carrying no entries allocates nothing, so it is
+			// left to the reactor to reject with its own error.
+			name: "Txs with no entries passes through",
+			msgB: txsMsgBytes(t),
+		},
+		{
+			name:    "truncated length prefix",
+			msgB:    []byte{0x0a, 0x05},
+			wantErr: nil, // errors, but with a wire-level error; asserted below
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := filterTxsMsgBytes(tc.msgB, testMaxTxSize)
+			switch {
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+			case tc.name == "truncated length prefix":
+				require.Error(t, err)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestFilterTxsMsgBytes_Malformed checks that malformed wire bytes are rejected
+// rather than panicking.
+func TestFilterTxsMsgBytes_Malformed(t *testing.T) {
+	malformed := [][]byte{
+		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, // varint overflow
+		{0x0a},             // tag with no length
+		{0x0a, 0x02, 0x0a}, // nested length runs past the buffer
+		{0x00},             // field number 0
+	}
+	for _, msgB := range malformed {
+		require.Error(t, filterTxsMsgBytes(msgB, testMaxTxSize), "bytes: %x", msgB)
+	}
+}
+
+// TestFilterTxsMsgBytes_UnknownFieldsSkipped ensures the scan tolerates fields
+// it does not know about instead of rejecting the message.
+func TestFilterTxsMsgBytes_UnknownFieldsSkipped(t *testing.T) {
+	// field 15, wire type 0 (varint), value 1 — not a known Message member.
+	unknown := []byte{0x78, 0x01}
+	require.NoError(t, filterTxsMsgBytes(unknown, testMaxTxSize))
+}
+
+// TestFilterTxsMsgBytes_MatchesReactorLimit pins the pre-unmarshal entry cap to
+// the post-unmarshal check in the reactor.
+func TestFilterTxsMsgBytes_MatchesReactorLimit(t *testing.T) {
+	txs := make([][]byte, 0, mempool.MaxTxsPerMessage+1)
+	for range mempool.MaxTxsPerMessage {
+		txs = append(txs, []byte("tx"))
+	}
+	require.NoError(t, filterTxsMsgBytes(txsMsgBytes(t, txs...), testMaxTxSize))
+
+	txs = append(txs, []byte("one too many"))
+	require.ErrorIs(t, filterTxsMsgBytes(txsMsgBytes(t, txs...), testMaxTxSize), ErrTooManyTxEntries)
+}
+
+// TestReactorChannelsPrecheckTxs ensures the filter is actually wired to every
+// channel that can carry transactions, and that the wired limit tracks the
+// reactor's configured MaxTxSize.
+func TestReactorChannelsPrecheckTxs(t *testing.T) {
+	reactor, _ := setupReactor(t)
+
+	prechecks := make(map[byte]func([]byte) error)
+	for _, chDesc := range reactor.GetChannels() {
+		prechecks[chDesc.ID] = chDesc.RecvMessagePrecheck
+	}
+
+	for _, chID := range []byte{mempool.MempoolChannel, MempoolDataChannel} {
+		precheck := prechecks[chID]
+		require.NotNil(t, precheck, "channel %#x carries txs but has no precheck", chID)
+
+		require.ErrorIs(t, precheck(txsMsgBytes(t, []byte{})), ErrEmptyTxEntry)
+		require.NoError(t, precheck(txsMsgBytes(t, []byte("a valid transaction"))))
+
+		maxTxSize := reactor.opts.MaxTxSize
+		require.NoError(t, precheck(txsMsgBytes(t, bytes.Repeat([]byte("x"), maxTxSize))))
+		require.ErrorIs(t, precheck(txsMsgBytes(t, bytes.Repeat([]byte("x"), maxTxSize+1))), ErrTxTooLarge)
+	}
+}

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -234,6 +234,12 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 		},
 	}
 
+	// Reject abusive Txs messages before they are unmarshalled. Both channels
+	// below can carry transactions, so both are sized to hold a maximum-size
+	// tx; without this precheck a peer could pack that budget with empty
+	// entries and amplify it into a much larger heap allocation.
+	filterTxsBytes := filterTxsMsgBytesFn(memR.opts.MaxTxSize)
+
 	return []*p2p.ChannelDescriptor{
 		{
 			ID:                  mempool.MempoolChannel,
@@ -241,6 +247,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 			SendQueueCapacity:   10,
 			RecvMessageCapacity: txMsg.Size(),
 			MessageType:         &protomem.Message{},
+			RecvMessagePrecheck: filterTxsBytes,
 		},
 		{
 			ID:                  MempoolDataChannel,
@@ -248,6 +255,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 			SendQueueCapacity:   1000,
 			RecvMessageCapacity: txMsg.Size(),
 			MessageType:         &protomem.Message{},
+			RecvMessagePrecheck: filterTxsBytes,
 		},
 		{
 			ID:                  MempoolWantsChannel,


### PR DESCRIPTION
Backports the mempool heap amplification fix from upstream CometBFT v0.38.25 ([cometbft#5946](https://github.com/cometbft/cometbft/pull/5946) + the follow-up [cometbft#5948](https://github.com/cometbft/cometbft/pull/5948)), adapted for the CAT reactor. Triage: #3194.

## Problem

`mempool/cat/reactor.go` rejects empty and over-count tx batches only *after* unmarshalling. A `Txs` message packed with empty entries costs ~2 bytes per entry on the wire but forces an allocation each, so a 1MB message (`RecvMessageCapacity` is `MaxTxSize`) amplifies into tens of MB of heap before any check runs — per message, per peer.

## Fix

Scan the raw wire bytes through the existing `RecvMessagePrecheck` hook on both tx-carrying channels, rejecting empty entries, oversized txs, and more entries than `mempool.MaxTxsPerMessage`. `SeenTx`/`WantTx` and a `Txs` submessage with no entries pass through — the latter allocates nothing, so the reactor keeps owning that error.

Upstream wires this via a new `MsgBytesFilter` reactor interface; we already have `RecvMessagePrecheck` (used by blocksync), so this uses that instead. `internal/protowire` is taken from upstream verbatim, with its tests, and includes cometbft#5948's `int32` truncation fix in `ReadTag`.

Tests cover the filter directly and assert it is wired to every tx-carrying channel — the wiring test fails without the `GetChannels` change.