### PR TITLE
docs: document v0.40.x and correct the celestia-app version mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,12 @@ Celestia-core is a fork of CometBFT (formerly Tendermint) — a BFT consensus en
 
 **Active branches:**
 - `main`: Development for celestia-app
+- `v0.40.x`: Current release line, used by celestia-app `v9.x` (no `-celestia` suffix)
+- `v0.39.x-celestia`: Used by celestia-app `v6.x`
 
-PRs should generally target `main` first, then backport to `v0.39.x-celestia` using the `backport-to-v0.39.x` label.
+PRs should generally target `main` first, then be backported to the release branches the fix applies to. Mergify handles this via labels: `backport-to-v0.40.x`, `backport-to-v0.39.x`, `backport-to-v0.38.x`, `backport-to-v0.34.x`. See `.github/mergify.yml` for the full list.
+
+Note that `main` and `v0.40.x` have diverged from the older release branches in ways that decide whether a backport is even possible — for example the CAT-only mempool (no `clist`) and the `RecvMessagePrecheck` p2p hook exist on `main` and `v0.40.x` but not on `v0.39.x-celestia`. Check that the code path exists on the target branch before labeling.
 
 ## Build Commands
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ make proto-gen
 
 - `main` is the canonical branch for development. Most PRs should target this branch and optionally be backported to a release branch.
 - `v0.40.x` was cut from `main` and is based on CometBFT `v0.38.x`. Releases from this branch look like `v0.40.0` and are used by celestia-app `v9.x`. Note this branch has no `-celestia` suffix.
-- `v0.39.x-celestia` was based on CometBFT `v0.38.x`. Releases from this branch look like `v0.39.0` and are used by celestia-app `v6.x`.
-- `v0.38.x-celestia` was based on CometBFT `v0.38.x`. Releases from this branch look like `v1.54.1-tm-v0.38.17` and are used by celestia-app `v4.x`.
-- `v0.34.x-celestia` was based on CometBFT `v0.34.x`. Releases from this branch look like `v1.52.1-tm-v0.34.35` and are used by celestia-app `v3.x`.
+- `v0.39.x-celestia` was based on CometBFT `v0.38.x`. Releases from this branch look like `v0.39.0` and are used by celestia-app `v6.x` through `v8.x`.
+- `v0.38.x-celestia` was based on CometBFT `v0.38.x`. Releases from this branch look like `v1.54.1-tm-v0.38.17` and are used by celestia-app `v4.x` and `v5.x`.
+- `v0.34.x-celestia` was based on CometBFT `v0.34.x`. Releases from this branch look like `v1.52.1-tm-v0.34.35` and are used by celestia-app `v1.x` through `v3.x`. Newer celestia-app versions still depend on this branch to multiplex ABCI v1 requests, via a `github.com/tendermint/tendermint` replace directive.
+
+The `replace` directives in [celestia-app's `go.mod`](https://github.com/celestiaorg/celestia-app/blob/main/go.mod) are the source of truth for which celestia-core version a given celestia-app branch consumes.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ make proto-gen
 ## Branches
 
 - `main` is the canonical branch for development. Most PRs should target this branch and optionally be backported to a release branch.
+- `v0.40.x` was cut from `main` and is based on CometBFT `v0.38.x`. Releases from this branch look like `v0.40.0` and are used by celestia-app `v9.x`. Note this branch has no `-celestia` suffix.
 - `v0.39.x-celestia` was based on CometBFT `v0.38.x`. Releases from this branch look like `v0.39.0` and are used by celestia-app `v6.x`.
 - `v0.38.x-celestia` was based on CometBFT `v0.38.x`. Releases from this branch look like `v1.54.1-tm-v0.38.17` and are used by celestia-app `v4.x`.
 - `v0.34.x-celestia` was based on CometBFT `v0.34.x`. Releases from this branch look like `v1.52.1-tm-v0.34.35` and are used by celestia-app `v3.x`.


### PR DESCRIPTION
## `v0.40.x` was undocumented

`v0.40.x` is the branch celestia-app `v9.x` consumes (`v9.0.4` pins celestia-core `v0.40.6`; app `main` pins `v0.40.7`), but it was missing from the README's branch list and from `CLAUDE.md`, which named only the `backport-to-v0.39.x` label.

That gap has a concrete cost: while triaging #3194 I initially labeled backports for `v0.39.x` only and nearly missed the current release line.

- **README**: add `v0.40.x` to `## Branches`, including that it has no `-celestia` suffix
- **CLAUDE.md**: list `v0.40.x` and `v0.39.x-celestia` as active branches, name all four Mergify backport labels, and note that branch divergence (CAT-only mempool, the `RecvMessagePrecheck` p2p hook) decides whether a backport is possible at all

## The app version mapping was stale

Each entry claimed a single celestia-app major, but most branches serve several. Checked the `replace` directives on every celestia-app release branch:

| celestia-core branch | celestia-app | was documented as |
|---|---|---|
| `v0.40.x` | `v9.x` | *missing* |
| `v0.39.x-celestia` | `v6.x`–`v8.x` | `v6.x` |
| `v0.38.x-celestia` | `v4.x`, `v5.x` | `v4.x` |
| `v0.34.x-celestia` | `v1.x`–`v3.x` | `v3.x` |

Also noted that `v0.34.x-celestia` is still pulled in by newer app versions via a `github.com/tendermint/tendermint` replace to multiplex ABCI v1 requests, and pointed at celestia-app's `go.mod` as the source of truth so the table degrades gracefully as pins move.

Docs only, no code changes.