### PR TITLE
fix(consensus): require the committed part set before finalizing

### DIFF
--- a/.changelog/unreleased/bug-fixes/3222-commit-part-set-identity.md
+++ b/.changelog/unreleased/bug-fixes/3222-commit-part-set-identity.md
@@ -1,7 +1,0 @@
-- `[consensus]` Require the committed part set, not just a matching
-  `BlockID.Hash`, before finalizing a commit. `enterCommit` now refetches when
-  the part set header differs, `addVote` clears `ProposalBlock` when it discards
-  the parts that block was decoded from, and `tryFinalizeCommit` waits for a
-  complete matching part set instead of letting `finalizeCommit` and the block
-  store panic.
-  ([\#3222](https://github.com/celestiaorg/celestia-core/issues/3222))

--- a/.changelog/unreleased/bug-fixes/3222-commit-part-set-identity.md
+++ b/.changelog/unreleased/bug-fixes/3222-commit-part-set-identity.md
@@ -1,0 +1,7 @@
+- `[consensus]` Require the committed part set, not just a matching
+  `BlockID.Hash`, before finalizing a commit. `enterCommit` now refetches when
+  the part set header differs, `addVote` clears `ProposalBlock` when it discards
+  the parts that block was decoded from, and `tryFinalizeCommit` waits for a
+  complete matching part set instead of letting `finalizeCommit` and the block
+  store panic.
+  ([\#3222](https://github.com/celestiaorg/celestia-core/issues/3222))

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1867,7 +1867,11 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 	}
 
 	// If we don't have the block being committed, set up to get it.
-	if !cs.rs.ProposalBlock.HashesTo(blockID.Hash) {
+	//
+	// Both halves of the BlockID have to match. A block hash does not uniquely
+	// determine the serialized body, so a block that hashes to blockID.Hash is
+	// not necessarily the body the network committed to.
+	if !cs.rs.ProposalBlock.HashesTo(blockID.Hash) || !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 		if !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 			logger.Info(
 				"commit is for a block we do not know about; set ProposalBlock=nil",
@@ -1877,7 +1881,6 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 
 			// We're getting the wrong block.
 			// Set up ProposalBlockParts and keep waiting.
-			cs.rs.ProposalBlock = nil
 			cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 			psh := blockID.PartSetHeader
 			cs.propagator.AddCommitment(height, commitRound, &psh)
@@ -1888,6 +1891,11 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 
 			cs.evsw.FireEvent(types.EventValidBlock, &cs.rs)
 		}
+
+		// Whatever block we were holding was not built from the part set being
+		// committed, so it cannot be the block to finalize even if it happens
+		// to hash to blockID.Hash. Drop it and wait for the committed parts.
+		cs.rs.ProposalBlock = nil
 	}
 }
 
@@ -1910,6 +1918,20 @@ func (cs *State) tryFinalizeCommit(height int64) {
 		// TODO: ^^ wait, why does it matter that we're a validator?
 		logger.Debug(
 			"failed attempt to finalize commit; we do not have the commit block",
+			"proposal_block", log.NewLazyBlockHash(cs.rs.ProposalBlock),
+			"commit_block", blockID.Hash,
+		)
+		return
+	}
+
+	// Hashing to blockID.Hash is not on its own enough to finalize: the part
+	// set we hold must also be the committed one, and it must be complete.
+	// finalizeCommit asserts both and panics otherwise, and the block store
+	// panics when handed an incomplete part set. Wait instead. Once the
+	// committed parts arrive, handleCompleteProposal calls back in here.
+	if !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) || !cs.rs.ProposalBlockParts.IsComplete() {
+		logger.Debug(
+			"failed attempt to finalize commit; we do not have the complete commit block parts",
 			"proposal_block", log.NewLazyBlockHash(cs.rs.ProposalBlock),
 			"commit_block", blockID.Hash,
 		)
@@ -2656,6 +2678,12 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 				}
 
 				if !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
+					// We are throwing away the parts collected so far, so any
+					// block decoded from them is stale. ProposalBlock may still
+					// hash to blockID.Hash while having been built from a
+					// different part set, so clear it explicitly rather than
+					// relying on the hash comparison above.
+					cs.rs.ProposalBlock = nil
 					cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 					psh := blockID.PartSetHeader
 					cs.propagator.AddCommitment(height, vote.Round, &psh)

--- a/consensus/state_partset_identity_test.go
+++ b/consensus/state_partset_identity_test.go
@@ -1,0 +1,113 @@
+package consensus
+
+import (
+	"context"
+	"testing"
+
+	cstypes "github.com/cometbft/cometbft/consensus/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/require"
+)
+
+// aliasBlock returns a copy of block whose Data.SquareSize differs but whose
+// header, and therefore block hash, is identical. Data.Hash() does not cover
+// SquareSize while Data.ToProto() serializes it, so the copy has the same block
+// hash and a different PartSetHeader.
+func aliasBlock(t *testing.T, block *types.Block) *types.Block {
+	t.Helper()
+
+	data := types.NewData(block.Txs, block.SquareSize+(uint64(1)<<63), block.DataHash)
+	alias := types.MakeBlock(block.Height, data, block.LastCommit, block.Evidence.Evidence)
+	alias.Header = block.Header
+
+	require.Equal(t, block.Hash(), alias.Hash(), "alias must share the block hash")
+	return alias
+}
+
+// TestBlockHashDoesNotDeterminePartSetHeader documents the property the checks
+// below defend against: a block hash does not uniquely determine the serialized
+// body, so BlockID.Hash matching is not proof that the part set matches too.
+func TestBlockHashDoesNotDeterminePartSetHeader(t *testing.T) {
+	cs, _ := randState(1)
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+
+	require.NoError(t, alias.ValidateBasic())
+	require.NotEqual(t, parts.Header(), aliasParts.Header(),
+		"the two bodies must have distinct part set headers")
+}
+
+// TestEnterCommitDropsBlockFromDifferentPartSet checks that a node holding a
+// block that hashes to the committed BlockID, but which was built from a
+// different part set, drops that block and waits for the committed parts
+// instead of finalizing. Before this was handled, enterCommit left
+// ProposalBlock paired with a part set the commit did not refer to and
+// finalizeCommit panicked.
+func TestEnterCommitDropsBlockFromDifferentPartSet(t *testing.T) {
+	cs, vss := randState(4)
+	height, round := cs.rs.Height, cs.rs.Round
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	// We hold the block built from our own part set.
+	cs.rs.ProposalBlock = block
+	cs.rs.ProposalBlockParts = parts
+
+	// The rest of the network commits the aliased body: same hash, different
+	// part set header.
+	committed := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for _, vote := range signVotes(cmtproto.PrecommitType, committed.Hash, committed.PartSetHeader, true, vss[1:]...) {
+		added, err := cs.rs.Votes.AddVote(vote, "peer", true)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	require.NotPanics(t, func() { cs.enterCommit(height, round) })
+
+	require.Nil(t, cs.rs.ProposalBlock,
+		"the block we held was not built from the committed part set, so it must be dropped")
+	require.Equal(t, committed.PartSetHeader, cs.rs.ProposalBlockParts.Header(),
+		"we must be collecting the committed part set")
+	require.False(t, cs.rs.ProposalBlockParts.IsComplete())
+}
+
+// TestTryFinalizeCommitWaitsForCompletePartSet checks that tryFinalizeCommit
+// declines to finalize when the part set matches the commit but is not yet
+// complete. finalizeCommit would otherwise hand an incomplete part set to the
+// block store, which panics.
+func TestTryFinalizeCommitWaitsForCompletePartSet(t *testing.T) {
+	cs, vss := randState(4)
+	height, round := cs.rs.Height, cs.rs.Round
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	// We hold the committed block, but only an empty part set for it.
+	cs.rs.ProposalBlock = block
+	cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header(), types.BlockPartSizeBytes)
+	cs.rs.Step = cstypes.RoundStepCommit
+	cs.rs.CommitRound = round
+
+	committed := types.BlockID{Hash: block.Hash(), PartSetHeader: parts.Header()}
+	for _, vote := range signVotes(cmtproto.PrecommitType, committed.Hash, committed.PartSetHeader, true, vss[1:]...) {
+		added, err := cs.rs.Votes.AddVote(vote, "peer", true)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	require.NotPanics(t, func() { cs.tryFinalizeCommit(height) })
+
+	require.Equal(t, height, cs.rs.Height, "must not have advanced past the height")
+}


### PR DESCRIPTION
Defence in depth for [PROTOCO-2276](https://linear.app/celestia/issue/PROTOCO-2276/processproposal-squaresize-check-overflows-allowing-a-malformed-square). See the Linear issue for details and rationale.

`BlockID` has two halves, but three places in `consensus/state.go` treated `BlockID.Hash` on its own as sufficient to identify the block being committed. This tightens all three to require the committed part set as well.

No serialization, hashing, or wire format changes — these are node-local state transitions, so the change is non-breaking and needs no coordinated upgrade.

## Test plan

- [x] New tests in `consensus/state_partset_identity_test.go` fail before the change and pass after
- [x] `go test ./consensus/... ./state/... ./store/...` and `golangci-lint run ./consensus/...` pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCNuxBmGto4Yg9ZWFvm6XK