### PR TITLE
chore: remove leftover .changelog entries

### DIFF
--- a/.changelog/unreleased/bug-fixes/2967-broadcast-to-listeners-non-blocking.md
+++ b/.changelog/unreleased/bug-fixes/2967-broadcast-to-listeners-non-blocking.md
@@ -1,7 +1,0 @@
-- Fix gRPC `BlockAPI.broadcastToListeners` holding the global mutex while
-  sending to subscriber channels. A slow subscriber would block the
-  broadcaster, starving every other subscriber and growing the EventBus
-  subscription buffer until the process was OOM-killed. The broadcaster
-  now snapshots listeners under the lock and does non-blocking sends
-  outside it. Server-side gRPC keepalive params were also added so dead
-  client connections get reaped. ([\#2967](https://github.com/celestiaorg/celestia-core/issues/2967))

--- a/.changelog/unreleased/bug-fixes/3003-blockapi-stop-deadlock.md
+++ b/.changelog/unreleased/bug-fixes/3003-blockapi-stop-deadlock.md
@@ -1,9 +1,0 @@
-- Fix `BlockAPI.Stop()` deadlocking the gRPC streaming API on shutdown.
-  `Stop` acquired `blockAPI.Lock()` and then called `closeAllListeners`,
-  which tried to acquire the same non-reentrant mutex. Renamed the helper
-  to `closeAllListenersLocked` (caller now holds the lock). Also removed
-  a `newBlockSubscription = nil` assignment that raced with
-  `StartNewBlockEventListener`. Fixed the same reentrant-mutex pattern in
-  `broadcastToListeners`: the recover path now calls a
-  `removeHeightListenerLocked` helper instead of re-acquiring the lock.
-  ([\#3003](https://github.com/celestiaorg/celestia-core/issues/3003))

--- a/.changelog/unreleased/bug-fixes/3005-lock-newblocksubscription.md
+++ b/.changelog/unreleased/bug-fixes/3005-lock-newblocksubscription.md
@@ -1,4 +1,0 @@
-- Lock-protect the initial write to `BlockAPI.newBlockSubscription` in
-  `StartNewBlockEventListener` so all writes to the field are consistently
-  synchronized with `Stop` and `retryNewBlocksSubscription`.
-  ([\#3005](https://github.com/celestiaorg/celestia-core/issues/3005))

--- a/.changelog/unreleased/improvements/3073-log-pruning-progress.md
+++ b/.changelog/unreleased/improvements/3073-log-pruning-progress.md
@@ -1,5 +1,0 @@
-- Log a warning before `PruneBlocks` works through a large block backlog (more
-  than 100 blocks), reporting how many blocks will be pruned and that it pauses
-  block syncing until complete, so the synchronous pause is expected instead of
-  looking like a hang.
-  ([\#3073](https://github.com/celestiaorg/celestia-core/pull/3073))


### PR DESCRIPTION
## Motivation

#3019 dropped the changelog system: it deleted `.changelog/`, removed the `## Changelog` section from `CONTRIBUTING.md`, and updated `CLAUDE.md` to tell agents not to create entries. But four entry files crept back in afterwards, via PRs authored before that merged (#3002, #3004, #3007, #3073):

```
.changelog/unreleased/bug-fixes/2967-broadcast-to-listeners-non-blocking.md
.changelog/unreleased/bug-fixes/3003-blockapi-stop-deadlock.md
.changelog/unreleased/bug-fixes/3005-lock-newblocksubscription.md
.changelog/unreleased/improvements/3073-log-pruning-progress.md
```

This deletes them, so the tree matches what `CLAUDE.md` already claims ("This repo no longer maintains a `.changelog/` directory").

`CLAUDE.md` needs no change on `main` — #3019 already added the instruction. The companion PR to `v0.40.x` carries that instruction over, since that branch still tells agents every PR needs an entry.

## Verification

- `grep -rn '\.changelog\|unclog'` over workflows, Makefile, and scripts: no CI job or script consumes `.changelog/`
- `CHANGELOG.md` untouched — kept as a frozen historical record

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qjy4CCWnjBfKeuejp4gwXp