### PR TITLE
feat!(rpc): harden rpc endpoints

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,21 @@
 
 This guide provides instructions for upgrading to specific versions of CometBFT.
 
+## Unreleased
+
+### RPC Changes
+
+* Added a new RPC config option `max_concurrent_heavy_requests` (default: `20`)
+  that bounds how many "heavy" responses (full blocks, block results, unbounded
+  search sets, share and data-root proofs) are built concurrently. All
+  transports (HTTP JSON-RPC, URI, WebSocket and gRPC) share a single budget.
+  When the budget is saturated, heavy requests are rejected with HTTP `503`
+  (gRPC: `ResourceExhausted`) instead of being served; light endpoints are
+  unaffected. Clients calling heavy endpoints should retry on
+  `503`/`ResourceExhausted` with backoff. Set the option to `0` to use the
+  built-in default, or to a negative value to disable the limit (not
+  recommended).
+
 ## v0.38.13
 
 It is recommended that CometBFT be built with Go v1.22+ since v1.21 is no longer

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,12 +10,12 @@ This guide provides instructions for upgrading to specific versions of CometBFT.
   that bounds how many "heavy" responses (full blocks, block results, unbounded
   search sets, share and data-root proofs) are built concurrently. All
   transports (HTTP JSON-RPC, URI, WebSocket and gRPC) share a single budget.
-  When the budget is saturated, heavy requests are rejected with HTTP `503`
-  (gRPC: `ResourceExhausted`) instead of being served; light endpoints are
-  unaffected. Clients calling heavy endpoints should retry on
-  `503`/`ResourceExhausted` with backoff. Set the option to `0` to use the
-  built-in default, or to a negative value to disable the limit (not
-  recommended).
+  When the budget is saturated, excess heavy requests are rejected fast: the URI
+  (GET) handler returns HTTP `503`, the JSON-RPC and WebSocket paths return a
+  JSON-RPC error, and gRPC returns `ResourceExhausted`; light endpoints are
+  unaffected. Clients calling heavy endpoints should retry with backoff. Set the
+  option to `0` to use the built-in default, or to a negative value to disable
+  the limit (not recommended).
 
 ## v0.38.13
 

--- a/config/config.go
+++ b/config/config.go
@@ -416,8 +416,15 @@ type RPCConfig struct {
 	// When saturated, excess heavy requests are rejected fast: the URI (GET)
 	// handler returns HTTP 503, the JSON-RPC and WebSocket paths return a
 	// JSON-RPC error, and gRPC returns ResourceExhausted; light endpoints are
-	// unaffected. This bounds how many heavy responses are built at once; it is
-	// not a hard byte cap (response serialization is not counted).
+	// unaffected.
+	//
+	// This is a request count, not a byte budget, so size it against RAM:
+	//   max_concurrent_heavy_requests * peak_response_bytes < spare_RAM
+	// peak_response_bytes is the largest single response the node serves; count
+	// serialization too, so roughly 2x the payload. Payload per heavy request:
+	// block/block_results/tx/proofs ~ one block; block_search ~ per_page blocks;
+	// unconfirmed_txs (limit=-1) ~ the mempool's max_txs_bytes. spare_RAM is
+	// total RAM minus the mempool, app state and OS; leave headroom.
 	// 0 - use the built-in default; negative - unlimited (not recommended).
 	MaxConcurrentHeavyRequests int `mapstructure:"max_concurrent_heavy_requests"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -413,9 +413,11 @@ type RPCConfig struct {
 	// single budget). Heavy endpoints (block, block_results, tx_search, share
 	// proofs, etc.) can each materialize a full block or a large result set in
 	// memory, so without a cap a burst of concurrent requests can OOM the node.
-	// Excess heavy requests are rejected with HTTP 503 (gRPC: ResourceExhausted);
-	// light endpoints are unaffected. This counts requests, not bytes: worst-case
-	// memory is roughly this value times the heaviest single response.
+	// When saturated, excess heavy requests are rejected fast: the URI (GET)
+	// handler returns HTTP 503, the JSON-RPC and WebSocket paths return a
+	// JSON-RPC error, and gRPC returns ResourceExhausted; light endpoints are
+	// unaffected. This bounds how many heavy responses are built at once; it is
+	// not a hard byte cap (response serialization is not counted).
 	// 0 - use the built-in default; negative - unlimited (not recommended).
 	MaxConcurrentHeavyRequests int `mapstructure:"max_concurrent_heavy_requests"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,10 @@ const (
 	// DefaultMaxPersistentStickyPeers caps how many persistent peers are guaranteed
 	// in the SeenTx broadcast set per signer when the config field is unset.
 	DefaultMaxPersistentStickyPeers = 4
+
+	// DefaultMaxConcurrentHeavyRequests is the default cap on concurrently built
+	// heavy RPC responses (see RPCConfig.MaxConcurrentHeavyRequests).
+	DefaultMaxConcurrentHeavyRequests = 20
 )
 
 // NOTE: Most of the structs & relevant comments + the
@@ -404,6 +408,17 @@ type RPCConfig struct {
 	// 1024 - 40 - 10 - 50 = 924 = ~900
 	MaxOpenConnections int `mapstructure:"max_open_connections"`
 
+	// Maximum number of "heavy" RPC responses built concurrently across all
+	// connections and transports (HTTP JSON-RPC, URI, WebSocket and gRPC share a
+	// single budget). Heavy endpoints (block, block_results, tx_search, share
+	// proofs, etc.) can each materialize a full block or a large result set in
+	// memory, so without a cap a burst of concurrent requests can OOM the node.
+	// Excess heavy requests are rejected with HTTP 503 (gRPC: ResourceExhausted);
+	// light endpoints are unaffected. This counts requests, not bytes: worst-case
+	// memory is roughly this value times the heaviest single response.
+	// 0 - use the built-in default; negative - unlimited (not recommended).
+	MaxConcurrentHeavyRequests int `mapstructure:"max_concurrent_heavy_requests"`
+
 	// Maximum number of unique clientIDs that can /subscribe
 	// If you're using /broadcast_tx_commit, set to the estimated maximum number
 	// of broadcast_tx_commit calls per block.
@@ -488,6 +503,8 @@ func DefaultRPCConfig() *RPCConfig {
 
 		Unsafe:             false,
 		MaxOpenConnections: 900,
+
+		MaxConcurrentHeavyRequests: DefaultMaxConcurrentHeavyRequests,
 
 		MaxSubscriptionClients:    100,
 		MaxSubscriptionsPerClient: 5,

--- a/config/toml.go
+++ b/config/toml.go
@@ -185,6 +185,15 @@ unsafe = {{ .RPC.Unsafe }}
 # 1024 - 40 - 10 - 50 = 924 = ~900
 max_open_connections = {{ .RPC.MaxOpenConnections }}
 
+# Maximum number of "heavy" RPC responses (full blocks, block results, large
+# search sets) built concurrently across all connections and transports (HTTP
+# and gRPC share one budget). Excess heavy requests are rejected with HTTP 503
+# (gRPC: ResourceExhausted) while light endpoints stay unaffected. This counts
+# requests, not bytes: worst-case memory is roughly this value times one heavy
+# response. Raise it on nodes with more RAM that serve heavy RPC traffic.
+# 0 - use the built-in default; negative - unlimited (not recommended).
+max_concurrent_heavy_requests = {{ .RPC.MaxConcurrentHeavyRequests }}
+
 # Maximum number of unique clientIDs that can /subscribe
 # If you're using /broadcast_tx_commit, set to the estimated maximum number
 # of broadcast_tx_commit calls per block.

--- a/config/toml.go
+++ b/config/toml.go
@@ -190,8 +190,16 @@ max_open_connections = {{ .RPC.MaxOpenConnections }}
 # and gRPC share one budget). When saturated, excess heavy requests are rejected
 # fast: the URI (GET) handler returns HTTP 503, the JSON-RPC and WebSocket paths
 # return a JSON-RPC error, and gRPC returns ResourceExhausted; light endpoints
-# stay unaffected. This bounds how many heavy responses are built at once; it is
-# not a hard byte cap (response serialization is not counted).
+# stay unaffected.
+#
+# This is a request count, not a byte budget, so size it against available RAM:
+#   max_concurrent_heavy_requests * peak_response_bytes < spare_RAM
+# peak_response_bytes is the largest single response the node serves; count
+# serialization too, so roughly 2x the payload. Payload per heavy request:
+#   - block / block_results / tx / proofs:  ~ one block (block max_bytes)
+#   - block_search:                          ~ per_page blocks
+#   - unconfirmed_txs (limit=-1):            ~ mempool max_txs_bytes
+# spare_RAM is total RAM minus the mempool, app state and OS; leave headroom.
 # 0 - use the built-in default; negative - unlimited (not recommended).
 max_concurrent_heavy_requests = {{ .RPC.MaxConcurrentHeavyRequests }}
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -185,22 +185,18 @@ unsafe = {{ .RPC.Unsafe }}
 # 1024 - 40 - 10 - 50 = 924 = ~900
 max_open_connections = {{ .RPC.MaxOpenConnections }}
 
-# Maximum number of "heavy" RPC responses (full blocks, block results, large
-# search sets) built concurrently across all connections and transports (HTTP
-# and gRPC share one budget). When saturated, excess heavy requests are rejected
-# fast: the URI (GET) handler returns HTTP 503, the JSON-RPC and WebSocket paths
-# return a JSON-RPC error, and gRPC returns ResourceExhausted; light endpoints
-# stay unaffected.
+# Maximum number of memory-intensive RPC requests processed concurrently.
+# Higher values increase RPC capacity but also increase peak memory usage.
+# For blocks up to 32 MiB, use this conservative starting point:
 #
-# This is a request count, not a byte budget, so size it against available RAM:
-#   max_concurrent_heavy_requests * peak_response_bytes < spare_RAM
-# peak_response_bytes is the largest single response the node serves; count
-# serialization too, so roughly 2x the payload. Payload per heavy request:
-#   - block / block_results / tx / proofs:  ~ one block (block max_bytes)
-#   - block_search:                          ~ per_page blocks
-#   - unconfirmed_txs (limit=-1):            ~ mempool max_txs_bytes
-# spare_RAM is total RAM minus the mempool, app state and OS; leave headroom.
-# 0 - use the built-in default; negative - unlimited (not recommended).
+#   max_concurrent_heavy_requests = floor(available_RAM_GiB * 1.25)
+#
+# Use the RAM assigned to this node, not the host's total RAM when other
+# services share the machine. Example: 32 GiB  ->  40 requests.
+#
+# Monitor peak memory usage under RPC load and adjust if necessary.
+# 0 uses the built-in default of 20. A negative value disables the limit and is
+# not recommended.
 max_concurrent_heavy_requests = {{ .RPC.MaxConcurrentHeavyRequests }}
 
 # Maximum number of unique clientIDs that can /subscribe

--- a/config/toml.go
+++ b/config/toml.go
@@ -187,10 +187,11 @@ max_open_connections = {{ .RPC.MaxOpenConnections }}
 
 # Maximum number of "heavy" RPC responses (full blocks, block results, large
 # search sets) built concurrently across all connections and transports (HTTP
-# and gRPC share one budget). Excess heavy requests are rejected with HTTP 503
-# (gRPC: ResourceExhausted) while light endpoints stay unaffected. This counts
-# requests, not bytes: worst-case memory is roughly this value times one heavy
-# response. Raise it on nodes with more RAM that serve heavy RPC traffic.
+# and gRPC share one budget). When saturated, excess heavy requests are rejected
+# fast: the URI (GET) handler returns HTTP 503, the JSON-RPC and WebSocket paths
+# return a JSON-RPC error, and gRPC returns ResourceExhausted; light endpoints
+# stay unaffected. This bounds how many heavy responses are built at once; it is
+# not a hard byte cap (response serialization is not counted).
 # 0 - use the built-in default; negative - unlimited (not recommended).
 max_concurrent_heavy_requests = {{ .RPC.MaxConcurrentHeavyRequests }}
 

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -502,15 +502,19 @@ func (env *Environment) fetchDataRootTuples(start, end uint64) ([]DataRootTuple,
 
 	tuples := make([]DataRootTuple, 0, end-start)
 	for height := start; height < end; height++ {
+		// only the header's data root and height are needed
 		//nolint:gosec
-		block := env.BlockStore.LoadBlock(int64(height))
-		if block == nil {
-			return nil, fmt.Errorf("couldn't load block %d", height)
+		meta := env.BlockStore.LoadBlockMeta(int64(height))
+		if meta == nil {
+			return nil, fmt.Errorf("couldn't load block meta %d", height)
+		}
+		if len(meta.Header.DataHash) != 32 {
+			return nil, fmt.Errorf("unexpected data hash length %d at height %d", len(meta.Header.DataHash), height)
 		}
 		tuples = append(tuples, DataRootTuple{
 			//nolint:gosec
-			height:   uint64(block.Height),
-			dataRoot: *(*[32]byte)(block.DataHash),
+			height:   uint64(meta.Header.Height),
+			dataRoot: *(*[32]byte)(meta.Header.DataHash),
 		})
 	}
 	return tuples, nil

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/base64"
 	"fmt"
+	"sync"
 	"time"
 
 	cfg "github.com/cometbft/cometbft/config"
@@ -93,6 +94,29 @@ type Environment struct {
 
 	// cache of chunked genesis data.
 	genChunks []string
+
+	// heavySem bounds concurrent "heavy" RPC responses, shared across all
+	// transports. Built once, lazily, via HeavySem.
+	heavySem     chan struct{}
+	heavySemOnce sync.Once
+}
+
+// HeavySem returns the process-wide semaphore bounding concurrent "heavy" RPC
+// responses, shared across all transports and memoized so every caller draws
+// from the same budget. A zero config value uses the built-in default; a
+// negative value disables the limit (nil semaphore == unlimited).
+func (env *Environment) HeavySem() chan struct{} {
+	env.heavySemOnce.Do(func() {
+		n := env.Config.MaxConcurrentHeavyRequests
+		if n == 0 {
+			n = cfg.DefaultMaxConcurrentHeavyRequests
+		}
+		if n < 0 {
+			return // leave heavySem nil == unlimited
+		}
+		env.heavySem = make(chan struct{}, n)
+	})
+	return env.heavySem
 }
 
 //----------------------------------------------

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -12,7 +12,7 @@ type RoutesMap map[string]*rpc.RPCFunc
 func (env *Environment) GetRoutes() RoutesMap {
 	// heavy gates all large-response routes with a process-wide concurrency
 	// bound, shared with the equivalent gRPC endpoints (see the gRPC interceptors).
-	heavy := rpc.Heavy(env.HeavySem())
+	heavy := rpc.HeavyFn(env.HeavySem())
 	return RoutesMap{
 		// subscribe/unsubscribe are reserved for websocket events.
 		"subscribe":       rpc.NewWSRPCFunc(env.Subscribe, "query"),

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -10,6 +10,9 @@ type RoutesMap map[string]*rpc.RPCFunc
 
 // Routes is a map of available routes.
 func (env *Environment) GetRoutes() RoutesMap {
+	// heavy gates all large-response routes with a process-wide concurrency
+	// bound, shared with the equivalent gRPC endpoints (see the gRPC interceptors).
+	heavy := rpc.Heavy(env.HeavySem())
 	return RoutesMap{
 		// subscribe/unsubscribe are reserved for websocket events.
 		"subscribe":       rpc.NewWSRPCFunc(env.Subscribe, "query"),
@@ -23,21 +26,21 @@ func (env *Environment) GetRoutes() RoutesMap {
 		"blockchain":           rpc.NewRPCFunc(env.BlockchainInfo, "minHeight,maxHeight", rpc.Cacheable()),
 		"genesis":              rpc.NewRPCFunc(env.Genesis, "", rpc.Cacheable()),
 		"genesis_chunked":      rpc.NewRPCFunc(env.GenesisChunked, "chunk", rpc.Cacheable()),
-		"block":                rpc.NewRPCFunc(env.Block, "height", rpc.Cacheable("height")),
-		"block_by_hash":        rpc.NewRPCFunc(env.BlockByHash, "hash", rpc.Cacheable()),
-		"block_results":        rpc.NewRPCFunc(env.BlockResults, "height", rpc.Cacheable("height")),
+		"block":                rpc.NewRPCFunc(env.Block, "height", rpc.Cacheable("height"), heavy),
+		"block_by_hash":        rpc.NewRPCFunc(env.BlockByHash, "hash", rpc.Cacheable(), heavy),
+		"block_results":        rpc.NewRPCFunc(env.BlockResults, "height", rpc.Cacheable("height"), heavy),
 		"commit":               rpc.NewRPCFunc(env.Commit, "height", rpc.Cacheable("height")),
 		"header":               rpc.NewRPCFunc(env.Header, "height", rpc.Cacheable("height")),
 		"header_by_hash":       rpc.NewRPCFunc(env.HeaderByHash, "hash", rpc.Cacheable()),
 		"check_tx":             rpc.NewRPCFunc(env.CheckTx, "tx"),
-		"tx":                   rpc.NewRPCFunc(env.Tx, "hash,prove", rpc.Cacheable()),
-		"tx_search":            rpc.NewRPCFunc(env.TxSearch, "query,prove,page,per_page,order_by"),
-		"block_search":         rpc.NewRPCFunc(env.BlockSearch, "query,page,per_page,order_by"),
+		"tx":                   rpc.NewRPCFunc(env.Tx, "hash,prove", rpc.Cacheable(), heavy),
+		"tx_search":            rpc.NewRPCFunc(env.TxSearch, "query,prove,page,per_page,order_by", heavy),
+		"block_search":         rpc.NewRPCFunc(env.BlockSearch, "query,page,per_page,order_by", heavy),
 		"validators":           rpc.NewRPCFunc(env.Validators, "height,page,per_page", rpc.Cacheable("height")),
 		"dump_consensus_state": rpc.NewRPCFunc(env.DumpConsensusState, ""),
 		"consensus_state":      rpc.NewRPCFunc(env.GetConsensusState, ""),
 		"consensus_params":     rpc.NewRPCFunc(env.ConsensusParams, "height", rpc.Cacheable("height")),
-		"unconfirmed_txs":      rpc.NewRPCFunc(env.UnconfirmedTxs, "limit"),
+		"unconfirmed_txs":      rpc.NewRPCFunc(env.UnconfirmedTxs, "limit", heavy),
 		"num_unconfirmed_txs":  rpc.NewRPCFunc(env.NumUnconfirmedTxs, ""),
 
 		// tx broadcast API
@@ -53,11 +56,11 @@ func (env *Environment) GetRoutes() RoutesMap {
 		"broadcast_evidence": rpc.NewRPCFunc(env.BroadcastEvidence, "evidence"),
 
 		// celestia-specific API
-		"prove_shares":              rpc.NewRPCFunc(env.ProveShares, "height,startShare,endShare"),
-		"prove_shares_v2":           rpc.NewRPCFunc(env.ProveSharesV2, "height,startShare,endShare"),
-		"data_root_inclusion_proof": rpc.NewRPCFunc(env.DataRootInclusionProof, "height,start,end"),
-		"signed_block":              rpc.NewRPCFunc(env.SignedBlock, "height", rpc.Cacheable("height")),
-		"data_commitment":           rpc.NewRPCFunc(env.DataCommitment, "start,end"),
+		"prove_shares":              rpc.NewRPCFunc(env.ProveShares, "height,startShare,endShare", heavy),
+		"prove_shares_v2":           rpc.NewRPCFunc(env.ProveSharesV2, "height,startShare,endShare", heavy),
+		"data_root_inclusion_proof": rpc.NewRPCFunc(env.DataRootInclusionProof, "height,start,end", heavy),
+		"signed_block":              rpc.NewRPCFunc(env.SignedBlock, "height", rpc.Cacheable("height"), heavy),
+		"data_commitment":           rpc.NewRPCFunc(env.DataCommitment, "start,end", heavy),
 		"tx_status":                 rpc.NewRPCFunc(env.TxStatus, "hash"),
 		"tx_status_batch":           rpc.NewRPCFunc(env.TxStatusBatch, "hashes"),
 	}

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -33,7 +33,10 @@ type Config struct {
 //
 // Deprecated: A new gRPC API will be introduced after v0.38.
 func StartGRPCServer(env *core.Environment, ln net.Listener) error {
+	sem := env.HeavySem()
 	grpcServer := grpc.NewServer(
+		grpc.UnaryInterceptor(heavyUnaryInterceptor(sem)),
+		grpc.StreamInterceptor(heavyStreamInterceptor(sem)),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			// Send a keepalive ping every 30s of inactivity.
 			Time: 30 * time.Second,

--- a/rpc/grpc/interceptor.go
+++ b/rpc/grpc/interceptor.go
@@ -1,0 +1,93 @@
+package coregrpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// heavyGRPCMethods are the gRPC methods whose responses can be large or whose
+// cost scales with chain data. They share the same process-wide semaphore as
+// the equivalent HTTP RPC routes so a burst over either transport can't exceed
+// the combined budget.
+//
+// ValidatorSet is gated here even though the HTTP validators route is not: the
+// gRPC method returns the full validator set for a height unpaginated, while the
+// HTTP route paginates (max_per_page), so only the gRPC form is unbounded.
+//
+// SubscribeNewHeights is deliberately excluded: it is a long-lived subscription
+// stream and holding a slot for its lifetime would starve the budget. Cheap or
+// bounded methods (Ping, Status, BroadcastTx, Commit) are excluded as well.
+var heavyGRPCMethods = map[string]struct{}{
+	"/tendermint.rpc.grpc.BlockAPI/BlockByHash":                 {},
+	"/tendermint.rpc.grpc.BlockAPI/BlockByHeight":               {},
+	"/tendermint.rpc.grpc.BlockAPI/ValidatorSet":                {},
+	"/tendermint.rpc.grpc.BlobstreamAPI/DataRootInclusionProof": {},
+}
+
+// errHeavyGRPCLimit is returned when the shared heavy-request budget is
+// saturated. ResourceExhausted maps to HTTP 503 and signals clients to back off
+// and retry, mirroring the HTTP RPC handlers.
+var errHeavyGRPCLimit = status.Error(
+	codes.ResourceExhausted,
+	"server busy: too many concurrent heavy RPC requests, retry later",
+)
+
+// heavyUnaryInterceptor bounds concurrent heavy unary responses using the
+// shared semaphore. A nil semaphore (limit disabled) is a no-op.
+func heavyUnaryInterceptor(sem chan struct{}) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		release, ok := acquireHeavy(sem, info.FullMethod)
+		if !ok {
+			return nil, errHeavyGRPCLimit
+		}
+		defer release()
+		return handler(ctx, req)
+	}
+}
+
+// heavyStreamInterceptor bounds concurrent heavy streaming responses (e.g.
+// BlockByHash/BlockByHeight, which stream a full block) using the shared
+// semaphore. The slot is held for the duration of the stream, since the block
+// data lives until the stream completes.
+func heavyStreamInterceptor(sem chan struct{}) grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		release, ok := acquireHeavy(sem, info.FullMethod)
+		if !ok {
+			return errHeavyGRPCLimit
+		}
+		defer release()
+		return handler(srv, ss)
+	}
+}
+
+// acquireHeavy performs a non-blocking acquire of the shared slot for heavy
+// methods. Non-heavy methods (and a nil semaphore) always admit with a no-op
+// release. When the semaphore is full it returns ok == false so the caller can
+// reject the request instead of queueing.
+func acquireHeavy(sem chan struct{}, fullMethod string) (release func(), ok bool) {
+	if sem == nil {
+		return func() {}, true
+	}
+	if _, heavy := heavyGRPCMethods[fullMethod]; !heavy {
+		return func() {}, true
+	}
+	select {
+	case sem <- struct{}{}:
+		return func() { <-sem }, true
+	default:
+		return nil, false
+	}
+}

--- a/rpc/grpc/interceptor.go
+++ b/rpc/grpc/interceptor.go
@@ -44,7 +44,7 @@ func heavyUnaryInterceptor(sem chan struct{}) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		release, ok := acquireHeavy(sem, info.FullMethod)
+		release, ok := acquireHeavyFn(sem, info.FullMethod)
 		if !ok {
 			return nil, errHeavyGRPCLimit
 		}
@@ -64,7 +64,7 @@ func heavyStreamInterceptor(sem chan struct{}) grpc.StreamServerInterceptor {
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		release, ok := acquireHeavy(sem, info.FullMethod)
+		release, ok := acquireHeavyFn(sem, info.FullMethod)
 		if !ok {
 			return errHeavyGRPCLimit
 		}
@@ -73,11 +73,11 @@ func heavyStreamInterceptor(sem chan struct{}) grpc.StreamServerInterceptor {
 	}
 }
 
-// acquireHeavy performs a non-blocking acquire of the shared slot for heavy
+// acquireHeavyFn performs a non-blocking acquire of the shared slot for heavy
 // methods. Non-heavy methods (and a nil semaphore) always admit with a no-op
 // release. When the semaphore is full it returns ok == false so the caller can
 // reject the request instead of queueing.
-func acquireHeavy(sem chan struct{}, fullMethod string) (release func(), ok bool) {
+func acquireHeavyFn(sem chan struct{}, fullMethod string) (release func(), ok bool) {
 	if sem == nil {
 		return func() {}, true
 	}

--- a/rpc/grpc/interceptor_test.go
+++ b/rpc/grpc/interceptor_test.go
@@ -12,24 +12,24 @@ const (
 	subMethod   = "/tendermint.rpc.grpc.BlockAPI/SubscribeNewHeights"
 )
 
-// TestAcquireHeavyNilSemaphore verifies the limit-disabled case: a nil
+// TestAcquireHeavyFnNilSemaphore verifies the limit-disabled case: a nil
 // semaphore always admits, even for heavy methods, with a no-op release.
-func TestAcquireHeavyNilSemaphore(t *testing.T) {
-	release, ok := acquireHeavy(nil, heavyMethod)
+func TestAcquireHeavyFnNilSemaphore(t *testing.T) {
+	release, ok := acquireHeavyFn(nil, heavyMethod)
 	require.True(t, ok)
 	require.NotNil(t, release)
 	release()
 }
 
-// TestAcquireHeavyLightMethodNotGated verifies that non-heavy methods (and the
+// TestAcquireHeavyFnLightMethodNotGated verifies that non-heavy methods (and the
 // long-lived subscription stream) never draw from the budget: they admit even
 // when the semaphore is full.
-func TestAcquireHeavyLightMethodNotGated(t *testing.T) {
+func TestAcquireHeavyFnLightMethodNotGated(t *testing.T) {
 	sem := make(chan struct{}, 1)
 	sem <- struct{}{} // saturate
 
 	for _, method := range []string{lightMethod, subMethod} {
-		release, ok := acquireHeavy(sem, method)
+		release, ok := acquireHeavyFn(sem, method)
 		require.True(t, ok, "method %s should not be gated", method)
 		require.NotNil(t, release)
 		release()
@@ -37,20 +37,20 @@ func TestAcquireHeavyLightMethodNotGated(t *testing.T) {
 	require.Len(t, sem, 1, "light methods must not touch the budget")
 }
 
-// TestAcquireHeavyGatedAndReleased verifies that heavy methods draw from the
+// TestAcquireHeavyFnGatedAndReleased verifies that heavy methods draw from the
 // shared budget: they admit up to capacity, reject the rest, and admit again
 // once a slot is released.
-func TestAcquireHeavyGatedAndReleased(t *testing.T) {
+func TestAcquireHeavyFnGatedAndReleased(t *testing.T) {
 	sem := make(chan struct{}, 1)
 
-	release, ok := acquireHeavy(sem, heavyMethod)
+	release, ok := acquireHeavyFn(sem, heavyMethod)
 	require.True(t, ok)
 
-	_, ok2 := acquireHeavy(sem, heavyMethod)
+	_, ok2 := acquireHeavyFn(sem, heavyMethod)
 	require.False(t, ok2, "second heavy request should be rejected when full")
 
 	release()
-	release3, ok3 := acquireHeavy(sem, heavyMethod)
+	release3, ok3 := acquireHeavyFn(sem, heavyMethod)
 	require.True(t, ok3, "slot should be free again after release")
 	release3()
 }

--- a/rpc/grpc/interceptor_test.go
+++ b/rpc/grpc/interceptor_test.go
@@ -1,0 +1,56 @@
+package coregrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	heavyMethod = "/tendermint.rpc.grpc.BlockAPI/BlockByHeight"
+	lightMethod = "/tendermint.rpc.grpc.BlockAPI/Status"
+	subMethod   = "/tendermint.rpc.grpc.BlockAPI/SubscribeNewHeights"
+)
+
+// TestAcquireHeavyNilSemaphore verifies the limit-disabled case: a nil
+// semaphore always admits, even for heavy methods, with a no-op release.
+func TestAcquireHeavyNilSemaphore(t *testing.T) {
+	release, ok := acquireHeavy(nil, heavyMethod)
+	require.True(t, ok)
+	require.NotNil(t, release)
+	release()
+}
+
+// TestAcquireHeavyLightMethodNotGated verifies that non-heavy methods (and the
+// long-lived subscription stream) never draw from the budget: they admit even
+// when the semaphore is full.
+func TestAcquireHeavyLightMethodNotGated(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // saturate
+
+	for _, method := range []string{lightMethod, subMethod} {
+		release, ok := acquireHeavy(sem, method)
+		require.True(t, ok, "method %s should not be gated", method)
+		require.NotNil(t, release)
+		release()
+	}
+	require.Len(t, sem, 1, "light methods must not touch the budget")
+}
+
+// TestAcquireHeavyGatedAndReleased verifies that heavy methods draw from the
+// shared budget: they admit up to capacity, reject the rest, and admit again
+// once a slot is released.
+func TestAcquireHeavyGatedAndReleased(t *testing.T) {
+	sem := make(chan struct{}, 1)
+
+	release, ok := acquireHeavy(sem, heavyMethod)
+	require.True(t, ok)
+
+	_, ok2 := acquireHeavy(sem, heavyMethod)
+	require.False(t, ok2, "second heavy request should be rejected when full")
+
+	release()
+	release3, ok3 := acquireHeavy(sem, heavyMethod)
+	require.True(t, ok3, "slot should be free again after release")
+	release3()
+}

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -105,7 +105,18 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 				cache = false
 			}
 
-			returns := rpcFunc.f.Call(args)
+			// Bound concurrent heavy responses; reject fast when saturated.
+			// release() is deferred so a panic can't leak the slot.
+			admitted, release := rpcFunc.tryAcquire()
+			if !admitted {
+				responses = append(responses, types.RPCInternalError(request.ID, errHeavyRequestLimit))
+				cache = false
+				continue
+			}
+			returns := func() []reflect.Value {
+				defer release()
+				return rpcFunc.f.Call(args)
+			}()
 			result, err := unreflectResult(returns)
 			if err != nil {
 				responses = append(responses, types.RPCInternalError(request.ID, err))

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -51,6 +51,19 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 		}
 		args = append(args, fnArgs...)
 
+		// Bound concurrent heavy responses; reject fast when saturated. The slot
+		// is held until the response is fully written, since the large buffers
+		// live that long.
+		admitted, release := rpcFunc.tryAcquire()
+		if !admitted {
+			res := types.RPCInternalError(dummyID, errHeavyRequestLimit)
+			if wErr := WriteRPCResponseHTTPError(w, http.StatusServiceUnavailable, res); wErr != nil {
+				logger.Error("failed to write response", "err", wErr)
+			}
+			return
+		}
+		defer release()
+
 		returns := rpcFunc.f.Call(args)
 
 		logger.Trace("HTTPRestRPC", "method", r.URL.Path, "args", args, "returns", returns)

--- a/rpc/jsonrpc/server/rpc_func.go
+++ b/rpc/jsonrpc/server/rpc_func.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -8,6 +9,11 @@ import (
 
 	"github.com/cometbft/cometbft/libs/log"
 )
+
+// errHeavyRequestLimit is returned when the concurrent heavy-request limit is
+// saturated so clients back off and retry. The URI handler surfaces it as HTTP
+// 503; the JSON-RPC and WebSocket paths return it as a JSON-RPC error.
+var errHeavyRequestLimit = errors.New("server busy: too many concurrent heavy RPC requests, retry later")
 
 // RegisterRPCFuncs adds a route for each function in the funcMap, as well as
 // general jsonrpc and websocket handlers for all functions. "result" is the
@@ -48,6 +54,17 @@ func Ws() Option {
 	}
 }
 
+// Heavy marks an RPC function as "heavy": one whose response can be large or
+// whose cost scales with chain data (a full block, all results for a height, an
+// unbounded search set). Heavy functions share the supplied semaphore so the
+// number of such responses built concurrently is bounded. A nil semaphore
+// disables the limit.
+func Heavy(sem chan struct{}) Option {
+	return func(r *RPCFunc) {
+		r.heavySem = sem
+	}
+}
+
 // RPCFunc contains the introspected type information for a function
 type RPCFunc struct {
 	f              reflect.Value          // underlying rpc function
@@ -57,6 +74,22 @@ type RPCFunc struct {
 	cacheable      bool                   // enable cache control
 	ws             bool                   // enable websocket communication
 	noCacheDefArgs map[string]interface{} // a lookup table of args that, if not supplied or are set to default values, cause us to not cache
+	heavySem       chan struct{}          // if non-nil, a shared semaphore bounding concurrent heavy responses
+}
+
+// tryAcquire does a non-blocking acquire of the heavy-request slot. Non-heavy
+// functions (nil semaphore) always admit with a no-op release; when the
+// semaphore is full it returns (false, nil) so the caller can reject.
+func (f *RPCFunc) tryAcquire() (admitted bool, release func()) {
+	if f.heavySem == nil {
+		return true, func() {}
+	}
+	select {
+	case f.heavySem <- struct{}{}:
+		return true, func() { <-f.heavySem }
+	default:
+		return false, nil
+	}
 }
 
 // NewRPCFunc wraps a function for introspection.

--- a/rpc/jsonrpc/server/rpc_func.go
+++ b/rpc/jsonrpc/server/rpc_func.go
@@ -54,12 +54,12 @@ func Ws() Option {
 	}
 }
 
-// Heavy marks an RPC function as "heavy": one whose response can be large or
+// HeavyFn marks an RPC function as "heavy": one whose response can be large or
 // whose cost scales with chain data (a full block, all results for a height, an
 // unbounded search set). Heavy functions share the supplied semaphore so the
 // number of such responses built concurrently is bounded. A nil semaphore
 // disables the limit.
-func Heavy(sem chan struct{}) Option {
+func HeavyFn(sem chan struct{}) Option {
 	return func(r *RPCFunc) {
 		r.heavySem = sem
 	}

--- a/rpc/jsonrpc/server/rpc_func_test.go
+++ b/rpc/jsonrpc/server/rpc_func_test.go
@@ -8,7 +8,7 @@ import (
 
 func dummyRPC() interface{} { return func() {} }
 
-// TestRPCFuncTryAcquireNonHeavy verifies that a function without the Heavy
+// TestRPCFuncTryAcquireNonHeavy checks that a function without the HeavyFn
 // option is never gated: it always admits with a no-op release.
 func TestRPCFuncTryAcquireNonHeavy(t *testing.T) {
 	f := NewRPCFunc(dummyRPC(), "")
@@ -20,13 +20,13 @@ func TestRPCFuncTryAcquireNonHeavy(t *testing.T) {
 	}
 }
 
-// TestRPCFuncTryAcquireHeavyShared verifies that heavy functions sharing a
+// TestRPCFuncTryAcquireHeavyShared checks that heavy functions sharing a
 // semaphore draw from a single budget: they admit only up to its capacity,
 // reject the rest, and admit again once a slot is released.
 func TestRPCFuncTryAcquireHeavyShared(t *testing.T) {
 	sem := make(chan struct{}, 1)
-	a := NewRPCFunc(dummyRPC(), "", Heavy(sem))
-	b := NewRPCFunc(dummyRPC(), "", Heavy(sem))
+	a := NewRPCFunc(dummyRPC(), "", HeavyFn(sem))
+	b := NewRPCFunc(dummyRPC(), "", HeavyFn(sem))
 
 	okA, relA := a.tryAcquire()
 	require.True(t, okA)

--- a/rpc/jsonrpc/server/rpc_func_test.go
+++ b/rpc/jsonrpc/server/rpc_func_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func dummyRPC() interface{} { return func() {} }
+
+// TestRPCFuncTryAcquireNonHeavy verifies that a function without the Heavy
+// option is never gated: it always admits with a no-op release.
+func TestRPCFuncTryAcquireNonHeavy(t *testing.T) {
+	f := NewRPCFunc(dummyRPC(), "")
+	for i := 0; i < 3; i++ {
+		admitted, release := f.tryAcquire()
+		require.True(t, admitted)
+		require.NotNil(t, release)
+		release()
+	}
+}
+
+// TestRPCFuncTryAcquireHeavyShared verifies that heavy functions sharing a
+// semaphore draw from a single budget: they admit only up to its capacity,
+// reject the rest, and admit again once a slot is released.
+func TestRPCFuncTryAcquireHeavyShared(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	a := NewRPCFunc(dummyRPC(), "", Heavy(sem))
+	b := NewRPCFunc(dummyRPC(), "", Heavy(sem))
+
+	okA, relA := a.tryAcquire()
+	require.True(t, okA)
+
+	// b shares a's single slot, so it is rejected until a releases.
+	okB, relB := b.tryAcquire()
+	require.False(t, okB)
+	require.Nil(t, relB)
+
+	relA()
+	okB2, relB2 := b.tryAcquire()
+	require.True(t, okB2)
+	relB2()
+}

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -378,7 +378,20 @@ func (wsc *wsConnection) readRoutine() {
 				args = append(args, fnArgs...)
 			}
 
-			returns := rpcFunc.f.Call(args)
+			// Bound concurrent heavy responses; reject fast when saturated so WS
+			// clients can't bypass the limit the HTTP handlers enforce.
+			admitted, release := rpcFunc.tryAcquire()
+			if !admitted {
+				if err := wsc.WriteRPCResponse(writeCtx, types.RPCInternalError(request.ID, errHeavyRequestLimit)); err != nil {
+					wsc.Logger.Error("Error writing RPC response", "err", err)
+				}
+				continue
+			}
+			// release() is deferred so a panic can't leak the slot.
+			returns := func() []reflect.Value {
+				defer release()
+				return rpcFunc.f.Call(args)
+			}()
 
 			// TODO: Need to encode args/returns to string if we want to log them
 			wsc.Logger.Info("WSJSONRPC", "method", request.Method)

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -387,26 +387,29 @@ func (wsc *wsConnection) readRoutine() {
 				}
 				continue
 			}
-			// release() is deferred so a panic can't leak the slot.
-			returns := func() []reflect.Value {
+			// Hold the slot across the call and the response marshal+write so the
+			// large response is accounted for until it is queued to the writer.
+			// release() runs via defer so a panic can't leak the slot.
+			func() {
 				defer release()
-				return rpcFunc.f.Call(args)
-			}()
 
-			// TODO: Need to encode args/returns to string if we want to log them
-			wsc.Logger.Info("WSJSONRPC", "method", request.Method)
+				returns := rpcFunc.f.Call(args)
 
-			result, err := unreflectResult(returns)
-			if err != nil {
-				if err := wsc.WriteRPCResponse(writeCtx, types.RPCInternalError(request.ID, err)); err != nil {
+				// TODO: Need to encode args/returns to string if we want to log them
+				wsc.Logger.Info("WSJSONRPC", "method", request.Method)
+
+				result, err := unreflectResult(returns)
+				if err != nil {
+					if err := wsc.WriteRPCResponse(writeCtx, types.RPCInternalError(request.ID, err)); err != nil {
+						wsc.Logger.Error("Error writing RPC response", "err", err)
+					}
+					return
+				}
+
+				if err := wsc.WriteRPCResponse(writeCtx, types.NewRPCSuccessResponse(request.ID, result)); err != nil {
 					wsc.Logger.Error("Error writing RPC response", "err", err)
 				}
-				continue
-			}
-
-			if err := wsc.WriteRPCResponse(writeCtx, types.NewRPCSuccessResponse(request.ID, result)); err != nil {
-				wsc.Logger.Error("Error writing RPC response", "err", err)
-			}
+			}()
 		}
 	}
 }

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -528,6 +528,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Service unavailable. The server's concurrent heavy-request limit
+            (max_concurrent_heavy_requests) is saturated. Retry with backoff.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /block_by_hash:
     get:
       summary: Get block by hash
@@ -560,6 +568,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Service unavailable. The server's concurrent heavy-request limit
+            (max_concurrent_heavy_requests) is saturated. Retry with backoff.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /block_results:
     get:
       summary: Get block results at a specified height
@@ -588,6 +604,14 @@ paths:
                 $ref: "#/components/schemas/BlockResultsResponse"
         "500":
           description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Service unavailable. The server's concurrent heavy-request limit
+            (max_concurrent_heavy_requests) is saturated. Retry with backoff.
           content:
             application/json:
               schema:
@@ -846,6 +870,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Service unavailable. The server's concurrent heavy-request limit
+            (max_concurrent_heavy_requests) is saturated. Retry with backoff.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /num_unconfirmed_txs:
     get:
       summary: Get data about unconfirmed transactions
@@ -933,6 +965,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Service unavailable. The server's concurrent heavy-request limit
+            (max_concurrent_heavy_requests) is saturated. Retry with backoff.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /block_search:
     get:
       summary: Search for blocks by FinalizeBlock events
@@ -991,6 +1031,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Service unavailable. The server's concurrent heavy-request limit
+            (max_concurrent_heavy_requests) is saturated. Retry with backoff.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /tx:
     get:
@@ -1029,6 +1077,14 @@ paths:
                 $ref: "#/components/schemas/TxResponse"
         "500":
           description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Service unavailable. The server's concurrent heavy-request limit
+            (max_concurrent_heavy_requests) is saturated. Retry with backoff.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Resolves [PROTOCO-2169](https://linear.app/celestia/issue/PROTOCO-2169/harden-rpc-endpoints)

Adds a process-wide concurrency limit for "heavy" RPC responses (configurable via max_concurrent_heavy_requests, default 20), shared across all transports (HTTP JSON-RPC, URI, WebSocket, gRPC). Excess heavy requests are rejected fast — HTTP 503 / gRPC ResourceExhausted — while light endpoints stay unaffected.

Endpoints gated by the shared heavy-request semaphore:

1. HTTP RPC

- block, block_by_hash, block_results — load a full block
- tx, tx_search, block_search — full block(s) / unbounded result set
- unconfirmed_txs — can reap the whole mempool (limit=-1)
- prove_shares, prove_shares_v2, data_root_inclusion_proof, data_commitment, signed_block — full block / wide-range proofs

2. gRPC

- BlockByHash, BlockByHeight — stream a full block
- ValidatorSet — returns the full validator set unpaginated (HTTP validators paginates, so it isn't gated)
- DataRootInclusionProof — proof over a height range

Additional hardening
- data_root_inclusion_proof / data_commitment now load block meta instead of full blocks — a wide range no longer pulls thousands of full blocks into memory.