### PR TITLE
docs: instruct Claude to write short godoc comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ The codebase follows CometBFT's modular architecture. Key packages and their rol
 ## Code Conventions
 
 - Follow [Uber Go Style Guide](https://github.com/uber-go/guide/blob/master/style.md) as baseline
+- Keep godoc comments short and easy to understand: one or two plain-language sentences saying what the thing does. Avoid big blocks of text — they are hard to read and reason about.
 - Use `errors.New()` over `fmt.Errorf()` unless formatting with arguments; wrap errors with `%w`
 - Use `testify/assert` and `testify/require` for test assertions; prefer table-driven tests
 - Import alias conventions: `cmtcfg`, `cmttypes`, `cmtbits` etc. for internal packages; `dbm` for cometbft-db


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/3245

Adds a Code Conventions bullet to CLAUDE.md telling Claude to write short, plain-language godoc comments instead of big blocks of text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bziVkwQzppETR3p39nJui