### PR TITLE
fix(light): bind ConsensusParams response to requested height

### DIFF
--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -238,6 +238,13 @@ func (c *Client) ConsensusParams(ctx context.Context, height *int64) (*ctypes.Re
 	if res.BlockHeight <= 0 {
 		return nil, errNegOrZeroHeight
 	}
+	// Bind the response to the requested height. Otherwise a malicious server
+	// could answer with authentic parameters from a different height, which
+	// would still pass the hash check below against that height's light block.
+	if height != nil && res.BlockHeight != *height {
+		return nil, fmt.Errorf("params height %d does not match requested height %d",
+			res.BlockHeight, *height)
+	}
 
 	// Update the light client if we're behind.
 	l, err := c.updateLightClientIfNeededTo(ctx, &res.BlockHeight)

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -241,6 +241,8 @@ func (c *Client) ConsensusParams(ctx context.Context, height *int64) (*ctypes.Re
 	// Bind the response to the requested height. Otherwise a malicious server
 	// could answer with authentic parameters from a different height, which
 	// would still pass the hash check below against that height's light block.
+	// A nil height means "latest", which has no specific height to bind to, so
+	// the response is only authenticated against its own reported height.
 	if height != nil && res.BlockHeight != *height {
 		return nil, fmt.Errorf("params height %d does not match requested height %d",
 			res.BlockHeight, *height)

--- a/light/rpc/client_test.go
+++ b/light/rpc/client_test.go
@@ -27,15 +27,15 @@ func (n nextClient) ConsensusParams(_ context.Context, _ *int64) (*ctypes.Result
 
 // A malicious primary can answer a ConsensusParams request for height H with
 // authentic parameters from a different height X. The response must be rejected
-// because it is not bound to the requested height.
+// on the height mismatch, before the params are authenticated against X's light
+// block (so VerifyLightBlockAtHeight is never reached).
 func TestConsensusParamsRejectsWrongHeightResponse(t *testing.T) {
 	const (
 		requestedHeight int64 = 100 // what the caller asks for
 		responseHeight  int64 = 1   // what the malicious primary answers with
 	)
 
-	// Authentic historical params from height X=1, with a hash distinct from the
-	// params the caller wants at height H=100.
+	// Authentic historical params from height X=1.
 	paramsX := types.DefaultConsensusParams()
 	paramsX.Block.MaxBytes = 1 * 1024 * 1024
 
@@ -44,16 +44,10 @@ func TestConsensusParamsRejectsWrongHeightResponse(t *testing.T) {
 		ConsensusParams: *paramsX,
 	}
 
-	// The light client honestly verifies the block at the server-chosen height X;
-	// its ConsensusHash legitimately commits to paramsX, so the hash check passes.
-	lightBlockX := &types.LightBlock{
-		SignedHeader: &types.SignedHeader{
-			Header: &types.Header{ConsensusHash: paramsX.Hash()},
-		},
-	}
+	// No light-client interaction is expected: the request is rejected before
+	// hash verification. A bare mock with no expectations would fail the test if
+	// any method were called.
 	lc := &mocks.LightClient{}
-	lc.On("VerifyLightBlockAtHeight", mock.Anything, responseHeight, mock.Anything).
-		Return(lightBlockX, nil)
 
 	c := NewClient(nextClient{res: res}, lc)
 
@@ -61,6 +55,7 @@ func TestConsensusParamsRejectsWrongHeightResponse(t *testing.T) {
 	_, err := c.ConsensusParams(context.Background(), &h)
 	require.Error(t, err, "wrapper accepted params from height %d for a request at height %d",
 		responseHeight, requestedHeight)
+	lc.AssertNotCalled(t, "VerifyLightBlockAtHeight")
 }
 
 // When the response height matches the requested height, verification succeeds.

--- a/light/rpc/client_test.go
+++ b/light/rpc/client_test.go
@@ -1,0 +1,90 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/light/rpc/mocks"
+	rpcclient "github.com/cometbft/cometbft/rpc/client"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/cometbft/cometbft/types"
+)
+
+// nextClient embeds the rpcclient.Client interface so every method except the
+// one we override panics if unexpectedly called. It lets the test control what
+// the underlying RPC server returns for ConsensusParams.
+type nextClient struct {
+	rpcclient.Client
+	res *ctypes.ResultConsensusParams
+}
+
+func (n nextClient) ConsensusParams(_ context.Context, _ *int64) (*ctypes.ResultConsensusParams, error) {
+	return n.res, nil
+}
+
+// A malicious primary can answer a ConsensusParams request for height H with
+// authentic parameters from a different height X. The response must be rejected
+// because it is not bound to the requested height.
+func TestConsensusParamsRejectsWrongHeightResponse(t *testing.T) {
+	const (
+		requestedHeight int64 = 100 // what the caller asks for
+		responseHeight  int64 = 1   // what the malicious primary answers with
+	)
+
+	// Authentic historical params from height X=1, with a hash distinct from the
+	// params the caller wants at height H=100.
+	paramsX := types.DefaultConsensusParams()
+	paramsX.Block.MaxBytes = 1 * 1024 * 1024
+
+	res := &ctypes.ResultConsensusParams{
+		BlockHeight:     responseHeight,
+		ConsensusParams: *paramsX,
+	}
+
+	// The light client honestly verifies the block at the server-chosen height X;
+	// its ConsensusHash legitimately commits to paramsX, so the hash check passes.
+	lightBlockX := &types.LightBlock{
+		SignedHeader: &types.SignedHeader{
+			Header: &types.Header{ConsensusHash: paramsX.Hash()},
+		},
+	}
+	lc := &mocks.LightClient{}
+	lc.On("VerifyLightBlockAtHeight", mock.Anything, responseHeight, mock.Anything).
+		Return(lightBlockX, nil)
+
+	c := NewClient(nextClient{res: res}, lc)
+
+	h := requestedHeight
+	_, err := c.ConsensusParams(context.Background(), &h)
+	require.Error(t, err, "wrapper accepted params from height %d for a request at height %d",
+		responseHeight, requestedHeight)
+}
+
+// When the response height matches the requested height, verification succeeds.
+func TestConsensusParamsAcceptsMatchingHeightResponse(t *testing.T) {
+	const height int64 = 100
+
+	params := types.DefaultConsensusParams()
+	res := &ctypes.ResultConsensusParams{
+		BlockHeight:     height,
+		ConsensusParams: *params,
+	}
+	lightBlock := &types.LightBlock{
+		SignedHeader: &types.SignedHeader{
+			Header: &types.Header{ConsensusHash: params.Hash()},
+		},
+	}
+	lc := &mocks.LightClient{}
+	lc.On("VerifyLightBlockAtHeight", mock.Anything, height, mock.Anything).
+		Return(lightBlock, nil)
+
+	c := NewClient(nextClient{res: res}, lc)
+
+	h := height
+	got, err := c.ConsensusParams(context.Background(), &h)
+	require.NoError(t, err)
+	require.Equal(t, height, got.BlockHeight)
+}

--- a/statesync/stateprovider.go
+++ b/statesync/stateprovider.go
@@ -183,8 +183,11 @@ func (s *lightClientStateProvider) State(ctx context.Context, height uint64) (sm
 	result, err := rpcclient.ConsensusParams(ctx, &currentLightBlock.Height)
 	if err != nil {
 		return sm.State{}, fmt.Errorf("unable to fetch consensus parameters for height %v: %w",
-			nextLightBlock.Height, err)
+			currentLightBlock.Height, err)
 	}
+	// Defense in depth: lightrpc.Client.ConsensusParams already binds the
+	// response to the requested height, but re-check here so a future client
+	// that skips that binding cannot poison the bootstrapped state.
 	if result.BlockHeight != currentLightBlock.Height {
 		return sm.State{}, fmt.Errorf("consensus parameters height %d does not match requested height %d",
 			result.BlockHeight, currentLightBlock.Height)

--- a/statesync/stateprovider.go
+++ b/statesync/stateprovider.go
@@ -185,6 +185,10 @@ func (s *lightClientStateProvider) State(ctx context.Context, height uint64) (sm
 		return sm.State{}, fmt.Errorf("unable to fetch consensus parameters for height %v: %w",
 			nextLightBlock.Height, err)
 	}
+	if result.BlockHeight != currentLightBlock.Height {
+		return sm.State{}, fmt.Errorf("consensus parameters height %d does not match requested height %d",
+			result.BlockHeight, currentLightBlock.Height)
+	}
 	state.ConsensusParams = result.ConsensusParams
 	state.LastHeightConsensusParamsChanged = currentLightBlock.Height
 


### PR DESCRIPTION
Closes [PROTOCO-2494](https://linear.app/celestia/issue/PROTOCO-2494/light-rpc-consensusparams-response-not-bound-to-requested-height)

`light/rpc.Client.ConsensusParams` verified the params hash against the light block at the server-returned `BlockHeight` but never checked that it matched the caller's requested height, so a response could be authenticated at a height the caller did not ask for. This binds the response to the requested height and adds a matching defense-in-depth check on the state-sync path.

Note for reviewers: resolves a Hacken bug bounty report; see the Linear issue for details.