### PR TITLE
chore: bump Go to 1.26.6 to clear govulncheck stdlib findings (backport #3239)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,5 +1,5 @@
 # We use Debian instead of Alpine for compatibility.
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 


### PR DESCRIPTION
Backport of #3239 to `v0.40.x`. govulncheck is failing on this branch (e.g. [this run](https://github.com/celestiaorg/celestia-core/actions/runs/32886967956/job/97929577743?pr=3258)) because `go.mod` declares `go 1.26.5`, which is flagged for 7 stdlib vulnerabilities all fixed in `go1.26.6`. Bumps the Go patch version in `go.mod` and the e2e Dockerfile, same as main. Verified locally: `make vulncheck` now reports 0 reachable vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YJREBbQ7nmQq6HtX4U4bF