### PR TITLE
fix(consensus): validate part set before updating valid block

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2662,13 +2662,11 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			// NOTE: our proposal block may be nil or not what received a polka..
 			if len(blockID.Hash) != 0 && (cs.rs.ValidRound < vote.Round) && (vote.Round == cs.rs.Round) {
 				partsMatch := cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader)
-				stateChanged := false
 				if cs.rs.ProposalBlock.HashesTo(blockID.Hash) && partsMatch {
 					cs.Logger.Debug("updating valid block because of POL", "valid_round", cs.rs.ValidRound, "pol_round", vote.Round)
 					cs.rs.ValidRound = vote.Round
 					cs.rs.ValidBlock = cs.rs.ProposalBlock
 					cs.rs.ValidBlockParts = cs.rs.ProposalBlockParts
-					stateChanged = true
 				} else if cs.rs.ProposalBlock != nil {
 					cs.Logger.Debug(
 						"valid block we do not know about; set ProposalBlock=nil",
@@ -2680,7 +2678,6 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 
 					// we're getting the wrong block
 					cs.rs.ProposalBlock = nil
-					stateChanged = true
 				}
 
 				if !partsMatch {
@@ -2689,18 +2686,14 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 					cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 					psh := blockID.PartSetHeader
 					cs.propagator.AddCommitment(height, vote.Round, &psh)
-					stateChanged = true
 				}
 
-				// When the polka names a part set we do not hold, ValidRound
-				// does not advance, so every later prevote of the round
-				// re-enters this block. Announce only for the vote that
-				// changed what we hold.
-				if stateChanged {
-					cs.evsw.FireEvent(types.EventValidBlock, &cs.rs)
-					if err := cs.eventBus.PublishEventValidBlock(cs.rs.RoundStateEvent()); err != nil {
-						return added, err
-					}
+				// Announce unconditionally, as before this change: the reactor
+				// broadcasts NewValidBlock off this event, and comet relies on
+				// the repetition to make progress.
+				cs.evsw.FireEvent(types.EventValidBlock, &cs.rs)
+				if err := cs.eventBus.PublishEventValidBlock(cs.rs.RoundStateEvent()); err != nil {
+					return added, err
 				}
 			}
 		}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -3117,11 +3117,10 @@ func (cs *State) syncData() {
 	}
 }
 
-// blockMatchesBlockID reports whether both halves of blockID match: block
-// hashes to blockID.Hash and parts carries blockID.PartSetHeader. A block hash
-// does not uniquely determine the serialized body, so hashing to blockID.Hash
-// alone is not proof that a (block, parts) pair is the body blockID refers to.
-// A nil block or part set never matches.
+// blockMatchesBlockID reports whether block hashes to blockID.Hash and parts
+// carries blockID.PartSetHeader; a nil block or part set never matches. Both
+// halves are checked because a hash alone does not uniquely determine the
+// serialized body.
 func blockMatchesBlockID(block *types.Block, parts *types.PartSet, blockID types.BlockID) bool {
 	return block.HashesTo(blockID.Hash) && parts.HasHeader(blockID.PartSetHeader)
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1737,7 +1737,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 	// At this point, +2/3 prevoted for a particular block.
 
 	// If we're already locked on that block, precommit it, and update the LockedRound
-	if cs.rs.LockedBlock.HashesTo(blockID.Hash) {
+	if blockMatchesBlockID(cs.rs.LockedBlock, cs.rs.LockedBlockParts, blockID) {
 		logger.Debug("precommit step; +2/3 prevoted locked block; relocking")
 		cs.rs.LockedRound = round
 
@@ -1750,7 +1750,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 	}
 
 	// If +2/3 prevoted for proposal block, stage and precommit it
-	if cs.rs.ProposalBlock.HashesTo(blockID.Hash) {
+	if blockMatchesBlockID(cs.rs.ProposalBlock, cs.rs.ProposalBlockParts, blockID) {
 		logger.Debug("precommit step; +2/3 prevoted proposal block; locking", "hash", blockID.Hash)
 
 		// Validate the block.
@@ -1770,7 +1770,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 		return
 	}
 
-	// There was a polka in this round for a block we don't have.
+	// There was a polka in this round for a block (or a part set) we don't have.
 	// Fetch that block, unlock, and precommit nil.
 	// The +2/3 prevotes for this round is the POL for our unlock.
 	logger.Debug("precommit step; +2/3 prevotes for a block we do not have; voting nil", "block_id", blockID)
@@ -1867,11 +1867,7 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 	}
 
 	// If we don't have the block being committed, set up to get it.
-	//
-	// Both halves of the BlockID have to match. A block hash does not uniquely
-	// determine the serialized body, so a block that hashes to blockID.Hash is
-	// not necessarily the body the network committed to.
-	if !cs.rs.ProposalBlock.HashesTo(blockID.Hash) || !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
+	if !blockMatchesBlockID(cs.rs.ProposalBlock, cs.rs.ProposalBlockParts, blockID) {
 		if !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 			logger.Info(
 				"commit is for a block we do not know about; set ProposalBlock=nil",
@@ -2407,7 +2403,7 @@ func (cs *State) handleCompleteProposal(blockHeight int64) {
 	prevotes := cs.rs.Votes.Prevotes(cs.rs.Round)
 	blockID, hasTwoThirds := prevotes.TwoThirdsMajority()
 	if hasTwoThirds && !blockID.IsZero() && (cs.rs.ValidRound < cs.rs.Round) {
-		if cs.rs.ProposalBlock.HashesTo(blockID.Hash) {
+		if blockMatchesBlockID(cs.rs.ProposalBlock, cs.rs.ProposalBlockParts, blockID) {
 			cs.Logger.Debug(
 				"updating valid block to new proposal block",
 				"valid_round", cs.rs.Round,
@@ -2645,7 +2641,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			if (cs.rs.LockedBlock != nil) &&
 				(cs.rs.LockedRound < vote.Round) &&
 				(vote.Round <= cs.rs.Round) &&
-				!cs.rs.LockedBlock.HashesTo(blockID.Hash) {
+				!blockMatchesBlockID(cs.rs.LockedBlock, cs.rs.LockedBlockParts, blockID) {
 
 				cs.Logger.Debug("unlocking because of POL", "locked_round", cs.rs.LockedRound, "pol_round", vote.Round)
 
@@ -2661,8 +2657,8 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			// Update Valid* if we can.
 			// NOTE: our proposal block may be nil or not what received a polka..
 			if len(blockID.Hash) != 0 && (cs.rs.ValidRound < vote.Round) && (vote.Round == cs.rs.Round) {
-				if cs.rs.ProposalBlock.HashesTo(blockID.Hash) &&
-					cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
+				partsMatch := cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader)
+				if cs.rs.ProposalBlock.HashesTo(blockID.Hash) && partsMatch {
 					cs.Logger.Debug("updating valid block because of POL", "valid_round", cs.rs.ValidRound, "pol_round", vote.Round)
 					cs.rs.ValidRound = vote.Round
 					cs.rs.ValidBlock = cs.rs.ProposalBlock
@@ -2671,20 +2667,18 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 					cs.Logger.Debug(
 						"valid block we do not know about; set ProposalBlock=nil",
 						"proposal", log.NewLazyBlockHash(cs.rs.ProposalBlock),
+						"proposal_parts", cs.rs.ProposalBlockParts.Header(),
 						"block_id", blockID.Hash,
+						"block_id_parts", blockID.PartSetHeader,
 					)
 
 					// we're getting the wrong block
 					cs.rs.ProposalBlock = nil
 				}
 
-				if !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
-					// We are throwing away the parts collected so far, so any
-					// block decoded from them is stale. ProposalBlock may still
-					// hash to blockID.Hash while having been built from a
-					// different part set, so clear it explicitly rather than
-					// relying on the hash comparison above.
-					cs.rs.ProposalBlock = nil
+				if !partsMatch {
+					// The parts collected so far are not the polka's part set;
+					// throw them away and start collecting the polka's parts.
 					cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 					psh := blockID.PartSetHeader
 					cs.propagator.AddCommitment(height, vote.Round, &psh)
@@ -3107,6 +3101,15 @@ func (cs *State) syncData() {
 			cs.peerMsgQueue <- msgInfo{&BlockPartMessage{h, r, part.Part}, ""}
 		}
 	}
+}
+
+// blockMatchesBlockID reports whether both halves of blockID match: block
+// hashes to blockID.Hash and parts carries blockID.PartSetHeader. A block hash
+// does not uniquely determine the serialized body, so hashing to blockID.Hash
+// alone is not proof that a (block, parts) pair is the body blockID refers to.
+// A nil block or part set never matches.
+func blockMatchesBlockID(block *types.Block, parts *types.PartSet, blockID types.BlockID) bool {
+	return block.HashesTo(blockID.Hash) && parts.HasHeader(blockID.PartSetHeader)
 }
 
 func (cs *State) lockAll() {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2661,7 +2661,8 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			// Update Valid* if we can.
 			// NOTE: our proposal block may be nil or not what received a polka..
 			if len(blockID.Hash) != 0 && (cs.rs.ValidRound < vote.Round) && (vote.Round == cs.rs.Round) {
-				if cs.rs.ProposalBlock.HashesTo(blockID.Hash) {
+				if cs.rs.ProposalBlock.HashesTo(blockID.Hash) &&
+					cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 					cs.Logger.Debug("updating valid block because of POL", "valid_round", cs.rs.ValidRound, "pol_round", vote.Round)
 					cs.rs.ValidRound = vote.Round
 					cs.rs.ValidBlock = cs.rs.ProposalBlock

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1858,9 +1858,11 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 	}
 
 	// The Locked* fields no longer matter.
-	// Move them over to ProposalBlock if they match the commit hash,
-	// otherwise they'll be cleared in updateToState.
-	if cs.rs.LockedBlock.HashesTo(blockID.Hash) {
+	// Move them over to ProposalBlock if they match the full commit BlockID,
+	// otherwise they'll be cleared in updateToState. Promoting on the hash
+	// alone could replace a proposal pair that matches the commit with a
+	// locked body built from a different part set.
+	if blockMatchesBlockID(cs.rs.LockedBlock, cs.rs.LockedBlockParts, blockID) {
 		logger.Debug("commit is for a locked block; set ProposalBlock=LockedBlock", "block_hash", blockID.Hash)
 		cs.rs.ProposalBlock = cs.rs.LockedBlock
 		cs.rs.ProposalBlockParts = cs.rs.LockedBlockParts
@@ -1868,6 +1870,12 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 
 	// If we don't have the block being committed, set up to get it.
 	if !blockMatchesBlockID(cs.rs.ProposalBlock, cs.rs.ProposalBlockParts, blockID) {
+		// Whatever block we were holding was not built from the part set being
+		// committed, so it cannot be the block to finalize even if it happens
+		// to hash to blockID.Hash. Drop it before announcing the new round
+		// state and wait for the committed parts.
+		cs.rs.ProposalBlock = nil
+
 		if !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 			logger.Info(
 				"commit is for a block we do not know about; set ProposalBlock=nil",
@@ -1887,11 +1895,6 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 
 			cs.evsw.FireEvent(types.EventValidBlock, &cs.rs)
 		}
-
-		// Whatever block we were holding was not built from the part set being
-		// committed, so it cannot be the block to finalize even if it happens
-		// to hash to blockID.Hash. Drop it and wait for the committed parts.
-		cs.rs.ProposalBlock = nil
 	}
 }
 
@@ -2658,12 +2661,14 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			// NOTE: our proposal block may be nil or not what received a polka..
 			if len(blockID.Hash) != 0 && (cs.rs.ValidRound < vote.Round) && (vote.Round == cs.rs.Round) {
 				partsMatch := cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader)
+				stateChanged := false
 				if cs.rs.ProposalBlock.HashesTo(blockID.Hash) && partsMatch {
 					cs.Logger.Debug("updating valid block because of POL", "valid_round", cs.rs.ValidRound, "pol_round", vote.Round)
 					cs.rs.ValidRound = vote.Round
 					cs.rs.ValidBlock = cs.rs.ProposalBlock
 					cs.rs.ValidBlockParts = cs.rs.ProposalBlockParts
-				} else {
+					stateChanged = true
+				} else if cs.rs.ProposalBlock != nil {
 					cs.Logger.Debug(
 						"valid block we do not know about; set ProposalBlock=nil",
 						"proposal", log.NewLazyBlockHash(cs.rs.ProposalBlock),
@@ -2674,6 +2679,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 
 					// we're getting the wrong block
 					cs.rs.ProposalBlock = nil
+					stateChanged = true
 				}
 
 				if !partsMatch {
@@ -2682,11 +2688,18 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 					cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartSetHeader, types.BlockPartSizeBytes)
 					psh := blockID.PartSetHeader
 					cs.propagator.AddCommitment(height, vote.Round, &psh)
+					stateChanged = true
 				}
 
-				cs.evsw.FireEvent(types.EventValidBlock, &cs.rs)
-				if err := cs.eventBus.PublishEventValidBlock(cs.rs.RoundStateEvent()); err != nil {
-					return added, err
+				// When the polka names a part set we do not hold, ValidRound
+				// does not advance, so every later prevote of the round
+				// re-enters this block. Announce only for the vote that
+				// changed what we hold.
+				if stateChanged {
+					cs.evsw.FireEvent(types.EventValidBlock, &cs.rs)
+					if err := cs.eventBus.PublishEventValidBlock(cs.rs.RoundStateEvent()); err != nil {
+						return added, err
+					}
 				}
 			}
 		}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1926,8 +1926,9 @@ func (cs *State) tryFinalizeCommit(height int64) {
 	// Hashing to blockID.Hash is not on its own enough to finalize: the part
 	// set we hold must also be the committed one, and it must be complete.
 	// finalizeCommit asserts both and panics otherwise, and the block store
-	// panics when handed an incomplete part set. Wait instead. Once the
-	// committed parts arrive, handleCompleteProposal calls back in here.
+	// panics when handed an incomplete part set. Wait instead: as the missing
+	// parts arrive, addProposalBlockPart decodes the block and calls back in
+	// here via handleCompleteProposal.
 	if !cs.rs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) || !cs.rs.ProposalBlockParts.IsComplete() {
 		logger.Debug(
 			"failed attempt to finalize commit; we do not have the complete commit block parts",

--- a/consensus/state_partset_identity_test.go
+++ b/consensus/state_partset_identity_test.go
@@ -309,43 +309,6 @@ func TestEnterCommitKeepsCommittedProposalOverAliasedLock(t *testing.T) {
 		"the committed parts we were collecting must be kept")
 }
 
-// TestAliasedPolkaAnnouncesValidBlockOnce checks that a polka for a different
-// part set fires EventValidBlock only for the vote that changed our state.
-// Because the aliased case never advances ValidRound, every later prevote of
-// the round re-enters the update and would otherwise re-broadcast
-// NewValidBlock to every peer.
-func TestAliasedPolkaAnnouncesValidBlockOnce(t *testing.T) {
-	cs, vss := randState(4)
-	// randState leaves the stub for our own validator at height 0; sign with
-	// it too so a fourth prevote can arrive after the polka.
-	vss[0].Height = cs.rs.Height
-
-	block, parts, err := cs.createProposalBlock(context.Background())
-	require.NoError(t, err)
-
-	alias := aliasBlock(t, block)
-	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
-	require.NoError(t, err)
-	require.NotEqual(t, parts.Header(), aliasParts.Header())
-
-	cs.rs.ProposalBlock = block
-	cs.rs.ProposalBlockParts = parts
-
-	fired := 0
-	require.NoError(t, cs.evsw.AddListenerForEvent("test", types.EventValidBlock,
-		func(cmtevents.EventData) { fired++ }))
-
-	pol := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
-	for i, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss...) {
-		added, err := cs.addVote(vote, "peer")
-		require.NoError(t, err)
-		require.True(t, added, "vote %d from validator %X", i, vote.ValidatorAddress)
-	}
-
-	require.Equal(t, 1, fired,
-		"only the prevote that crossed two thirds changed our state, so only it may announce")
-}
-
 // TestEnterCommitClearsStaleBlockBeforeAnnouncing checks that when enterCommit
 // drops a block that was not built from the committed part set, listeners of
 // EventValidBlock never observe the stale block paired with the freshly reset
@@ -414,4 +377,35 @@ func TestTryFinalizeCommitWaitsForCompletePartSet(t *testing.T) {
 	require.NotPanics(t, func() { cs.tryFinalizeCommit(height) })
 
 	require.Equal(t, height, cs.rs.Height, "must not have advanced past the height")
+}
+
+// TestPOLAnnouncesValidBlockWhenPartsAlreadyKnown covers the delayed-body path:
+// the proposal metadata has arrived so ProposalBlockParts already carries the
+// polka's part set header, but the body is still incomplete so ProposalBlock is
+// nil. Nothing about what we hold changes, yet subscribers still have to learn
+// about the polka: the reactor broadcasts NewValidBlock off this event, which is
+// how peers learn which parts to send us.
+func TestPOLAnnouncesValidBlockWhenPartsAlreadyKnown(t *testing.T) {
+	cs, vss := randState(4)
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	// Proposal metadata arrived, body did not.
+	cs.rs.ProposalBlock = nil
+	cs.rs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header(), types.BlockPartSizeBytes)
+
+	fired := 0
+	require.NoError(t, cs.evsw.AddListenerForEvent("test", types.EventValidBlock,
+		func(cmtevents.EventData) { fired++ }))
+
+	pol := types.BlockID{Hash: block.Hash(), PartSetHeader: parts.Header()}
+	for _, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss[1:]...) {
+		added, err := cs.addVote(vote, "peer")
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	require.NotZero(t, fired,
+		"the polka has to be announced so peers learn which parts to send us")
 }

--- a/consensus/state_partset_identity_test.go
+++ b/consensus/state_partset_identity_test.go
@@ -83,6 +83,36 @@ func TestEnterCommitDropsBlockFromDifferentPartSet(t *testing.T) {
 	require.False(t, cs.rs.ProposalBlockParts.IsComplete())
 }
 
+// TestPOLDoesNotPromoteBlockFromDifferentPartSet checks that a proposal is not
+// recorded as the valid block unless both halves of its BlockID match the POL.
+func TestPOLDoesNotPromoteBlockFromDifferentPartSet(t *testing.T) {
+	cs, vss := randState(4)
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	cs.rs.ProposalBlock = block
+	cs.rs.ProposalBlockParts = parts
+
+	pol := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for _, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss[1:]...) {
+		added, err := cs.addVote(vote, "peer")
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	require.EqualValues(t, -1, cs.rs.ValidRound)
+	require.Nil(t, cs.rs.ValidBlock)
+	require.Nil(t, cs.rs.ValidBlockParts)
+	require.Nil(t, cs.rs.ProposalBlock)
+	require.Equal(t, pol.PartSetHeader, cs.rs.ProposalBlockParts.Header())
+}
+
 // TestTryFinalizeCommitWaitsForCompletePartSet checks that tryFinalizeCommit
 // declines to finalize when the part set matches the commit but is not yet
 // complete. finalizeCommit would otherwise hand an incomplete part set to the

--- a/consensus/state_partset_identity_test.go
+++ b/consensus/state_partset_identity_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	cstypes "github.com/cometbft/cometbft/consensus/types"
+	cmtevents "github.com/cometbft/cometbft/libs/events"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
@@ -266,6 +267,124 @@ func TestPOLUnlocksBlockFromDifferentPartSet(t *testing.T) {
 		"a POL for the same hash but a different part set must unlock")
 	require.EqualValues(t, -1, cs.rs.LockedRound)
 	require.Nil(t, cs.rs.LockedBlockParts)
+}
+
+// TestEnterCommitKeepsCommittedProposalOverAliasedLock checks that a lock on an
+// aliased body does not clobber a proposal pair that matches the commit. Before
+// this was handled, the locked pair was promoted on the hash alone and the
+// guard below then discarded the committed parts we were collecting.
+func TestEnterCommitKeepsCommittedProposalOverAliasedLock(t *testing.T) {
+	cs, vss := randState(4)
+	height, round := cs.rs.Height, cs.rs.Round
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	// We locked on the aliased body, but hold the committed block and are
+	// collecting the committed part set.
+	cs.rs.LockedRound = round
+	cs.rs.LockedBlock = alias
+	cs.rs.LockedBlockParts = aliasParts
+	cs.rs.ProposalBlock = block
+	proposalParts := types.NewPartSetFromHeader(parts.Header(), types.BlockPartSizeBytes)
+	cs.rs.ProposalBlockParts = proposalParts
+
+	committed := types.BlockID{Hash: block.Hash(), PartSetHeader: parts.Header()}
+	for _, vote := range signVotes(cmtproto.PrecommitType, committed.Hash, committed.PartSetHeader, true, vss[1:]...) {
+		added, err := cs.rs.Votes.AddVote(vote, "peer", true)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	require.NotPanics(t, func() { cs.enterCommit(height, round) })
+
+	require.Same(t, block, cs.rs.ProposalBlock,
+		"the proposal matches the commit, so the aliased lock must not replace it")
+	require.Same(t, proposalParts, cs.rs.ProposalBlockParts,
+		"the committed parts we were collecting must be kept")
+}
+
+// TestAliasedPolkaAnnouncesValidBlockOnce checks that a polka for a different
+// part set fires EventValidBlock only for the vote that changed our state.
+// Because the aliased case never advances ValidRound, every later prevote of
+// the round re-enters the update and would otherwise re-broadcast
+// NewValidBlock to every peer.
+func TestAliasedPolkaAnnouncesValidBlockOnce(t *testing.T) {
+	cs, vss := randState(4)
+	// randState leaves the stub for our own validator at height 0; sign with
+	// it too so a fourth prevote can arrive after the polka.
+	vss[0].Height = cs.rs.Height
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	cs.rs.ProposalBlock = block
+	cs.rs.ProposalBlockParts = parts
+
+	fired := 0
+	require.NoError(t, cs.evsw.AddListenerForEvent("test", types.EventValidBlock,
+		func(cmtevents.EventData) { fired++ }))
+
+	pol := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for i, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss...) {
+		added, err := cs.addVote(vote, "peer")
+		require.NoError(t, err)
+		require.True(t, added, "vote %d from validator %X", i, vote.ValidatorAddress)
+	}
+
+	require.Equal(t, 1, fired,
+		"only the prevote that crossed two thirds changed our state, so only it may announce")
+}
+
+// TestEnterCommitClearsStaleBlockBeforeAnnouncing checks that when enterCommit
+// drops a block that was not built from the committed part set, listeners of
+// EventValidBlock never observe the stale block paired with the freshly reset
+// part set.
+func TestEnterCommitClearsStaleBlockBeforeAnnouncing(t *testing.T) {
+	cs, vss := randState(4)
+	height, round := cs.rs.Height, cs.rs.Round
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	cs.rs.ProposalBlock = block
+	cs.rs.ProposalBlockParts = parts
+
+	var observed *types.Block
+	fired := 0
+	require.NoError(t, cs.evsw.AddListenerForEvent("test", types.EventValidBlock,
+		func(data cmtevents.EventData) {
+			fired++
+			observed = data.(*cstypes.RoundState).ProposalBlock
+		}))
+
+	committed := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for _, vote := range signVotes(cmtproto.PrecommitType, committed.Hash, committed.PartSetHeader, true, vss[1:]...) {
+		added, err := cs.rs.Votes.AddVote(vote, "peer", true)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	require.NotPanics(t, func() { cs.enterCommit(height, round) })
+
+	require.Equal(t, 1, fired)
+	require.Nil(t, observed,
+		"the block we held was not built from the committed part set, so listeners must not see it")
 }
 
 // TestTryFinalizeCommitWaitsForCompletePartSet checks that tryFinalizeCommit

--- a/consensus/state_partset_identity_test.go
+++ b/consensus/state_partset_identity_test.go
@@ -113,6 +113,161 @@ func TestPOLDoesNotPromoteBlockFromDifferentPartSet(t *testing.T) {
 	require.Equal(t, pol.PartSetHeader, cs.rs.ProposalBlockParts.Header())
 }
 
+// TestHandleCompleteProposalDoesNotPromoteBlockFromDifferentPartSet checks the
+// parts-arrive-after-polka path: when a completed proposal hashes to a
+// pre-existing POL but was built from a different part set, it must not be
+// recorded as the valid block.
+func TestHandleCompleteProposalDoesNotPromoteBlockFromDifferentPartSet(t *testing.T) {
+	cs, vss := randState(4)
+	height := cs.rs.Height
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	// We hold a complete proposal built from our own part set, past the
+	// propose step so handleCompleteProposal only runs the Valid* update.
+	cs.rs.ProposalBlock = block
+	cs.rs.ProposalBlockParts = parts
+	cs.rs.Step = cstypes.RoundStepPrevote
+
+	// A polka for the aliased body already exists at this round; add the votes
+	// to the vote set directly so addVote's own defenses are not in play.
+	pol := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for _, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss[1:]...) {
+		added, err := cs.rs.Votes.AddVote(vote, "peer", true)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	cs.handleCompleteProposal(height)
+
+	require.EqualValues(t, -1, cs.rs.ValidRound)
+	require.Nil(t, cs.rs.ValidBlock)
+	require.Nil(t, cs.rs.ValidBlockParts)
+}
+
+// TestEnterPrecommitDoesNotLockBlockFromDifferentPartSet checks that a polka
+// for a block that hashes to our proposal but was built from a different part
+// set does not lock the proposal: the node must precommit nil, drop the
+// mismatched body, and start collecting the polka's part set.
+func TestEnterPrecommitDoesNotLockBlockFromDifferentPartSet(t *testing.T) {
+	cs, vss := randState(4)
+	height, round := cs.rs.Height, cs.rs.Round
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	cs.rs.ProposalBlock = block
+	cs.rs.ProposalBlockParts = parts
+	cs.rs.Step = cstypes.RoundStepPrevote
+
+	pol := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for _, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss[1:]...) {
+		added, err := cs.rs.Votes.AddVote(vote, "peer", true)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	cs.lockAll()
+	cs.enterPrecommit(height, round)
+	cs.unlockAll()
+
+	require.Nil(t, cs.rs.LockedBlock,
+		"must not lock a block built from a different part set than the polka")
+	require.EqualValues(t, -1, cs.rs.LockedRound)
+	require.Nil(t, cs.rs.ProposalBlock)
+	require.Equal(t, pol.PartSetHeader, cs.rs.ProposalBlockParts.Header(),
+		"we must be collecting the polka's part set")
+}
+
+// TestEnterPrecommitDoesNotRelockBlockFromDifferentPartSet checks that a polka
+// for a block that hashes to our locked block but was built from a different
+// part set does not relock: relocking would keep a part set the precommit's
+// BlockID does not refer to.
+func TestEnterPrecommitDoesNotRelockBlockFromDifferentPartSet(t *testing.T) {
+	cs, vss := randState(4)
+	height, round := cs.rs.Height, cs.rs.Round
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	// We are locked on the body built from our own part set.
+	cs.rs.LockedRound = round
+	cs.rs.LockedBlock = block
+	cs.rs.LockedBlockParts = parts
+	cs.rs.Step = cstypes.RoundStepPrevote
+
+	pol := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for _, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss[1:]...) {
+		added, err := cs.rs.Votes.AddVote(vote, "peer", true)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	cs.lockAll()
+	cs.enterPrecommit(height, round)
+	cs.unlockAll()
+
+	require.Nil(t, cs.rs.LockedBlock,
+		"must not stay locked on a block built from a different part set than the polka")
+	require.EqualValues(t, -1, cs.rs.LockedRound)
+	require.Equal(t, pol.PartSetHeader, cs.rs.ProposalBlockParts.Header(),
+		"we must be collecting the polka's part set")
+}
+
+// TestPOLUnlocksBlockFromDifferentPartSet checks that a later-round polka for
+// the same block hash but a different part set unlocks: the locked identity is
+// not the one the polka endorses, so staying locked would keep the node
+// prevoting a BlockID no polka backs.
+func TestPOLUnlocksBlockFromDifferentPartSet(t *testing.T) {
+	cs, vss := randState(4)
+
+	block, parts, err := cs.createProposalBlock(context.Background())
+	require.NoError(t, err)
+
+	alias := aliasBlock(t, block)
+	aliasParts, err := alias.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	require.NotEqual(t, parts.Header(), aliasParts.Header())
+
+	// Locked in round 0 on the body built from our own part set; the node has
+	// since moved to round 1.
+	cs.rs.LockedRound = 0
+	cs.rs.LockedBlock = block
+	cs.rs.LockedBlockParts = parts
+	cs.rs.Round = 1
+
+	pol := types.BlockID{Hash: alias.Hash(), PartSetHeader: aliasParts.Header()}
+	for _, vs := range vss[1:] {
+		vs.Round = 1
+	}
+	for _, vote := range signVotes(cmtproto.PrevoteType, pol.Hash, pol.PartSetHeader, false, vss[1:]...) {
+		added, err := cs.addVote(vote, "peer")
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	require.Nil(t, cs.rs.LockedBlock,
+		"a POL for the same hash but a different part set must unlock")
+	require.EqualValues(t, -1, cs.rs.LockedRound)
+	require.Nil(t, cs.rs.LockedBlockParts)
+}
+
 // TestTryFinalizeCommitWaitsForCompletePartSet checks that tryFinalizeCommit
 // declines to finalize when the part set matches the commit but is not yet
 // complete. finalizeCommit would otherwise hand an incomplete part set to the


### PR DESCRIPTION
Closes [PROTOCO-2276](https://linear.app/celestia/issue/PROTOCO-2276)

Ensures consensus identifies blocks by the full `BlockID` (hash and part-set header), not the hash alone. A shared helper now covers valid-block promotion, lock/relock/unlock, and commit paths. It also prevents listeners from observing a stale proposal block paired with a freshly reset part set.

Regression coverage is in `consensus/state_partset_identity_test.go`.

**Consensus impact:** a polka or commit with a different part-set header is treated as a block we do not have, triggering unlock, precommit nil, or re-fetch as appropriate. `EventValidBlock` emission is unchanged from `v0.40.x`.

Backport: #3260.
