### PR TITLE
fix(p2p): render peer identity in JSON log fields

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"sync/atomic"
@@ -190,6 +191,14 @@ func (p *peer) String() string {
 	}
 
 	return fmt.Sprintf("Peer{%v %v in}", p.mconn, p.ID())
+}
+
+// MarshalJSON renders the peer as its string form. JSON-field loggers marshal
+// log values with encoding/json, which ignores fmt.Stringer and would
+// otherwise dump the peer's exported fields ({"Data":{},"Logger":{...}}),
+// which identify nothing.
+func (p *peer) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
 }
 
 //---------------------------------------------------

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"encoding/json"
 	"fmt"
 	golog "log"
 	"net"
@@ -47,6 +48,32 @@ func TestPeerBasic(t *testing.T) {
 	assert.True(p.IsPersistent())
 	assert.Equal(rp.Addr().DialString(), p.RemoteAddr().String())
 	assert.Equal(rp.ID(), p.ID())
+}
+
+// JSON-field loggers (e.g. the zerolog-backed logger celestia-app injects)
+// marshal log values with encoding/json, which ignores fmt.Stringer. Without a
+// MarshalJSON override, a peer renders as a dump of its exported fields
+// (`{"Data":{},"Logger":{"Logger":{}}}`) instead of anything identifying it.
+func TestPeerMarshalJSON(t *testing.T) {
+	rp := &remotePeer{PrivKey: ed25519.GenPrivKey(), Config: cfg}
+	rp.Start()
+	t.Cleanup(rp.Stop)
+
+	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), cfg, cmtconn.DefaultMConnConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := p.CloseConn(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	bz, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	expected, err := json.Marshal(p.String())
+	require.NoError(t, err)
+	assert.Equal(t, string(expected), string(bz))
+	assert.Contains(t, string(bz), string(p.ID()))
 }
 
 func TestPeerSend(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-core/issues/3051

Node operators see log lines like `Stopping peer for error err=EOF ... peer={"Data":{},"Logger":{"Logger":{}}}` because JSON-field loggers (e.g. the zerolog-backed logger celestia-app injects) marshal log values with `encoding/json`, which ignores `fmt.Stringer` and dumps the peer struct's exported fields. This implements `MarshalJSON` on `*peer` so every `"peer", peer` log field renders the peer's address and ID instead. Together with #3110 and #3111 (which downgraded the noisy log levels), this covers the errors reported in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8jRDMBEEPbwDE2jJoquSJ