### PR TITLE
fix(consensus): backport double-sign check off-by-one and statsMsgQueue stall (backport #3207)

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1056,9 +1056,6 @@ func (cs *State) handleMsg(mi msgInfo) {
 		if added && cs.rs.ProposalBlockParts.IsComplete() {
 			cs.handleCompleteProposal(msg.Height)
 		}
-		if added {
-			cs.statsMsgQueue <- mi
-		}
 
 		if err != nil && msg.Round != cs.rs.Round {
 			cs.Logger.Trace(
@@ -1074,9 +1071,6 @@ func (cs *State) handleMsg(mi msgInfo) {
 		// attempt to add the vote and dupeout the validator if its a duplicate signature
 		// if the vote gives us a 2/3-any or 2/3-one, we transition
 		added, err = cs.tryAddVote(msg.Vote, peerID)
-		if added {
-			cs.statsMsgQueue <- mi
-		}
 
 		// if err == ErrAddingVote {
 		// TODO: punish peer
@@ -1107,6 +1101,14 @@ func (cs *State) handleMsg(mi msgInfo) {
 			"msg_type", fmt.Sprintf("%T", msg),
 			"err", err,
 		)
+	}
+
+	// Release the locks while sending: statsMsgQueue is drained by the reactor,
+	// and blocking on a full queue here would stall the state machine.
+	if added {
+		cs.unlockAll()
+		cs.statsMsgQueue <- mi
+		cs.lockAll()
 	}
 }
 
@@ -2790,11 +2792,11 @@ func (cs *State) checkDoubleSigningRisk(height int64) error {
 	if cs.privValidator != nil && cs.privValidatorPubKey != nil && cs.config.DoubleSignCheckHeight > 0 && height > 0 {
 		valAddr := cs.privValidatorPubKey.Address()
 		doubleSignCheckHeight := cs.config.DoubleSignCheckHeight
-		if doubleSignCheckHeight > height {
-			doubleSignCheckHeight = height
+		if doubleSignCheckHeight >= height {
+			doubleSignCheckHeight = height - 1
 		}
 
-		for i := int64(1); i < doubleSignCheckHeight; i++ {
+		for i := int64(1); i <= doubleSignCheckHeight; i++ {
 			lastCommit := cs.blockStore.LoadSeenCommit(height - i)
 			if lastCommit != nil {
 				for sigIdx, s := range lastCommit.Signatures {

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -25,6 +25,7 @@ import (
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	p2pmock "github.com/cometbft/cometbft/p2p/mock"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	smmocks "github.com/cometbft/cometbft/state/mocks"
 	"github.com/cometbft/cometbft/types"
 )
 
@@ -2720,4 +2721,161 @@ func findBlockSizeLimit(t *testing.T, height, maxBytes int64, cs *State, _ uint3
 	}
 	require.Fail(t, "We shouldn't hit the end of the loop")
 	return nil, nil
+}
+
+// newStateForDoubleSignTest builds the minimal State needed by checkDoubleSigningRisk.
+func newStateForDoubleSignTest(t *testing.T, doubleSignCheckHeight int64) (*State, *smmocks.BlockStore) {
+	t.Helper()
+
+	consConfig := *config.Consensus
+	consConfig.DoubleSignCheckHeight = doubleSignCheckHeight
+
+	mockBS := &smmocks.BlockStore{}
+
+	cs := &State{
+		config:     &consConfig,
+		blockStore: mockBS,
+	}
+	// Set the logger directly on the embedded BaseService: timeoutTicker and the
+	// rest of the wiring are not needed by checkDoubleSigningRisk.
+	cs.Logger = log.TestingLogger()
+
+	pv := types.NewMockPV()
+	pubKey, err := pv.GetPubKey()
+	require.NoError(t, err)
+
+	cs.privValidator = pv
+	cs.privValidatorPubKey = pubKey
+
+	return cs, mockBS
+}
+
+// makeCommitWithValidator builds a commit with a single commit signature.
+func makeCommitWithValidator(height int64, validatorAddr types.Address) *types.Commit {
+	return &types.Commit{
+		Height: height,
+		Signatures: []types.CommitSig{
+			{
+				BlockIDFlag:      types.BlockIDFlagCommit,
+				ValidatorAddress: validatorAddr,
+				Timestamp:        time.Now(),
+			},
+		},
+	}
+}
+
+// TestCheckDoubleSigningRisk checks that double_sign_check_height = N inspects
+// exactly the N blocks preceding height.
+func TestCheckDoubleSigningRisk(t *testing.T) {
+	type seenCommit struct {
+		height     int64
+		signedByUs bool
+	}
+
+	testCases := []struct {
+		name                  string
+		doubleSignCheckHeight int64
+		height                int64
+		seenCommits           []seenCommit
+		wantErr               error
+		wantNoLoadSeenCommit  bool
+	}{
+		{
+			// Regression: a value of 1 used to perform zero checks, silently
+			// behaving like 0 (disabled).
+			name:                  "one checks the single preceding block",
+			doubleSignCheckHeight: 1,
+			height:                10,
+			seenCommits:           []seenCommit{{height: 9, signedByUs: true}},
+			wantErr:               ErrSignatureFoundInPastBlocks,
+		},
+		{
+			name:                  "two checks both preceding blocks",
+			doubleSignCheckHeight: 2,
+			height:                10,
+			seenCommits:           []seenCommit{{height: 9}, {height: 8, signedByUs: true}},
+			wantErr:               ErrSignatureFoundInPastBlocks,
+		},
+		{
+			name:                  "no signature from us is not a risk",
+			doubleSignCheckHeight: 2,
+			height:                10,
+			seenCommits:           []seenCommit{{height: 9}, {height: 8}},
+		},
+		{
+			name:                  "zero disables the check",
+			doubleSignCheckHeight: 0,
+			height:                10,
+			wantNoLoadSeenCommit:  true,
+		},
+		{
+			name:                  "check height beyond chain height does not look below the genesis block",
+			doubleSignCheckHeight: 10,
+			height:                1,
+			wantNoLoadSeenCommit:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs, mockBS := newStateForDoubleSignTest(t, tc.doubleSignCheckHeight)
+			ourAddr := cs.privValidatorPubKey.Address()
+			otherAddr := append(types.Address(nil), ourAddr...)
+			require.NotEmpty(t, otherAddr)
+			otherAddr[len(otherAddr)-1] ^= 0x01
+
+			for _, sc := range tc.seenCommits {
+				addr := otherAddr
+				if sc.signedByUs {
+					addr = ourAddr
+				}
+				mockBS.On("LoadSeenCommit", sc.height).Return(makeCommitWithValidator(sc.height, addr))
+			}
+
+			var err error
+			require.NotPanics(t, func() {
+				err = cs.checkDoubleSigningRisk(tc.height)
+			})
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.wantNoLoadSeenCommit {
+				mockBS.AssertNotCalled(t, "LoadSeenCommit", mock.Anything)
+				return
+			}
+			mockBS.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandleMsgReleasesLockBeforeStatsMsgQueueSend ensures a saturated
+// statsMsgQueue cannot stall the consensus state machine: handleMsg must not
+// hold the round state lock while sending.
+func TestHandleMsgReleasesLockBeforeStatsMsgQueueSend(t *testing.T) {
+	cs, vss := randState(2)
+	peer := p2pmock.NewPeer(nil)
+
+	randBytes := cmtrand.Bytes(tmhash.Size)
+	vote := signVote(vss[1], cmtproto.PrecommitType, randBytes, types.PartSetHeader{}, true)
+
+	// An unbuffered channel with no consumer simulates a saturated queue.
+	cs.statsMsgQueue = make(chan msgInfo)
+
+	go cs.handleMsg(msgInfo{&VoteMessage{vote}, peer.ID()})
+	time.Sleep(20 * time.Millisecond)
+
+	rsResult := make(chan *cstypes.RoundState, 1)
+	go func() { rsResult <- cs.GetRoundState() }()
+
+	select {
+	case <-rsResult:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetRoundState timed out: round state lock held during statsMsgQueue send")
+	}
+
+	<-cs.statsMsgQueue
 }


### PR DESCRIPTION
Backport of #3207 to v0.40.x. Mergify's attempt (#3211) died on a cherry-pick conflict in `consensus/state.go`; resolved here by keeping the v0.40.x catch-all error logging while hoisting the `statsMsgQueue` send out of the switch with the consensus locks released. Includes the `checkDoubleSigningRisk` off-by-one fix and both regression tests.

Note for reviewers: touches the consensus message-handling path — please double-check the conflict resolution in `handleMsg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2YFU3xibm42UWwCoFy1q