### PR TITLE
fix(blocksync): prevent maxPeerHeight poisoning and IsCaughtUp with pruned-ahead peers (backport #3038, #3058)

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -275,10 +275,35 @@ func (pool *BlockPool) IsCaughtUp() bool {
 	// and that we're synced to the highest known height.
 	// Note we use maxPeerHeight - 1 because to sync block H requires block H+1
 	// to verify the LastCommit.
+	//
+	// maxPeerHeight == 0 happens in two distinct cases:
+	//   1. Fresh network: no peer has produced any blocks yet (all peer
+	//      heights are 0). We are caught up to the network and should switch
+	//      to consensus to participate in producing the first block.
+	//   2. Stalled: peers exist with blocks but updateMaxPeerHeight filtered
+	//      them all out (every peer's base is ahead of pool.height). The
+	//      network is ahead of us but no peer can serve our height, so we
+	//      are not caught up and must stay in blocksync.
 	receivedBlockOrTimedOut := pool.height > 0 || time.Since(pool.startTime) > 5*time.Second
-	ourChainIsLongestAmongPeers := pool.maxPeerHeight == 0 || pool.height >= (pool.maxPeerHeight-1)
+	var ourChainIsLongestAmongPeers bool
+	if pool.maxPeerHeight == 0 {
+		ourChainIsLongestAmongPeers = !pool.anyPeerHasBlocks()
+	} else {
+		ourChainIsLongestAmongPeers = pool.height >= (pool.maxPeerHeight - 1)
+	}
 	isCaughtUp := receivedBlockOrTimedOut && ourChainIsLongestAmongPeers
 	return isCaughtUp
+}
+
+// anyPeerHasBlocks reports whether any peer in the pool advertises a non-zero
+// height. CONTRACT: pool.mtx must be locked.
+func (pool *BlockPool) anyPeerHasBlocks() bool {
+	for _, peer := range pool.peers {
+		if peer.height > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // PeekTwoBlocks returns blocks at pool.height and pool.height+1. We need to

--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -302,6 +302,15 @@ func (pool *BlockPool) PeekTwoBlocks() (first, second *types.Block, firstExtComm
 	return
 }
 
+// SetHeight sets the current pool height under the mutex. Used by the
+// blocksync reactor when switching from state sync, where pool.height must be
+// advanced past the snapshot height before requesters start firing.
+func (pool *BlockPool) SetHeight(height int64) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	pool.height = height
+}
+
 // PopRequest removes the requester at pool.height and increments pool.height.
 func (pool *BlockPool) PopRequest() {
 	pool.mtx.Lock()
@@ -317,6 +326,10 @@ func (pool *BlockPool) PopRequest() {
 	}
 	delete(pool.requesters, pool.height)
 	pool.height++
+
+	// Re-evaluate maxPeerHeight: peers whose pruned base was just beyond the
+	// previous pool.height may now be able to contribute.
+	pool.updateMaxPeerHeight()
 }
 
 // RemovePeerAndRedoAllPeerRequests retries the request at the given height and
@@ -452,6 +465,17 @@ func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
+	// A peer whose own reported base exceeds its own height is structurally
+	// impossible and treated as malicious.
+	if base > height {
+		pool.Logger.Info("Peer reporting base greater than height", "peer", peerID, "base", base, "height", height)
+		if _, exists := pool.peers[peerID]; exists {
+			pool.removePeer(peerID)
+		}
+		pool.banPeer(peerID)
+		return
+	}
+
 	peer := pool.peers[peerID]
 	if peer != nil {
 		if base < peer.base || height < peer.height {
@@ -479,9 +503,7 @@ func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 		pool.sortedPeers = append([]*bpPeer{peer}, pool.sortedPeers...)
 	}
 
-	if height > pool.maxPeerHeight {
-		pool.maxPeerHeight = height
-	}
+	pool.updateMaxPeerHeight()
 }
 
 // RemovePeer removes the peer with peerID from the pool. If there's no peer
@@ -523,10 +545,18 @@ func (pool *BlockPool) removePeer(peerID p2p.ID) {
 	}
 }
 
-// If no peers are left, maxPeerHeight is set to 0.
+// updateMaxPeerHeight sets maxPeerHeight to the highest height among peers
+// whose advertised range still covers pool.height. If no peers are left,
+// maxPeerHeight is set to 0.
 func (pool *BlockPool) updateMaxPeerHeight() {
 	var max int64
 	for _, peer := range pool.peers {
+		if pool.height > 0 && peer.base > pool.height {
+			// Block a malicious peer from poisoning maxPeerHeight with an
+			// inflated base/height pair no peer can actually serve, which
+			// would stall IsCaughtUp forever.
+			continue
+		}
 		if peer.height > max {
 			max = peer.height
 		}

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -719,3 +719,58 @@ func TestBlockPoolMaxPeerHeightRefreshesOnPopRequest(t *testing.T) {
 	require.EqualValues(t, 100, pool.MaxPeerHeight(),
 		"peer B must contribute to maxPeerHeight once pool.height reaches its base")
 }
+
+// TestBlockPoolIsCaughtUpAllPeersPrunedAhead verifies that a node does NOT
+// consider itself caught up when every connected peer advertises a base
+// higher than pool.height. In that case updateMaxPeerHeight() filters all
+// peers out, leaving maxPeerHeight == 0; IsCaughtUp must still return false
+// because peers exist and are in fact ahead of us, just unable to serve.
+//
+// Regression test for premature blocksync -> consensus switch  when the only available
+// peer reports base > pool.height.
+func TestBlockPoolIsCaughtUpAllPeersPrunedAhead(t *testing.T) {
+	const ourHeight = int64(100)
+
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+	pool := NewBlockPool(ourHeight, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	// Every connected peer is pruned ahead of pool.height — none can serve
+	// us blocks at our current height even though their advertised height is
+	// higher than ours.
+	pool.SetPeerRange(p2p.ID("pruned1"), ourHeight+50, ourHeight+200)
+	pool.SetPeerRange(p2p.ID("pruned2"), ourHeight+10, ourHeight+150)
+
+	require.EqualValues(t, 0, pool.MaxPeerHeight(),
+		"all peers pruned ahead of pool.height must be excluded from maxPeerHeight")
+	require.False(t, pool.IsCaughtUp(),
+		"node must not consider itself caught up when no peer can serve blocks at pool.height")
+}
+
+// TestBlockPoolIsCaughtUpFreshNetwork verifies that a node DOES consider
+// itself caught up when every peer advertises height 0 — i.e. the network
+// has not produced any blocks yet. Without this, validators at network
+// genesis would stay in blocksync forever, waiting for blocks no one has
+// produced yet, and the chain would never start.
+//
+// pool.height here is state.InitialHeight (the next block to fetch) while
+// every peer reports a fresh store: base=0, height=0. maxPeerHeight ends up
+// at 0, but the correct answer is "caught up" so consensus can take over.
+func TestBlockPoolIsCaughtUpFreshNetwork(t *testing.T) {
+	const initialHeight = int64(1000)
+
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+	pool := NewBlockPool(initialHeight, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	// Every peer is at network genesis: no blocks produced yet.
+	pool.SetPeerRange(p2p.ID("peer1"), 0, 0)
+	pool.SetPeerRange(p2p.ID("peer2"), 0, 0)
+
+	require.EqualValues(t, 0, pool.MaxPeerHeight(),
+		"peers without blocks contribute 0 to maxPeerHeight")
+	require.True(t, pool.IsCaughtUp(),
+		"node must be considered caught up when no peer has any blocks (fresh network)")
+}

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -191,7 +191,8 @@ func TestBlockPoolTimeout(t *testing.T) {
 	// Introduce each peer.
 	go func() {
 		for _, peer := range peers {
-			pool.SetPeerRange(peer.id, peer.base, peer.height)
+			// Force uniform base so every peer contributes to maxPeerHeight at pool startup.
+			pool.SetPeerRange(peer.id, start, peer.height)
 		}
 	}()
 
@@ -560,13 +561,13 @@ func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 }
 
 // TestBlockPoolMaliciousNodeUnreachableBase tests that the max-height poisoning
-// attack described in CELESTIA-188 is not a persistent issue.
+// attack described in CELESTIA-188 is structurally prevented.
 //
 // A malicious peer sends a StatusResponse with an unreachable base/height
-// (base=2^60, height=2^60+100), poisoning maxPeerHeight so IsCaughtUp returns
-// false. Once the P2P layer disconnects the peer (SendTimeout, ping/pong
-// timeout, or TCP failure), RemovePeer recalculates maxPeerHeight from the
-// remaining honest peers and IsCaughtUp returns true.
+// (base=2^60, height=2^60+100). The pool excludes peers whose base is ahead
+// of pool.height from maxPeerHeight, so the poison never takes effect.
+// RemovePeer is exercised as a follow-up to confirm state remains consistent
+// once the P2P layer disconnects the peer.
 func TestBlockPoolMaliciousNodeUnreachableBase(t *testing.T) {
 	const honestHeight = int64(20)
 	var (
@@ -584,14 +585,15 @@ func TestBlockPoolMaliciousNodeUnreachableBase(t *testing.T) {
 	pool.SetPeerRange("honest2", 1, honestHeight)
 	pool.SetPeerRange("poison", poisonBase, poisonHeight)
 
-	// maxPeerHeight is poisoned, IsCaughtUp returns false.
-	require.Equal(t, poisonHeight, pool.MaxPeerHeight())
-	require.False(t, pool.IsCaughtUp())
+	// The poison peer's base is ahead of pool.height, so it's excluded from
+	// maxPeerHeight. The honest peers determine the sync target and the pool
+	// is already caught up.
+	require.Equal(t, honestHeight, pool.MaxPeerHeight())
+	require.True(t, pool.IsCaughtUp())
 
-	// Simulate the P2P layer disconnecting the malicious peer.
+	// Simulate the P2P layer disconnecting the malicious peer. State remains
+	// consistent: maxPeerHeight still tracks the honest peers.
 	pool.RemovePeer("poison")
-
-	// maxPeerHeight recalculates from honest peers, IsCaughtUp returns true.
 	require.Equal(t, honestHeight, pool.MaxPeerHeight())
 	require.True(t, pool.IsCaughtUp())
 }
@@ -666,4 +668,54 @@ func TestAddBlockDoesNotDeadlockOnSendError(t *testing.T) {
 		<-heightDone
 		t.Fatal("deadlock: AddBlock held pool.mtx while blocked in sendError")
 	}
+}
+
+// TestBlockPoolBansPeerWithBaseGreaterThanHeight verifies that a peer whose self-reported base
+// exceeds its own height (a structurally impossible state) is banned.
+func TestBlockPoolBansPeerWithBaseGreaterThanHeight(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	badID := p2p.ID("bad")
+	pool.SetPeerRange(badID, 500, 100)
+
+	require.True(t, pool.IsPeerBanned(badID), "peer reporting base > height must be banned")
+	require.EqualValues(t, 0, pool.MaxPeerHeight(), "banned peer must not raise maxPeerHeight")
+}
+
+// TestBlockPoolMaxPeerHeightRefreshesOnPopRequest covers:
+//  1. A peer whose base is ahead of pool.height must not contribute to maxPeerHeight
+//  2. When pool.height advances past a pruned peer's base, maxPeerHeight is re-evaluated.
+func TestBlockPoolMaxPeerHeightRefreshesOnPopRequest(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(10, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	// Peer A's range covers pool.height, so it contributes to maxPeerHeight.
+	pool.SetPeerRange(p2p.ID("A"), 1, 20)
+	// Peer B is pruned ahead of pool.height and must be excluded until the
+	// pool advances past its base.
+	pool.SetPeerRange(p2p.ID("B"), 15, 100)
+	require.EqualValues(t, 20, pool.MaxPeerHeight(),
+		"peer B is pruned ahead of pool.height and must not contribute yet")
+
+	// Advance pool.height from 10 to 15 via PopRequest. Install a dummy
+	// requester at each height so PopRequest has something to pop; the
+	// requester is never started, so Stop() is a logged no-op.
+	for h := int64(10); h < 15; h++ {
+		pool.mtx.Lock()
+		pool.requesters[h] = newBPRequester(pool, h)
+		pool.mtx.Unlock()
+		pool.PopRequest()
+	}
+
+	// pool.height is now 15, so B (base=15) becomes eligible and must lift
+	// maxPeerHeight to its advertised height without B re-sending status.
+	require.EqualValues(t, 100, pool.MaxPeerHeight(),
+		"peer B must contribute to maxPeerHeight once pool.height reaches its base")
 }

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -174,7 +174,7 @@ func (bcR *Reactor) SwitchToBlockSync(state sm.State) error {
 	bcR.blockSync = true
 	bcR.initialState = state
 
-	bcR.pool.height = state.LastBlockHeight + 1
+	bcR.pool.SetHeight(state.LastBlockHeight + 1)
 	err := bcR.pool.Start()
 	if err != nil {
 		return err


### PR DESCRIPTION
Backport of #3038 and #3058 to v0.40.x, cherry-picked together because #3058's IsCaughtUp fix relies on #3038's pruned-ahead-peer filtering in updateMaxPeerHeight. Only conflict was in pool_test.go (both sides appended tests; kept both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2YFU3xibm42UWwCoFy1q