### PR TITLE
fix(rpc/grpc): non-blocking height broadcast, Stop deadlock, and subscription race (backport #3002, #3004, #3007)

### DIFF
--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -68,18 +68,8 @@ func NewBlockAPI(env *core.Environment) *BlockAPI {
 }
 
 func (blockAPI *BlockAPI) StartNewBlockEventListener(ctx context.Context) error {
-	if blockAPI.newBlockSubscription == nil {
-		var err error
-		blockAPI.newBlockSubscription, err = blockAPI.env.EventBus.Subscribe(
-			ctx,
-			blockAPI.subscriptionID,
-			blockAPI.subscriptionQuery,
-			500,
-		)
-		if err != nil {
-			blockAPI.env.Logger.Error("Failed to subscribe to new blocks", "err", err)
-			return err
-		}
+	if err := blockAPI.subscribe(ctx); err != nil {
+		return err
 	}
 	for {
 		select {
@@ -127,6 +117,30 @@ const RetryAttempts = 6
 
 // SubscriptionCapacity the maximum number of pending blocks in the subscription.
 const SubscriptionCapacity = 500
+
+// subscribe creates the initial EventBus subscription if one does not
+// already exist. Holding blockAPI.Lock keeps this write synchronized
+// with retryNewBlocksSubscription (which also writes the field under
+// the lock) and Stop (which reads it under the lock).
+func (blockAPI *BlockAPI) subscribe(ctx context.Context) error {
+	blockAPI.Lock()
+	defer blockAPI.Unlock()
+	if blockAPI.newBlockSubscription != nil {
+		return nil
+	}
+	sub, err := blockAPI.env.EventBus.Subscribe(
+		ctx,
+		blockAPI.subscriptionID,
+		blockAPI.subscriptionQuery,
+		SubscriptionCapacity,
+	)
+	if err != nil {
+		blockAPI.env.Logger.Error("Failed to subscribe to new blocks", "err", err)
+		return err
+	}
+	blockAPI.newBlockSubscription = sub
+	return nil
+}
 
 func (blockAPI *BlockAPI) retryNewBlocksSubscription(ctx context.Context) (bool, error) {
 	ticker := time.NewTicker(time.Second)

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -156,23 +156,44 @@ func (blockAPI *BlockAPI) retryNewBlocksSubscription(ctx context.Context) (bool,
 }
 
 func (blockAPI *BlockAPI) broadcastToListeners(ctx context.Context, height int64, hash []byte) {
+	// Snapshot the current set of listeners under the lock so we do not
+	// hold the lock during sends. A slow listener must not block the
+	// broadcaster (see https://github.com/celestiaorg/celestia-core/issues/2967).
 	blockAPI.Lock()
-	defer blockAPI.Unlock()
+	listeners := make([]chan SubscribeNewHeightsResponse, 0, len(blockAPI.heightListeners))
 	for ch := range blockAPI.heightListeners {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// logging the error then removing the heights listener
-					blockAPI.env.Logger.Debug("failed to write to heights listener", "err", r)
-					blockAPI.removeHeightListener(ch)
-				}
-			}()
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- SubscribeNewHeightsResponse{Height: height, Hash: hash}:
-			}
-		}()
+		listeners = append(listeners, ch)
+	}
+	blockAPI.Unlock()
+
+	if ctx.Err() != nil {
+		return
+	}
+
+	event := SubscribeNewHeightsResponse{Height: height, Hash: hash}
+	for _, ch := range listeners {
+		blockAPI.sendNonBlocking(ch, event)
+	}
+}
+
+// sendNonBlocking attempts to deliver event to ch without blocking.
+// If ch is full, the event is dropped and a debug log is emitted: a
+// slow subscriber must not block the broadcaster or any other
+// subscriber. Callers that require lossless delivery should use
+// BlockByHeight to back-fill any gaps. The recover guards against a
+// concurrent close of ch and evicts the listener in that case
+// (matching the prior behavior).
+func (blockAPI *BlockAPI) sendNonBlocking(ch chan SubscribeNewHeightsResponse, event SubscribeNewHeightsResponse) {
+	defer func() {
+		if r := recover(); r != nil {
+			blockAPI.env.Logger.Debug("failed to write to heights listener", "err", r)
+			blockAPI.removeHeightListener(ch)
+		}
+	}()
+	select {
+	case ch <- event:
+	default:
+		blockAPI.env.Logger.Debug("dropped height event for slow subscriber", "height", event.Height)
 	}
 }
 

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -208,14 +208,21 @@ func (blockAPI *BlockAPI) addHeightListener() chan SubscribeNewHeightsResponse {
 func (blockAPI *BlockAPI) removeHeightListener(ch chan SubscribeNewHeightsResponse) {
 	blockAPI.Lock()
 	defer blockAPI.Unlock()
+	blockAPI.removeHeightListenerLocked(ch)
+}
+
+// removeHeightListenerLocked removes ch from heightListeners. The caller
+// must hold blockAPI.Lock().
+func (blockAPI *BlockAPI) removeHeightListenerLocked(ch chan SubscribeNewHeightsResponse) {
 	delete(blockAPI.heightListeners, ch)
 }
 
-func (blockAPI *BlockAPI) closeAllListeners() {
-	blockAPI.Lock()
-	defer blockAPI.Unlock()
+// closeAllListenersLocked clears every registered height listener.
+// The caller must hold blockAPI.Lock(); the function does not acquire
+// the lock itself because doing so would deadlock against Stop, which
+// already holds it (sync.Mutex is not reentrant).
+func (blockAPI *BlockAPI) closeAllListenersLocked() {
 	if blockAPI.heightListeners == nil {
-		// if this is nil, then there is no need to close anything
 		return
 	}
 	for channel := range blockAPI.heightListeners {
@@ -230,13 +237,16 @@ func (blockAPI *BlockAPI) Stop(ctx context.Context) error {
 	defer blockAPI.Unlock()
 
 	// close all height listeners
-	blockAPI.closeAllListeners()
+	blockAPI.closeAllListenersLocked()
 
 	var err error
-	// stop the events subscription
+	// stop the events subscription. We deliberately do not clear
+	// blockAPI.newBlockSubscription here: StartNewBlockEventListener reads
+	// the field without holding the lock, so a write would race with that
+	// goroutine. Unsubscribe is sufficient to drain the subscription; the
+	// goroutine exits via ctx.Done after the caller cancels the context.
 	if blockAPI.newBlockSubscription != nil {
 		err = blockAPI.env.EventBus.Unsubscribe(ctx, blockAPI.subscriptionID, blockAPI.subscriptionQuery)
-		blockAPI.newBlockSubscription = nil
 	}
 
 	blockAPI.env.Logger.Info("gRPC streaming API has been stopped")

--- a/rpc/grpc/api_test.go
+++ b/rpc/grpc/api_test.go
@@ -1,0 +1,166 @@
+package coregrpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/rpc/core"
+)
+
+// newTestBlockAPI returns a BlockAPI suitable for unit-testing the
+// broadcast / listener bookkeeping paths. It avoids spinning up a full
+// node — only fields read by these paths are populated.
+func newTestBlockAPI(t *testing.T) *BlockAPI {
+	t.Helper()
+	env := &core.Environment{Logger: log.NewNopLogger()}
+	return NewBlockAPI(env)
+}
+
+// fillChannel writes n placeholder events to ch without blocking the test
+// if ch's capacity is smaller than n.
+func fillChannel(t *testing.T, ch chan SubscribeNewHeightsResponse, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case ch <- SubscribeNewHeightsResponse{Height: int64(i)}:
+		default:
+			t.Fatalf("channel full after %d writes (cap=%d)", i, cap(ch))
+		}
+	}
+}
+
+// TestBroadcastToListeners_DoesNotBlockOnSlowSubscriber verifies that a
+// listener whose channel buffer is full does not block the broadcaster.
+// Regression for https://github.com/celestiaorg/celestia-core/issues/2967.
+func TestBroadcastToListeners_DoesNotBlockOnSlowSubscriber(t *testing.T) {
+	api := newTestBlockAPI(t)
+
+	slow := api.addHeightListener()
+	fast := api.addHeightListener()
+
+	// Saturate the slow listener's channel (cap=50, see addHeightListener).
+	fillChannel(t, slow, cap(slow))
+
+	done := make(chan struct{})
+	go func() {
+		api.broadcastToListeners(context.Background(), 100, []byte("hash"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("broadcastToListeners blocked on slow subscriber")
+	}
+
+	// Fast listener still receives the broadcast event.
+	select {
+	case ev := <-fast:
+		assert.Equal(t, int64(100), ev.Height)
+		assert.Equal(t, []byte("hash"), ev.Hash)
+	case <-time.After(1 * time.Second):
+		t.Fatal("fast subscriber did not receive the broadcast")
+	}
+}
+
+// TestBroadcastToListeners_DoesNotHoldLockDuringSend verifies that
+// addHeightListener / removeHeightListener can make progress while a
+// broadcast is in flight to a saturated subscriber. Regression for
+// https://github.com/celestiaorg/celestia-core/issues/2967.
+func TestBroadcastToListeners_DoesNotHoldLockDuringSend(t *testing.T) {
+	api := newTestBlockAPI(t)
+
+	slow := api.addHeightListener()
+	fillChannel(t, slow, cap(slow))
+
+	// Run the broadcast concurrently. With the bug present, this acquires
+	// the lock and then blocks indefinitely on the saturated channel.
+	// We synchronize on `started` and yield briefly so the broadcast
+	// goroutine has actually entered broadcastToListeners and acquired
+	// the lock before the test contends for it.
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		api.broadcastToListeners(context.Background(), 100, []byte("hash"))
+	}()
+	<-started
+	time.Sleep(5 * time.Millisecond)
+
+	// addHeightListener must not block on the broadcaster's lock.
+	addDone := make(chan chan SubscribeNewHeightsResponse, 1)
+	go func() {
+		addDone <- api.addHeightListener()
+	}()
+
+	var newCh chan SubscribeNewHeightsResponse
+	select {
+	case newCh = <-addDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("addHeightListener blocked while broadcast was in flight")
+	}
+
+	// removeHeightListener must also not block.
+	removeDone := make(chan struct{})
+	go func() {
+		api.removeHeightListener(newCh)
+		close(removeDone)
+	}()
+
+	select {
+	case <-removeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("removeHeightListener blocked while broadcast was in flight")
+	}
+}
+
+// TestBroadcastToListeners_DeliversToAllSubscribersWhenAllDrain verifies
+// that with all subscribers actively draining their channels, every
+// broadcast reaches every subscriber.
+func TestBroadcastToListeners_DeliversToAllSubscribersWhenAllDrain(t *testing.T) {
+	api := newTestBlockAPI(t)
+
+	const numSubs = 4
+	const numEvents = 25
+
+	chans := make([]chan SubscribeNewHeightsResponse, numSubs)
+	for i := range chans {
+		chans[i] = api.addHeightListener()
+	}
+
+	var wg sync.WaitGroup
+	received := make([][]int64, numSubs)
+	for i, ch := range chans {
+		i, ch := i, ch
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for len(received[i]) < numEvents {
+				select {
+				case ev := <-ch:
+					received[i] = append(received[i], ev.Height)
+				case <-time.After(2 * time.Second):
+					return
+				}
+			}
+		}()
+	}
+
+	for h := int64(1); h <= numEvents; h++ {
+		api.broadcastToListeners(context.Background(), h, []byte("hash"))
+	}
+
+	wg.Wait()
+
+	for i, got := range received {
+		require.Len(t, got, numEvents, "subscriber %d missed events", i)
+		for j, h := range got {
+			assert.Equal(t, int64(j+1), h, "subscriber %d out-of-order", i)
+		}
+	}
+}

--- a/rpc/grpc/api_test.go
+++ b/rpc/grpc/api_test.go
@@ -164,3 +164,63 @@ func TestBroadcastToListeners_DeliversToAllSubscribersWhenAllDrain(t *testing.T)
 		}
 	}
 }
+
+// TestStop_DoesNotDeadlock is a regression test for
+// https://github.com/celestiaorg/celestia-core/issues/3003.
+// Stop acquires blockAPI.Lock() and then calls closeAllListeners which
+// also tries to acquire the same non-reentrant mutex, causing the
+// gRPC server shutdown path to hang indefinitely.
+func TestStop_DoesNotDeadlock(t *testing.T) {
+	env := &core.Environment{Logger: log.NewNopLogger()}
+	api := NewBlockAPI(env)
+
+	// Register a couple of listeners so closeAllListeners has work to do.
+	_ = api.addHeightListener()
+	_ = api.addHeightListener()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- api.Stop(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() deadlocked: did not return within 2s")
+	}
+}
+
+// TestBroadcastToListeners_DoesNotDeadlockOnPanic guards against the same
+// reentrant-mutex pattern as TestStop_DoesNotDeadlock, but in
+// broadcastToListeners. broadcastToListeners holds blockAPI.Lock() while
+// sending to each listener; if a send panics (e.g. channel closed by
+// SubscribeNewHeights returning) the recover handler calls
+// removeHeightListener, which tries to acquire the same non-reentrant
+// mutex and deadlocks the goroutine forever.
+func TestBroadcastToListeners_DoesNotDeadlockOnPanic(t *testing.T) {
+	env := &core.Environment{Logger: log.NewNopLogger()}
+	api := NewBlockAPI(env)
+
+	// Close the listener's channel so the next send panics with
+	// "send on closed channel", triggering the recover path.
+	ch := api.addHeightListener()
+	close(ch)
+
+	done := make(chan struct{})
+	go func() {
+		api.broadcastToListeners(context.Background(), 1, []byte("hash"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("broadcastToListeners() deadlocked: did not return within 2s")
+	}
+
+	api.Lock()
+	_, exists := api.heightListeners[ch]
+	api.Unlock()
+	require.False(t, exists, "listener should be removed after the recover path runs")
+}

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -5,9 +5,11 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 
 	cmtnet "github.com/cometbft/cometbft/libs/net"
@@ -31,7 +33,21 @@ type Config struct {
 //
 // Deprecated: A new gRPC API will be introduced after v0.38.
 func StartGRPCServer(env *core.Environment, ln net.Listener) error {
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			// Send a keepalive ping every 30s of inactivity.
+			Time: 30 * time.Second,
+			// Close the connection if the ping is not ACKed within 10s.
+			Timeout: 10 * time.Second,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			// Do not require the client to have an active stream to ping.
+			PermitWithoutStream: true,
+			// Allow client pings as frequent as every 10s. Clients that
+			// ping faster will be disconnected.
+			MinTime: 10 * time.Second,
+		}),
+	)
 	RegisterBroadcastAPIServer(grpcServer, &broadcastAPI{env: env})
 
 	api := NewBlockAPI(env)


### PR DESCRIPTION
Backport of #3002, #3004, and #3007 to v0.40.x, cherry-picked together because #3004 and #3007 build on #3002's BlockAPI changes and test file. All applied cleanly; `go test -race ./rpc/grpc/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2YFU3xibm42UWwCoFy1q