### PR TITLE
fix(abci): prevent panic on unlock in socket server panic recovery (backport #3040)

### DIFF
--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -164,6 +164,8 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 	var count int
 	var bufReader = bufio.NewReader(conn)
 
+	locked := false // true only while appMtx is held inside the loop
+
 	defer func() {
 		// make sure to recover from any app-related panics to allow proper socket cleanup.
 		// In the case of a panic, we do not notify the client by passing an exception so
@@ -178,6 +180,8 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 				fmt.Fprintln(os.Stderr, err)
 			}
 			closeConn <- err
+		}
+		if locked {
 			s.appMtx.Unlock()
 		}
 	}()
@@ -195,6 +199,7 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 			return
 		}
 		s.appMtx.Lock()
+		locked = true
 		count++
 		resp, err := s.handleRequest(context.TODO(), req)
 		if err != nil {
@@ -206,6 +211,7 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 			responses <- resp
 		}
 		s.appMtx.Unlock()
+		locked = false
 	}
 }
 

--- a/abci/server/socket_server_test.go
+++ b/abci/server/socket_server_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/abci/types"
+)
+
+type panicReader struct{}
+
+func (panicReader) Read(_ []byte) (int, error) {
+	panic("boom")
+}
+
+// TestHandleRequestsPanicBeforeLock ensures the panic recovery block does not
+// attempt to unlock appMtx when the lock was never acquired.
+func TestHandleRequestsPanicBeforeLock(t *testing.T) {
+	s := &SocketServer{}
+	closeConn := make(chan error, 1)
+	responses := make(chan *types.Response, 1)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		s.handleRequests(closeConn, panicReader{}, responses)
+	}()
+
+	select {
+	case <-closeConn:
+	case <-time.After(time.Second):
+		t.Fatal("closeConn not signaled")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleRequests did not exit")
+	}
+}


### PR DESCRIPTION
Backport of #3040 to v0.40.x. Clean cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2YFU3xibm42UWwCoFy1q