### PR TITLE
fix(consensus)!: use the round-adjusted proposer for propagation after WAL replay

### DIFF
--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -141,9 +141,8 @@ func shuffle[T any](slice []T) []T {
 }
 
 // applyCachedProposalIfAvailable checks for cached proposals at the current height/round
-// and applies the first valid one. Called automatically after SetProposer,
-// SetHeightAndRound, or SetConsensusState to enable fast catchup when a node
-// falls behind.
+// and applies the first valid one. Called automatically after SetConsensusState
+// to enable fast catchup when a node falls behind.
 //
 // This function iterates through ALL peers' cached proposals for the current height/round,
 // trying each one until it finds a valid proposal. This ensures a single invalid proposal

--- a/consensus/propagation/catchup_test.go
+++ b/consensus/propagation/catchup_test.go
@@ -114,11 +114,11 @@ func TestCacheCapacityEviction(t *testing.T) {
 	})
 
 	// n2 at height 1
-	n2.SetHeightAndRound(1, 0)
+	n2.SetConsensusState(1, 0, mockPubKey)
 
 	// Fill cache with proposals for heights 2 through MaxUnverifiedProposals+1
 	for h := int64(2); h <= int64(MaxUnverifiedProposals+1); h++ {
-		n1.SetHeightAndRound(h, 0)
+		n1.SetConsensusState(h, 0, mockPubKey)
 		prop, ps, _, metaData := createTestProposal(t, sm, pv, h, 0, 2, 100000)
 		cb, _ := createCompactBlock(t, prop, ps, metaData)
 		n2.handleCompactBlock(cb, n1.self, false)
@@ -131,7 +131,7 @@ func TestCacheCapacityEviction(t *testing.T) {
 	}
 
 	// Now add a proposal for height MaxUnverifiedProposals+2 (should be rejected - cache full with lower heights)
-	n1.SetHeightAndRound(int64(MaxUnverifiedProposals+2), 0)
+	n1.SetConsensusState(int64(MaxUnverifiedProposals+2), 0, mockPubKey)
 	propHigh, psHigh, _, metaDataHigh := createTestProposal(t, sm, pv, int64(MaxUnverifiedProposals+2), 0, 2, 100000)
 	cbHigh, _ := createCompactBlock(t, propHigh, psHigh, metaDataHigh)
 	n2.handleCompactBlock(cbHigh, n1.self, false)
@@ -160,7 +160,7 @@ func TestHandleCompactBlock_CachesCurrentHeightWrongRound(t *testing.T) {
 	})
 
 	// n2 at height 2, round 0
-	n2.SetHeightAndRound(2, 0)
+	n2.SetConsensusState(2, 0, mockPubKey)
 
 	// Create proposal for height 2, round 1 (different round)
 	prop, ps, _, metaData := createTestProposal(t, sm, pv, 2, 1, 2, 1000000)
@@ -196,8 +196,7 @@ func TestApplyCachedProposalIfAvailable(t *testing.T) {
 
 	// All nodes start at height 1
 	for _, r := range reactors {
-		r.SetHeightAndRound(1, 0)
-		r.SetProposer(mockPubKey)
+		r.SetConsensusState(1, 0, mockPubKey)
 	}
 
 	// Setup height 1 for all nodes - use testCompactBlock for proper signing
@@ -211,9 +210,9 @@ func TestApplyCachedProposalIfAvailable(t *testing.T) {
 
 	// n1 and n2 advance to height 2, n3 stays at height 1 (halted)
 	n1.Prune(1)
-	n1.SetHeightAndRound(2, 0)
+	n1.SetConsensusState(2, 0, mockPubKey)
 	n2.Prune(1)
-	n2.SetHeightAndRound(2, 0)
+	n2.SetConsensusState(2, 0, mockPubKey)
 
 	// Create proposal for height 2, round 0 - use testCompactBlock for proper signing
 	cb2, ps2, parityBlock2, _ := testCompactBlock(t, sm, pv, 2, 0)
@@ -237,9 +236,9 @@ func TestApplyCachedProposalIfAvailable(t *testing.T) {
 	_, _, has := n3.GetProposal(2, 0)
 	require.False(t, has, "proposal should not be in proposal cache yet")
 
-	// Now n3 catches up to height 2 - SetHeightAndRound triggers applyCachedProposalIfAvailable
+	// Now n3 catches up to height 2 - SetConsensusState triggers applyCachedProposalIfAvailable
 	n3.Prune(1)
-	n3.SetHeightAndRound(2, 0)
+	n3.SetConsensusState(2, 0, mockPubKey)
 
 	// Verify proposal is now in the proposal cache (automatically applied)
 	_, propData, has := n3.GetProposal(2, 0)
@@ -278,13 +277,12 @@ func TestApplyCachedProposalIfAvailable_MultiPeer(t *testing.T) {
 
 	// All nodes start at height 1
 	for _, r := range reactors {
-		r.SetHeightAndRound(1, 0)
-		r.SetProposer(mockPubKey)
+		r.SetConsensusState(1, 0, mockPubKey)
 	}
 
 	// n1, n2 advance to height 2
-	n1.SetHeightAndRound(2, 0)
-	n2.SetHeightAndRound(2, 0)
+	n1.SetConsensusState(2, 0, mockPubKey)
+	n2.SetConsensusState(2, 0, mockPubKey)
 
 	// Create an INVALID proposal (random signature) for peer n1
 	prop2Invalid, ps2Invalid, _, metaData2Invalid := createTestProposal(t, sm, pv, 2, 0, 2, 1000000)
@@ -307,7 +305,7 @@ func TestApplyCachedProposalIfAvailable_MultiPeer(t *testing.T) {
 
 	// n3 catches up to height 2 - this triggers applyCachedProposalIfAvailable
 	n3.Prune(1)
-	n3.SetHeightAndRound(2, 0)
+	n3.SetConsensusState(2, 0, mockPubKey)
 
 	// Proposal should now be in the proposal cache (applied from valid peer)
 	_, propData, has := n3.GetProposal(2, 0)
@@ -338,8 +336,7 @@ func TestApplyCachedProposalIfAvailable_KeepOnFailure(t *testing.T) {
 	})
 
 	// n2 at height 1, round 0, with proposer set
-	n2.SetHeightAndRound(1, 0)
-	n2.SetProposer(mockPubKey)
+	n2.SetConsensusState(1, 0, mockPubKey)
 
 	// Create a compact block with valid signatures but invalid parts hashes.
 	cbBad, _, _, _ := testCompactBlock(t, sm, pv, 2, 0)
@@ -362,7 +359,7 @@ func TestApplyCachedProposalIfAvailable_KeepOnFailure(t *testing.T) {
 
 	// Now n2 catches up to height 2 - applyCachedProposalIfAvailable runs and should fail to apply cbBad.
 	n2.Prune(1)
-	n2.SetHeightAndRound(2, 0)
+	n2.SetConsensusState(2, 0, mockPubKey)
 
 	_, _, has := n2.GetProposal(2, 0)
 	require.False(t, has, "proposal should not be applied when proofs are invalid")
@@ -386,7 +383,7 @@ func TestApplyCachedProposalIfAvailable_WrongRound(t *testing.T) {
 	})
 
 	// n2 at height 1, round 0
-	n2.SetHeightAndRound(1, 0)
+	n2.SetConsensusState(1, 0, mockPubKey)
 
 	// Create proposal for height 2, round 1
 	prop, ps, _, metaData := createTestProposal(t, sm, pv, 2, 1, 2, 1000000)
@@ -398,7 +395,7 @@ func TestApplyCachedProposalIfAvailable_WrongRound(t *testing.T) {
 
 	// n2 advances to height 2, round 0 - proposal should stay cached (wrong round)
 	n2.Prune(1)
-	n2.SetHeightAndRound(2, 0)
+	n2.SetConsensusState(2, 0, mockPubKey)
 
 	// Proposal should still be cached (we're at round 0, proposal is for round 1)
 	cached := n2.GetUnverifiedProposal(2)
@@ -423,8 +420,7 @@ func TestHandleCachedCompactBlockRejectsConflictBeforeForwarding(t *testing.T) {
 		cleanup(t)
 	})
 
-	n1.SetHeightAndRound(2, 0)
-	n1.SetProposer(mockPubKey)
+	n1.SetConsensusState(2, 0, mockPubKey)
 
 	// Preload proposal A for height 2, round 0.
 	cbA, _, _, _ := testCompactBlock(t, sm, pv, 2, 0)
@@ -474,8 +470,7 @@ func TestHandleCachedCompactBlockAllowsIdenticalDuplicate(t *testing.T) {
 		cleanup(t)
 	})
 
-	n1.SetHeightAndRound(2, 0)
-	n1.SetProposer(mockPubKey)
+	n1.SetConsensusState(2, 0, mockPubKey)
 
 	cbA, _, _, _ := testCompactBlock(t, sm, pv, 2, 0)
 	require.True(t, n1.AddProposal(cbA))
@@ -592,8 +587,7 @@ func TestSetConsensusStateReplaysCachedProposalOnce(t *testing.T) {
 
 	// both nodes at height 1, round 0 with the round-0 proposer.
 	for _, r := range reactors {
-		r.SetHeightAndRound(1, 0)
-		r.SetProposer(mockPubKey)
+		r.SetConsensusState(1, 0, mockPubKey)
 	}
 
 	// a round-1 proposal from a proposer different from the round-0 proposer.

--- a/consensus/propagation/commitment_test.go
+++ b/consensus/propagation/commitment_test.go
@@ -361,3 +361,45 @@ func randomBytes(n int) []byte {
 
 	return bytes
 }
+
+// TestValidateCompactBlockUsesRoundProposer ensures compact blocks are only
+// accepted when signed by the proposer installed for the current round: one
+// signed by another validator (e.g. the round-0 proposer claiming a later
+// round) is rejected and never applied from the unverified cache.
+func TestValidateCompactBlockUsesRoundProposer(t *testing.T) {
+	reactors, _ := createTestReactors(2, defaultTestP2PConf(), false, "")
+	n1 := reactors[0]
+	n2 := reactors[1]
+
+	cleanup, _, sm, pv := state.SetupTestCaseWithPrivVal(t)
+	t.Cleanup(func() {
+		cleanup(t)
+	})
+
+	round0Val := types.NewMockPV()
+	round2Val := types.NewMockPV()
+
+	// n2 is at height 1 waiting on round 2, whose proposer is round2Val.
+	n2.SetConsensusState(1, 2, round2Val.PrivKey.PubKey())
+
+	forged := signedCompactBlock(t, sm, pv, round0Val, 1, 2)
+	genuine := signedCompactBlock(t, sm, pv, round2Val, 1, 2)
+
+	require.Error(t, n2.validateCompactBlock(forged))
+	require.NoError(t, n2.validateCompactBlock(genuine))
+
+	// The forged compact block is cached, not applied, when received from a peer.
+	n2.handleCompactBlock(forged, n1.self, false)
+	_, _, has := n2.GetProposal(1, 2)
+	require.False(t, has, "forged compact block must not be applied")
+
+	// Re-installing the same round context must not apply it from the cache either.
+	n2.SetConsensusState(1, 2, round2Val.PrivKey.PubKey())
+	_, _, has = n2.GetProposal(1, 2)
+	require.False(t, has, "forged compact block must not be applied from the unverified cache")
+
+	// The genuine compact block is accepted.
+	n2.handleCompactBlock(genuine, n1.self, false)
+	_, _, has = n2.GetProposal(1, 2)
+	require.True(t, has, "genuine compact block from the round-2 proposer must be applied")
+}

--- a/consensus/propagation/propagator.go
+++ b/consensus/propagation/propagator.go
@@ -14,11 +14,11 @@ type Propagator interface {
 	ProposeBlock(proposal *types.Proposal, parts *types.PartSet, txs []proptypes.TxMetaData) error
 	AddCommitment(height int64, round int32, psh *types.PartSetHeader)
 	Prune(committedHeight int64)
-	SetHeightAndRound(height int64, round int32)
-	StartProcessing()
-	SetProposer(proposer crypto.PubKey)
-	// SetConsensusState installs the height, round, and proposer atomically.
+	// SetConsensusState installs the height, round, and proposer atomically so
+	// compact blocks are never verified against the proposer of a different
+	// round.
 	SetConsensusState(height int64, round int32, proposer crypto.PubKey)
+	StartProcessing()
 	GetPartChan() <-chan types.PartInfo
 	GetProposalChan() <-chan ProposalAndSrc
 	// IsCatchingUp returns true if the node is catching up on block data
@@ -77,16 +77,10 @@ func (nop *NoOpPropagator) AddCommitment(_ int64, _ int32, _ *types.PartSetHeade
 func (nop *NoOpPropagator) Prune(_ int64) {
 }
 
-func (nop *NoOpPropagator) SetHeightAndRound(_ int64, _ int32) {
+func (nop *NoOpPropagator) SetConsensusState(_ int64, _ int32, _ crypto.PubKey) {
 }
 
 func (nop *NoOpPropagator) StartProcessing() {
-}
-
-func (nop *NoOpPropagator) SetProposer(_ crypto.PubKey) {
-}
-
-func (nop *NoOpPropagator) SetConsensusState(_ int64, _ int32, _ crypto.PubKey) {
 }
 
 func (nop *NoOpPropagator) GetPartChan() <-chan types.PartInfo {

--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -318,16 +318,6 @@ func (blockProp *Reactor) Prune(committedHeight int64) {
 	blockProp.ticker.Reset(RetryTime)
 }
 
-func (blockProp *Reactor) SetProposer(proposer crypto.PubKey) {
-	blockProp.pmtx.Lock()
-	blockProp.currentProposer = proposer
-	blockProp.pmtx.Unlock()
-
-	// Check for cached proposals for the current height.
-	// This enables fast catchup when a node falls behind and misses proposals.
-	blockProp.applyCachedProposalIfAvailable()
-}
-
 // setHeightAndRoundLocked installs the height and round. The caller must hold
 // pmtx.
 func (blockProp *Reactor) setHeightAndRoundLocked(height int64, round int32) {
@@ -351,21 +341,6 @@ func (blockProp *Reactor) setHeightAndRoundLocked(height int64, round int32) {
 	}
 }
 
-func (blockProp *Reactor) SetHeightAndRound(height int64, round int32) {
-	blockProp.pmtx.Lock()
-	blockProp.setHeightAndRoundLocked(height, round)
-	blockProp.pmtx.Unlock()
-
-	blockProp.ResetRequestCounts()
-	// todo: delete the old round data as its no longer relevant don't delete
-	// past round data if it has a POL
-
-	// Check for cached proposals that might now be applicable.
-	// This handles the case where we advance to a new round and have a cached
-	// proposal for that round waiting to be applied.
-	blockProp.applyCachedProposalIfAvailable()
-}
-
 // SetConsensusState installs the height, round, and proposer atomically, then
 // replays any cached proposal once against the complete state.
 func (blockProp *Reactor) SetConsensusState(height int64, round int32, proposer crypto.PubKey) {
@@ -375,6 +350,8 @@ func (blockProp *Reactor) SetConsensusState(height int64, round int32, proposer 
 	blockProp.pmtx.Unlock()
 
 	blockProp.ResetRequestCounts()
+	// todo: delete the old round data as its no longer relevant don't delete
+	// past round data if it has a POL
 	blockProp.applyCachedProposalIfAvailable()
 }
 
@@ -391,6 +368,10 @@ func (blockProp *Reactor) ResetRequestCounts() {
 
 func (blockProp *Reactor) StartProcessing() {
 	blockProp.started.Store(true)
+	// request any parts still missing for proposals applied before processing
+	// started (e.g. from the unverified cache during the sync-to-consensus
+	// switch) instead of waiting for the next retry tick.
+	go blockProp.retryWants()
 }
 
 func ConcurrentRequestLimit(peersCount, partsCount int) int64 {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -167,12 +167,12 @@ conS:
 conR:
 %+v`, err, conR.conS, conR))
 	}
+	// The propagator's height, round, and proposer were installed by
+	// cs.OnStart from the round state the WAL replay resumed at (possibly a
+	// round > 0 with a different proposer than round 0), so they must not be
+	// overwritten here from state.Validators, which always carries the
+	// round-0 proposer.
 	conR.propagator.StartProcessing()
-	proposer := state.Validators.GetProposer()
-	conR.conS.rsMtx.RLock()
-	height, round := conR.conS.rs.Height, conR.conS.rs.Round
-	conR.conS.rsMtx.RUnlock()
-	conR.propagator.SetConsensusState(height, round, proposer.PubKey)
 }
 
 // GetChannels implements Reactor

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -22,8 +22,10 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	cfg "github.com/cometbft/cometbft/config"
 	cstypes "github.com/cometbft/cometbft/consensus/types"
+	"github.com/cometbft/cometbft/crypto"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
 	"github.com/cometbft/cometbft/crypto/tmhash"
+	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/libs/bits"
 	"github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/libs/json"
@@ -437,6 +439,182 @@ func TestSwitchToConsensusVoteExtensions(t *testing.T) {
 				reactor.SwitchToConsensus(cs.state, false)
 			}
 		})
+	}
+}
+
+// proposerAndRoundCall is one recorded SetConsensusState invocation.
+type proposerAndRoundCall struct {
+	height   int64
+	round    int32
+	proposer crypto.PubKey
+}
+
+// recordingPropagator records the round context the consensus layer installs
+// into the propagation layer so tests can assert on it.
+type recordingPropagator struct {
+	*propagation.NoOpPropagator
+
+	mtx          cmtsync.Mutex
+	calls        []proposerAndRoundCall
+	started      bool
+	callsAtStart []proposerAndRoundCall
+}
+
+func (r *recordingPropagator) SetConsensusState(height int64, round int32, proposer crypto.PubKey) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.calls = append(r.calls, proposerAndRoundCall{height: height, round: round, proposer: proposer})
+}
+
+func (r *recordingPropagator) StartProcessing() {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.started = true
+	r.callsAtStart = append([]proposerAndRoundCall(nil), r.calls...)
+}
+
+func (r *recordingPropagator) snapshotAtStart() (bool, []proposerAndRoundCall) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.started, append([]proposerAndRoundCall(nil), r.callsAtStart...)
+}
+
+func (r *recordingPropagator) snapshotCalls() []proposerAndRoundCall {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return append([]proposerAndRoundCall(nil), r.calls...)
+}
+
+// TestSwitchToConsensusUsesReplayedRoundProposer ensures that when the WAL
+// replay resumes consensus at a round > 0, the propagation layer holds that
+// round's proposer by the time it starts processing peer messages, and never
+// observes a proposer paired with a round it doesn't own.
+func TestSwitchToConsensusUsesReplayedRoundProposer(t *testing.T) {
+	const nVals = 4
+
+	state, privVals := randGenesisState(nVals, false, 10, test.ConsensusParams())
+
+	// The proposers of rounds 0, 1, and 2 at height 1. They are distinct
+	// because all validators have equal power.
+	expectedProposers := make([]*types.Validator, 3)
+	vals := state.Validators.Copy()
+	for r := range expectedProposers {
+		expectedProposers[r] = vals.GetProposer().Copy()
+		vals.IncrementProposerPriority(1)
+	}
+	require.False(t, expectedProposers[0].PubKey.Equals(expectedProposers[2].PubKey),
+		"test requires distinct round-0 and round-2 proposers")
+
+	// Pick a privval that doesn't propose in rounds 0-2 so the replay doesn't
+	// create proposals of its own.
+	var pv types.PrivValidator
+	for _, candidate := range privVals {
+		pk, err := candidate.GetPubKey()
+		require.NoError(t, err)
+		isProposer := false
+		for _, p := range expectedProposers {
+			if p.PubKey.Equals(pk) {
+				isProposer = true
+				break
+			}
+		}
+		if !isProposer {
+			pv = candidate
+			break
+		}
+	}
+	require.NotNil(t, pv)
+
+	thisConfig := test.ResetTestRoot("consensus_replayed_round_proposer_test")
+	defer os.RemoveAll(thisConfig.RootDir)
+
+	app := kvstore.NewInMemoryApplication()
+	blockDB := dbm.NewMemDB()
+	blockStore := store.NewBlockStore(blockDB)
+	mtx := new(cmtsync.Mutex)
+	proxyAppConnCon := proxy.NewAppConnConsensus(abcicli.NewLocalClient(mtx, app), proxy.NopMetrics())
+	proxyAppConnMem := proxy.NewAppConnMempool(abcicli.NewLocalClient(mtx, app), proxy.NopMetrics())
+	mempool := cat.NewTxPool(log.TestingLogger(), thisConfig.Mempool, proxyAppConnMem, state.LastBlockHeight)
+	evpool := sm.EmptyEvidencePool{}
+	stateStore := sm.NewStore(blockDB, sm.StoreOptions{DiscardABCIResponses: false})
+	require.NoError(t, stateStore.Save(state))
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, blockStore)
+
+	recorder := &recordingPropagator{NoOpPropagator: propagation.NewNoOpPropagator()}
+
+	cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, recorder, mempool, evpool)
+	cs.SetLogger(log.TestingLogger().With("module", "consensus"))
+	cs.SetPrivValidator(pv)
+
+	eventBus := types.NewEventBus()
+	eventBus.SetLogger(log.TestingLogger().With("module", "events"))
+	require.NoError(t, eventBus.Start())
+	cs.SetEventBus(eventBus)
+
+	// Craft a WAL that resumes height 1 at round 2: starting the WAL writes
+	// the #ENDHEIGHT 0 marker, and each precommit-wait timeout is replayed as
+	// enterPrecommit(1, r) followed by enterNewRound(1, r+1).
+	wal, err := NewWAL(thisConfig.Consensus.WalFile())
+	require.NoError(t, err)
+	wal.SetLogger(log.TestingLogger().With("module", "wal"))
+	require.NoError(t, wal.Start())
+	for round := int32(0); round < 2; round++ {
+		require.NoError(t, wal.Write(timeoutInfo{
+			Duration: time.Millisecond,
+			Height:   1,
+			Round:    round,
+			Step:     cstypes.RoundStepPrecommitWait,
+		}))
+	}
+	require.NoError(t, wal.FlushAndSync())
+	require.NoError(t, wal.Stop())
+	wal.Wait()
+
+	reactor := NewReactor(cs, recorder, true)
+	t.Cleanup(func() {
+		if err := cs.Stop(); err != nil {
+			t.Log(err)
+		}
+		cs.Wait()
+		if err := eventBus.Stop(); err != nil {
+			t.Log(err)
+		}
+	})
+
+	reactor.SwitchToConsensus(state, false)
+
+	rs := cs.GetRoundState()
+	require.Equal(t, int64(1), rs.Height)
+	require.Equal(t, int32(2), rs.Round, "WAL replay should have resumed consensus at round 2")
+	require.True(t, rs.Validators.GetProposer().PubKey.Equals(expectedProposers[2].PubKey),
+		"round state proposer should match the independently derived round-2 proposer")
+
+	started, callsAtStart := recorder.snapshotAtStart()
+	require.True(t, started)
+	require.NotEmpty(t, callsAtStart)
+
+	// When the propagation layer starts processing peer messages, it must
+	// hold the round-2 proposer, not the round-0 proposer.
+	atStart := callsAtStart[len(callsAtStart)-1]
+	require.Equal(t, int64(1), atStart.height)
+	require.Equal(t, int32(2), atStart.round)
+	require.True(t, expectedProposers[2].PubKey.Equals(atStart.proposer),
+		"propagation must start with the round-2 proposer after WAL replay")
+
+	// Every update, including any made after processing started (the original
+	// bug installed state.Validators' round-0 proposer right after), must
+	// carry the proposer that owns its round, so the round-0 proposer is
+	// never exposed for round 2.
+	calls := recorder.snapshotCalls()
+	last := calls[len(calls)-1]
+	require.Equal(t, int32(2), last.round)
+	require.True(t, expectedProposers[2].PubKey.Equals(last.proposer),
+		"propagation must be left with the round-2 proposer")
+	for _, call := range calls {
+		require.Equal(t, int64(1), call.height)
+		require.LessOrEqual(t, call.round, int32(2))
+		require.True(t, expectedProposers[call.round].PubKey.Equals(call.proposer),
+			"propagator observed the proposer of a different round at round %d", call.round)
 	}
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -247,7 +247,7 @@ func NewState(
 	if validators != nil {
 		proposer := validators.GetProposer()
 		if proposer != nil {
-			cs.propagator.SetProposer(proposer.PubKey)
+			cs.propagator.SetConsensusState(cs.rs.Height, cs.rs.Round, proposer.PubKey)
 		}
 	}
 
@@ -460,6 +460,23 @@ func (cs *State) OnStart() error {
 		return err
 	}
 
+	// Sync the propagator with the round state before starting the receive
+	// routine. The WAL replay above may have resumed at a later round, so the
+	// proposer must come from the round-adjusted validator set. Nothing else
+	// mutates cs.rs at this point, and once the receive routine starts, all
+	// further updates flow through the consensus state machine, so this value
+	// cannot be clobbered by a stale snapshot afterwards.
+	cs.rsMtx.RLock()
+	height, round := cs.rs.Height, cs.rs.Round
+	var proposer *types.Validator
+	if cs.rs.Validators != nil {
+		proposer = cs.rs.Validators.GetProposer()
+	}
+	cs.rsMtx.RUnlock()
+	if proposer != nil {
+		cs.propagator.SetConsensusState(height, round, proposer.PubKey)
+	}
+
 	// now start the receiveRoutine
 	go cs.receiveRoutine(0)
 	go cs.syncData()
@@ -467,9 +484,6 @@ func (cs *State) OnStart() error {
 	// schedule the first round!
 	// use GetRoundState so we don't race the receiveRoutine for access
 	cs.scheduleRound0(cs.GetRoundState())
-	cs.rsMtx.RLock()
-	cs.propagator.SetHeightAndRound(cs.rs.Height, cs.rs.Round)
-	cs.rsMtx.RUnlock()
 
 	return nil
 }
@@ -1247,8 +1261,6 @@ func (cs *State) enterNewRound(height int64, round int32) {
 
 	if proposer := cs.rs.Validators.GetProposer(); proposer != nil {
 		cs.propagator.SetConsensusState(height, round, proposer.PubKey)
-	} else {
-		cs.propagator.SetHeightAndRound(height, round)
 	}
 
 	// Wait for txs to be available in the mempool
@@ -2067,12 +2079,9 @@ func (cs *State) finalizeCommit(height int64) {
 		logger.Error("failed to get private validator pubkey", "err", err)
 	}
 
-	// prune the propagation reactor
+	// prune the propagation reactor. The next height's round state is
+	// installed atomically when enterNewRound(height+1, 0) runs.
 	cs.propagator.Prune(height)
-	proposer := cs.rs.Validators.GetProposer()
-	if proposer != nil {
-		cs.propagator.SetProposer(proposer.PubKey)
-	}
 
 	// cs.StartTime is already set.
 	// Schedule Round0 to start soon.


### PR DESCRIPTION
After a consensus WAL replay that resumes at round >= 1, `SwitchToConsensus` installed `state.Validators.GetProposer()` — the round-0 proposer — into the propagation reactor, so compact blocks for the replayed round were verified against the wrong key. The propagator is now synced from the replayed round state in `State.OnStart` before the receive routine starts, and `SwitchToConsensus` only starts processing. All remaining call sites go through the atomic `SetConsensusState` (#3287), and the legacy `SetProposer`/`SetHeightAndRound` are removed.

Note for reviewers: consensus-affecting and API-breaking (two `Propagator` methods removed). `finalizeCommit` intentionally no longer touches the propagator — the next round state is installed in `enterNewRound` — so delayed-precommit timing is unchanged.

Closes: #3272 PROTOCO-2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)