### PR TITLE
fix(propagation): forward proposals to consensus atomically with the identity check

### DIFF
--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -3,6 +3,7 @@ package propagation
 import (
 	"bytes"
 	"math/rand"
+	"time"
 
 	proptypes "github.com/cometbft/cometbft/consensus/propagation/types"
 	"github.com/cometbft/cometbft/libs/bits"
@@ -250,14 +251,9 @@ func (blockProp *Reactor) handleCachedCompactBlock(cb *proptypes.CompactBlock) b
 		return false
 	}
 
-	// Send proposal to consensus reactor
-	select {
-	case <-blockProp.ctx.Done():
+	// Send proposal to consensus reactor. From self since it's from cache.
+	if !blockProp.forwardProposalToConsensus(cb, blockProp.self) {
 		return false
-	case blockProp.proposalChan <- ProposalAndSrc{
-		Proposal: cb.Proposal,
-		From:     blockProp.self, // From self since it's from cache
-	}:
 	}
 
 	// Recover any parts from mempool
@@ -267,6 +263,38 @@ func (blockProp *Reactor) handleCachedCompactBlock(cb *proptypes.CompactBlock) b
 	blockProp.ticker.Reset(RetryTime)
 	go blockProp.retryWants()
 	return true
+}
+
+// forwardProposalToConsensus sends the proposal to consensus only while it
+// still matches the entry stored for its height and round. The check and the
+// send happen under pmtx, so a concurrent AddCommitment cannot replace the
+// entry in between.
+func (blockProp *Reactor) forwardProposalToConsensus(cb *proptypes.CompactBlock, from p2p.ID) bool {
+	msg := ProposalAndSrc{Proposal: cb.Proposal, From: from}
+	for {
+		blockProp.pmtx.Lock()
+		existing := blockProp.proposals[cb.Proposal.Height][cb.Proposal.Round]
+		if existing == nil || !sameProposalIdentity(existing, cb) {
+			blockProp.pmtx.Unlock()
+			return false
+		}
+		select {
+		case blockProp.proposalChan <- msg:
+			blockProp.pmtx.Unlock()
+			return true
+		default:
+		}
+		blockProp.pmtx.Unlock()
+
+		// the channel is full: wait off the lock, then re-check and retry.
+		// Blocking on the send while holding pmtx could deadlock with the
+		// consensus routines that consume the channel and take pmtx.
+		select {
+		case <-blockProp.ctx.Done():
+			return false
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
 }
 
 // sameProposalIdentity reports whether an existing proposal entry refers to the

--- a/consensus/propagation/commitment.go
+++ b/consensus/propagation/commitment.go
@@ -240,13 +240,8 @@ func (blockProp *Reactor) processValidatedCompactBlock(cb *proptypes.CompactBloc
 	}
 
 	if !proposer {
-		select {
-		case <-blockProp.ctx.Done():
+		if !blockProp.forwardProposalToConsensus(cb, peer) {
 			return
-		case blockProp.proposalChan <- ProposalAndSrc{
-			Proposal: cb.Proposal,
-			From:     peer,
-		}:
 		}
 		if p := blockProp.getPeer(peer); p != nil {
 			p.consensusPeerState.SetHasProposal(&cb.Proposal)

--- a/consensus/propagation/identity_test.go
+++ b/consensus/propagation/identity_test.go
@@ -9,6 +9,7 @@ import (
 	proptypes "github.com/cometbft/cometbft/consensus/propagation/types"
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cometbft/cometbft/state"
+	"github.com/cometbft/cometbft/types"
 )
 
 // TestPropagationStateDoesNotMixProposalIdentities delivers A's commitment
@@ -148,4 +149,89 @@ func TestAddCommitmentReplacementPurgesPeerState(t *testing.T) {
 	_, has = peer.GetRequests(3, 0)
 	require.False(t, has, "peer request state for the replaced identity must be purged")
 	require.Zero(t, peer.GetRemainingRequests(3, 0))
+}
+
+// TestForwardProposalToConsensus asserts a proposal is forwarded only while
+// the stored entry still matches its identity.
+func TestForwardProposalToConsensus(t *testing.T) {
+	reactors, _ := testBlockPropReactors(2, defaultTestP2PConf())
+	n1 := reactors[0]
+
+	cbA := makeCompactBlock(10, 0, 3)
+	cbA.Proposal.BlockID.Hash = cmtrand.Bytes(32)
+	cbA.Proposal.BlockID.PartSetHeader.Hash = cmtrand.Bytes(32)
+	require.True(t, n1.AddProposal(cbA))
+	for len(n1.GetProposalChan()) > 0 {
+		<-n1.GetProposalChan()
+	}
+
+	require.True(t, n1.forwardProposalToConsensus(cbA, n1.self))
+	select {
+	case prop := <-n1.GetProposalChan():
+		require.True(t, prop.Proposal.BlockID.Equals(cbA.Proposal.BlockID))
+	default:
+		t.Fatal("expected the proposal to be forwarded")
+	}
+
+	// no entry stored for the height: nothing is forwarded.
+	require.False(t, n1.forwardProposalToConsensus(makeCompactBlock(11, 0, 3), n1.self))
+
+	// a commitment replacing the entry with a different identity stops the
+	// forward.
+	pshB := types.PartSetHeader{Total: 3, Hash: cmtrand.Bytes(32)}
+	n1.AddCommitment(10, 0, &pshB)
+	require.False(t, n1.forwardProposalToConsensus(cbA, n1.self))
+	select {
+	case prop := <-n1.GetProposalChan():
+		t.Fatalf("proposal forwarded after its entry was replaced: %+v", prop)
+	default:
+	}
+}
+
+// TestForwardProposalToConsensusFullChannel asserts a full proposal channel is
+// waited on without holding pmtx, and that a replacement while waiting stops
+// the forward.
+func TestForwardProposalToConsensusFullChannel(t *testing.T) {
+	reactors, _ := testBlockPropReactors(2, defaultTestP2PConf())
+	n1 := reactors[0]
+
+	cbA := makeCompactBlock(10, 0, 3)
+	cbA.Proposal.BlockID.Hash = cmtrand.Bytes(32)
+	cbA.Proposal.BlockID.PartSetHeader.Hash = cmtrand.Bytes(32)
+	require.True(t, n1.AddProposal(cbA))
+
+	for len(n1.proposalChan) < cap(n1.proposalChan) {
+		n1.proposalChan <- ProposalAndSrc{}
+	}
+
+	forwarded := make(chan bool, 1)
+	go func() { forwarded <- n1.forwardProposalToConsensus(cbA, n1.self) }()
+
+	// pmtx stays available while the forward waits for channel space.
+	locked := make(chan struct{})
+	go func() {
+		n1.pmtx.Lock()
+		n1.pmtx.Unlock() //nolint:staticcheck
+		close(locked)
+	}()
+	select {
+	case <-locked:
+	case <-time.After(time.Second):
+		t.Fatal("pmtx held while waiting for channel space")
+	}
+
+	// replace the entry, then free a slot: the forward must give up.
+	pshB := types.PartSetHeader{Total: 3, Hash: cmtrand.Bytes(32)}
+	n1.AddCommitment(10, 0, &pshB)
+	<-n1.proposalChan
+	select {
+	case sent := <-forwarded:
+		require.False(t, sent)
+	case <-time.After(time.Second):
+		t.Fatal("forward did not return")
+	}
+	for len(n1.proposalChan) > 0 {
+		prop := <-n1.proposalChan
+		require.False(t, prop.Proposal.BlockID.Equals(cbA.Proposal.BlockID))
+	}
 }


### PR DESCRIPTION
Follow-up to #3286 and #3298. The identity check and the `proposalChan` send now happen under `pmtx` in a new `forwardProposalToConsensus` helper, closing the remaining window where an `AddCommitment` landing between the check and the send could forward a now-conflicting proposal to consensus. A full channel is waited on off the lock and re-checked, because blocking on the send while holding `pmtx` can deadlock with the consensus routines that consume the channel and take `pmtx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)