### PR TITLE
fix(propagation)!: evict proposals rejected by consensus

### DIFF
--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -107,6 +107,10 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 	if blockProp.proposals[height][round] != nil {
 		existingPSH := blockProp.proposals[height][round].block.Original().Header()
 		if existingPSH.Total == psh.Total && bytes.Equal(existingPSH.Hash, psh.Hash) {
+			// the cached proposal is the committed block. Mark it so that a
+			// later rejection of a proposal message carrying the same
+			// identity cannot evict quorum-backed data.
+			blockProp.proposals[height][round].commitmentBacked = true
 			return
 		}
 		blockProp.Logger.Error("replacing existing proposal with new one", "height", height, "round", round, "psh", psh, "existingPSH", existingPSH)
@@ -127,9 +131,10 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 				Round:  round,
 			},
 		},
-		catchup:     true,
-		block:       combinedSet,
-		maxRequests: bits.NewBitArray(int(psh.Total * 2)), // this assumes that the parity parts are the same size
+		catchup:          true,
+		commitmentBacked: true,
+		block:            combinedSet,
+		maxRequests:      bits.NewBitArray(int(psh.Total * 2)), // this assumes that the parity parts are the same size
 	}
 
 	// increment the local copies of the height and round

--- a/consensus/propagation/catchup.go
+++ b/consensus/propagation/catchup.go
@@ -107,9 +107,8 @@ func (blockProp *Reactor) AddCommitment(height int64, round int32, psh *types.Pa
 	if blockProp.proposals[height][round] != nil {
 		existingPSH := blockProp.proposals[height][round].block.Original().Header()
 		if existingPSH.Total == psh.Total && bytes.Equal(existingPSH.Hash, psh.Hash) {
-			// the cached proposal is the committed block. Mark it so that a
-			// later rejection of a proposal message carrying the same
-			// identity cannot evict quorum-backed data.
+			// the cached proposal is the committed block: mark it so a
+			// later rejection cannot evict quorum-backed data.
 			blockProp.proposals[height][round].commitmentBacked = true
 			return
 		}

--- a/consensus/propagation/commitment_state.go
+++ b/consensus/propagation/commitment_state.go
@@ -15,9 +15,8 @@ type proposalData struct {
 	block        *proptypes.CombinedPartSet
 	maxRequests  *bits.BitArray
 	catchup      bool
-	// commitmentBacked marks an entry whose part set header is backed by a
-	// +2/3 commitment, either created by AddCommitment or confirmed by it.
-	// Such an entry is never evicted.
+	// commitmentBacked marks an entry backed by a +2/3 commitment. Such an
+	// entry is never evicted.
 	commitmentBacked bool
 }
 
@@ -99,15 +98,9 @@ func (p *ProposalCache) conflictsWith(cb *proptypes.CompactBlock) bool {
 	return existing != nil && !sameProposalIdentity(existing, cb)
 }
 
-// evict removes the entry at the given height and round when it is bound to
-// the given proposal identity. An entry backed by a +2/3 commitment is kept,
-// since quorum support for the block outranks the rejection of a single
-// proposal message. Returns true if an entry was removed.
-//
-// The rejected identity is deliberately not blacklisted. A rejection means
-// consensus and propagation disagree about the proposer key or the block
-// params, not that the block is invalid, so refusing the identity later would
-// let one bad proposal message suppress an authentic block.
+// evict removes the proposal at the given height and round if it has the given
+// identity and no commitment backs it. The identity is not blacklisted, since a
+// rejected proposal message does not make the block invalid.
 func (p *ProposalCache) evict(height int64, round int32, blockID types.BlockID) bool {
 	p.pmtx.Lock()
 	defer p.pmtx.Unlock()

--- a/consensus/propagation/commitment_state.go
+++ b/consensus/propagation/commitment_state.go
@@ -22,6 +22,11 @@ type ProposalCache struct {
 	pmtx      *sync.Mutex
 	proposals map[int64]map[int32]*proposalData
 
+	// rejected quarantines the identities of proposals that consensus
+	// rejected, keyed by types.BlockID.Key(), so they are never stored again.
+	// It is cleared on every commit by prune.
+	rejected map[string]struct{}
+
 	// height the height we're trying to get consensus on.
 	// the last committed height is height-1.
 	height int64
@@ -36,6 +41,7 @@ func NewProposalCache(bs *store.BlockStore) *ProposalCache {
 	pc := &ProposalCache{
 		pmtx:      &mtx,
 		proposals: make(map[int64]map[int32]*proposalData),
+		rejected:  make(map[string]struct{}),
 		store:     bs,
 	}
 
@@ -64,6 +70,10 @@ func (p *ProposalCache) AddProposal(cb *proptypes.CompactBlock) (added bool) {
 		return false
 	}
 
+	if _, rejected := p.rejected[cb.Proposal.BlockID.Key()]; rejected {
+		return false
+	}
+
 	if p.proposals[cb.Proposal.Height] == nil {
 		p.proposals[cb.Proposal.Height] = make(map[int32]*proposalData)
 	}
@@ -85,14 +95,35 @@ func (p *ProposalCache) AddProposal(cb *proptypes.CompactBlock) (added bool) {
 	return true
 }
 
-// conflictsWith reports whether an entry bound to a different proposal
-// identity (block hash and part-set header) already occupies the compact
-// block's height and round.
+// conflictsWith reports whether the compact block can never be stored at its
+// height and round: either an entry bound to a different proposal identity
+// (block hash and part-set header) already occupies the slot, or this
+// identity was rejected by consensus.
 func (p *ProposalCache) conflictsWith(cb *proptypes.CompactBlock) bool {
 	p.pmtx.Lock()
 	defer p.pmtx.Unlock()
+	if _, rejected := p.rejected[cb.Proposal.BlockID.Key()]; rejected {
+		return true
+	}
 	existing := p.proposals[cb.Proposal.Height][cb.Proposal.Round]
 	return existing != nil && !sameProposalIdentity(existing, cb)
+}
+
+// evict quarantines a proposal identity and removes the entry at the given
+// height and round when it is bound to that identity. Entries created by
+// AddCommitment carry a zero block ID and are therefore never evicted, since
+// their part set header is backed by a +2/3 commitment. Returns true if an
+// entry was removed.
+func (p *ProposalCache) evict(height int64, round int32, blockID types.BlockID) bool {
+	p.pmtx.Lock()
+	defer p.pmtx.Unlock()
+	p.rejected[blockID.Key()] = struct{}{}
+	existing := p.proposals[height][round]
+	if existing == nil || !existing.compactBlock.Proposal.BlockID.Equals(blockID) {
+		return false
+	}
+	delete(p.proposals[height], round)
+	return true
 }
 
 // GetProposal returns the proposal and block for a given height and round if
@@ -266,4 +297,7 @@ func (p *ProposalCache) prune(pruneHeight int64) {
 			delete(p.proposals, height)
 		}
 	}
+	// a committed height ends every dispute below it: rejected identities can
+	// no longer be proposed, so the quarantine starts empty each height.
+	p.rejected = make(map[string]struct{})
 }

--- a/consensus/propagation/commitment_state.go
+++ b/consensus/propagation/commitment_state.go
@@ -15,17 +15,16 @@ type proposalData struct {
 	block        *proptypes.CombinedPartSet
 	maxRequests  *bits.BitArray
 	catchup      bool
+	// commitmentBacked marks an entry whose part set header is backed by a
+	// +2/3 commitment, either created by AddCommitment or confirmed by it.
+	// Such an entry is never evicted.
+	commitmentBacked bool
 }
 
 type ProposalCache struct {
 	store     *store.BlockStore
 	pmtx      *sync.Mutex
 	proposals map[int64]map[int32]*proposalData
-
-	// rejected quarantines the identities of proposals that consensus
-	// rejected, keyed by types.BlockID.Key(), so they are never stored again.
-	// It is cleared on every commit by prune.
-	rejected map[string]struct{}
 
 	// height the height we're trying to get consensus on.
 	// the last committed height is height-1.
@@ -41,7 +40,6 @@ func NewProposalCache(bs *store.BlockStore) *ProposalCache {
 	pc := &ProposalCache{
 		pmtx:      &mtx,
 		proposals: make(map[int64]map[int32]*proposalData),
-		rejected:  make(map[string]struct{}),
 		store:     bs,
 	}
 
@@ -70,10 +68,6 @@ func (p *ProposalCache) AddProposal(cb *proptypes.CompactBlock) (added bool) {
 		return false
 	}
 
-	if _, rejected := p.rejected[cb.Proposal.BlockID.Key()]; rejected {
-		return false
-	}
-
 	if p.proposals[cb.Proposal.Height] == nil {
 		p.proposals[cb.Proposal.Height] = make(map[int32]*proposalData)
 	}
@@ -95,31 +89,33 @@ func (p *ProposalCache) AddProposal(cb *proptypes.CompactBlock) (added bool) {
 	return true
 }
 
-// conflictsWith reports whether the compact block can never be stored at its
-// height and round: either an entry bound to a different proposal identity
-// (block hash and part-set header) already occupies the slot, or this
-// identity was rejected by consensus.
+// conflictsWith reports whether an entry bound to a different proposal
+// identity (block hash and part-set header) already occupies the compact
+// block's height and round.
 func (p *ProposalCache) conflictsWith(cb *proptypes.CompactBlock) bool {
 	p.pmtx.Lock()
 	defer p.pmtx.Unlock()
-	if _, rejected := p.rejected[cb.Proposal.BlockID.Key()]; rejected {
-		return true
-	}
 	existing := p.proposals[cb.Proposal.Height][cb.Proposal.Round]
 	return existing != nil && !sameProposalIdentity(existing, cb)
 }
 
-// evict quarantines a proposal identity and removes the entry at the given
-// height and round when it is bound to that identity. Entries created by
-// AddCommitment carry a zero block ID and are therefore never evicted, since
-// their part set header is backed by a +2/3 commitment. Returns true if an
-// entry was removed.
+// evict removes the entry at the given height and round when it is bound to
+// the given proposal identity. An entry backed by a +2/3 commitment is kept,
+// since quorum support for the block outranks the rejection of a single
+// proposal message. Returns true if an entry was removed.
+//
+// The rejected identity is deliberately not blacklisted. A rejection means
+// consensus and propagation disagree about the proposer key or the block
+// params, not that the block is invalid, so refusing the identity later would
+// let one bad proposal message suppress an authentic block.
 func (p *ProposalCache) evict(height int64, round int32, blockID types.BlockID) bool {
 	p.pmtx.Lock()
 	defer p.pmtx.Unlock()
-	p.rejected[blockID.Key()] = struct{}{}
 	existing := p.proposals[height][round]
-	if existing == nil || !existing.compactBlock.Proposal.BlockID.Equals(blockID) {
+	if existing == nil || existing.commitmentBacked {
+		return false
+	}
+	if !existing.compactBlock.Proposal.BlockID.Equals(blockID) {
 		return false
 	}
 	delete(p.proposals[height], round)
@@ -297,7 +293,4 @@ func (p *ProposalCache) prune(pruneHeight int64) {
 			delete(p.proposals, height)
 		}
 	}
-	// a committed height ends every dispute below it: rejected identities can
-	// no longer be proposed, so the quarantine starts empty each height.
-	p.rejected = make(map[string]struct{})
 }

--- a/consensus/propagation/identity_test.go
+++ b/consensus/propagation/identity_test.go
@@ -204,16 +204,8 @@ func TestConsensusRejectionEvictsPropagationProposal(t *testing.T) {
 	require.False(t, has, "peer have state for the rejected proposal must be purged")
 	_, has = peer.GetRequests(1, 0)
 	require.False(t, has, "peer request state for the rejected proposal must be purged")
-
-	// A cannot be re-added, and is not forwarded to consensus again.
-	n1.handleCompactBlock(cbA, n2.self, false)
-	_, _, has = n1.GetProposal(1, 0)
-	require.False(t, has, "the rejected identity must stay quarantined")
-	select {
-	case prop := <-n1.GetProposalChan():
-		t.Fatalf("rejected proposal forwarded to consensus again: %+v", prop)
-	default:
-	}
+	require.Zero(t, peer.concurrentReqs.Load(),
+		"the request budget spent on the rejected proposal must be released")
 
 	// B is accepted, forwarded to consensus, and its parts are usable.
 	n1.handleCompactBlock(cbB, n2.self, false)
@@ -241,5 +233,62 @@ func TestConsensusRejectionEvictsPropagationProposal(t *testing.T) {
 		require.EqualValues(t, 0, part.Index)
 	case <-time.After(time.Second):
 		t.Fatal("replacement proposal's part was not forwarded to consensus")
+	}
+}
+
+// TestEvictProposalKeepsQuorumBackedProposal asserts that a proposal confirmed
+// by a +2/3 commitment is not evicted. AddCommitment returns early when the
+// cached proposal already carries the committed part set header, so that entry
+// keeps its own block ID and would otherwise match a rejection.
+func TestEvictProposalKeepsQuorumBackedProposal(t *testing.T) {
+	reactors, _ := testBlockPropReactors(2, defaultTestP2PConf())
+	n1, n2 := reactors[0], reactors[1]
+
+	cleanup, _, sm, pv := state.SetupTestCaseWithPrivVal(t)
+	t.Cleanup(func() { cleanup(t) })
+
+	cb, _, _, _ := testCompactBlock(t, sm, pv, 1, 0)
+	n1.handleCompactBlock(cb, n2.self, false)
+	_, _, has := n1.GetProposal(1, 0)
+	require.True(t, has)
+
+	// the commitment confirms the cached proposal rather than replacing it.
+	psh := cb.Proposal.BlockID.PartSetHeader
+	n1.AddCommitment(1, 0, &psh)
+
+	n1.EvictProposal(1, 0, cb.Proposal.BlockID)
+
+	_, _, has = n1.GetProposal(1, 0)
+	require.True(t, has, "a proposal backed by a commitment must not be evicted")
+	require.Len(t, n1.unfinishedHeights(), 1, "quorum-backed data must stay on the retry path")
+}
+
+// TestEvictProposalDoesNotBlockAuthenticProposal asserts that rejecting a
+// proposal identity does not blacklist it. A peer can forge a proposal message
+// carrying an authentic block ID with a bad signature, which consensus rejects;
+// the authentic compact block for that same block must still be accepted and
+// forwarded.
+func TestEvictProposalDoesNotBlockAuthenticProposal(t *testing.T) {
+	reactors, _ := testBlockPropReactors(2, defaultTestP2PConf())
+	n1, n2 := reactors[0], reactors[1]
+
+	cleanup, _, sm, pv := state.SetupTestCaseWithPrivVal(t)
+	t.Cleanup(func() { cleanup(t) })
+
+	cb, _, _, _ := testCompactBlock(t, sm, pv, 1, 0)
+
+	// consensus rejects a forged proposal message before propagation has the
+	// authentic compact block, so nothing is cached to evict.
+	n1.EvictProposal(1, 0, cb.Proposal.BlockID)
+
+	// the authentic compact block is still accepted and forwarded.
+	n1.handleCompactBlock(cb, n2.self, false)
+	_, _, has := n1.GetProposal(1, 0)
+	require.True(t, has, "a rejected identity must not be blacklisted")
+	select {
+	case prop := <-n1.GetProposalChan():
+		require.True(t, prop.Proposal.BlockID.Equals(cb.Proposal.BlockID))
+	case <-time.After(time.Second):
+		t.Fatal("authentic proposal was not forwarded to consensus")
 	}
 }

--- a/consensus/propagation/identity_test.go
+++ b/consensus/propagation/identity_test.go
@@ -149,3 +149,97 @@ func TestAddCommitmentReplacementPurgesPeerState(t *testing.T) {
 	require.False(t, has, "peer request state for the replaced identity must be purged")
 	require.Zero(t, peer.GetRemainingRequests(3, 0))
 }
+
+// TestConsensusRejectionEvictsPropagationProposal asserts that a proposal
+// rejected by consensus is no longer advertised or requested, and that a
+// valid replacement for the same height and round is accepted and forwarded.
+func TestConsensusRejectionEvictsPropagationProposal(t *testing.T) {
+	reactors, _ := testBlockPropReactors(2, defaultTestP2PConf())
+	n1, n2 := reactors[0], reactors[1]
+
+	cleanup, _, sm, pv := state.SetupTestCaseWithPrivVal(t)
+	t.Cleanup(func() { cleanup(t) })
+
+	// proposal A is accepted into propagation, then rejected by consensus.
+	cbA, _, _, _ := testCompactBlock(t, sm, pv, 1, 0)
+	// proposal B is a valid replacement for the same height and round.
+	cbB, psB, _, proofsB := testCompactBlock(t, sm, pv, 1, 0)
+	require.False(t, cbA.Proposal.BlockID.Equals(cbB.Proposal.BlockID))
+
+	n1.handleCompactBlock(cbA, n2.self, false)
+	select {
+	case prop := <-n1.GetProposalChan():
+		require.True(t, prop.Proposal.BlockID.Equals(cbA.Proposal.BlockID))
+	case <-time.After(time.Second):
+		t.Fatal("proposal A was not forwarded to consensus")
+	}
+
+	// record A's have and request state on the peer.
+	n1.handleHaves(n2.self, &proptypes.HaveParts{
+		Height: 1,
+		Round:  0,
+		Parts: []proptypes.PartMetaData{
+			{Index: 0, Hash: cbA.PartsHashes[0]},
+			{Index: 1, Hash: cbA.PartsHashes[1]},
+		},
+	})
+	peer := n1.getPeer(n2.self)
+	require.NotNil(t, peer)
+	haves, has := peer.GetHaves(1, 0)
+	require.True(t, has)
+	require.False(t, haves.IsEmpty())
+	// let the queued haves drain into sent requests before the eviction.
+	time.Sleep(300 * time.Millisecond)
+
+	// consensus rejects A.
+	n1.EvictProposal(1, 0, cbA.Proposal.BlockID)
+
+	// A is no longer stored, advertised, or requested.
+	_, _, has = n1.GetProposal(1, 0)
+	require.False(t, has, "the rejected proposal must not be stored")
+	_, _, found := n1.GetCurrentCompactBlock()
+	require.False(t, found, "the rejected proposal must not be advertised to new peers")
+	require.Empty(t, n1.unfinishedHeights(), "the rejected proposal must not be requested")
+	_, has = peer.GetHaves(1, 0)
+	require.False(t, has, "peer have state for the rejected proposal must be purged")
+	_, has = peer.GetRequests(1, 0)
+	require.False(t, has, "peer request state for the rejected proposal must be purged")
+
+	// A cannot be re-added, and is not forwarded to consensus again.
+	n1.handleCompactBlock(cbA, n2.self, false)
+	_, _, has = n1.GetProposal(1, 0)
+	require.False(t, has, "the rejected identity must stay quarantined")
+	select {
+	case prop := <-n1.GetProposalChan():
+		t.Fatalf("rejected proposal forwarded to consensus again: %+v", prop)
+	default:
+	}
+
+	// B is accepted, forwarded to consensus, and its parts are usable.
+	n1.handleCompactBlock(cbB, n2.self, false)
+	select {
+	case prop := <-n1.GetProposalChan():
+		require.True(t, prop.Proposal.BlockID.Equals(cbB.Proposal.BlockID))
+	case <-time.After(time.Second):
+		t.Fatal("replacement proposal was not forwarded to consensus")
+	}
+
+	_, parts, _, has := n1.getAllState(1, 0, true)
+	require.True(t, has)
+	require.True(t, parts.Original().Header().Equals(cbB.Proposal.BlockID.PartSetHeader))
+
+	partB := psB.GetPart(0)
+	n1.handleRecoveryPart(n2.self, &proptypes.RecoveryPart{
+		Height: 1,
+		Round:  0,
+		Index:  0,
+		Data:   partB.Bytes,
+		Proof:  proofsB[0],
+	})
+	select {
+	case part := <-n1.GetPartChan():
+		require.EqualValues(t, 0, part.Index)
+	case <-time.After(time.Second):
+		t.Fatal("replacement proposal's part was not forwarded to consensus")
+	}
+}

--- a/consensus/propagation/propagator.go
+++ b/consensus/propagation/propagator.go
@@ -19,6 +19,9 @@ type Propagator interface {
 	SetProposer(proposer crypto.PubKey)
 	// SetConsensusState installs the height, round, and proposer atomically.
 	SetConsensusState(height int64, round int32, proposer crypto.PubKey)
+	// EvictProposal drops a proposal that consensus rejected so a replacement
+	// at the same height and round can be accepted.
+	EvictProposal(height int64, round int32, blockID types.BlockID)
 	GetPartChan() <-chan types.PartInfo
 	GetProposalChan() <-chan ProposalAndSrc
 	// IsCatchingUp returns true if the node is catching up on block data
@@ -87,6 +90,9 @@ func (nop *NoOpPropagator) SetProposer(_ crypto.PubKey) {
 }
 
 func (nop *NoOpPropagator) SetConsensusState(_ int64, _ int32, _ crypto.PubKey) {
+}
+
+func (nop *NoOpPropagator) EvictProposal(_ int64, _ int32, _ types.BlockID) {
 }
 
 func (nop *NoOpPropagator) GetPartChan() <-chan types.PartInfo {

--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -378,16 +378,22 @@ func (blockProp *Reactor) SetConsensusState(height int64, round int32, proposer 
 	blockProp.applyCachedProposalIfAvailable()
 }
 
-// EvictProposal drops a proposal that consensus rejected. The rejected
-// identity is quarantined so it is not stored or gossiped again, and the
-// per-peer part state bound to it is purged so stale request bits cannot stop
-// retryWants from fetching a replacement proposal's parts.
+// EvictProposal drops a proposal that consensus rejected, freeing its height
+// and round so a replacement can be accepted. The per-peer part state bound
+// to the rejected identity is purged, so stale request bits cannot stop
+// retryWants from fetching the replacement's parts, and the request budget
+// spent on it is released.
 func (blockProp *Reactor) EvictProposal(height int64, round int32, blockID types.BlockID) {
 	if !blockProp.evict(height, round, blockID) {
 		return
 	}
 	blockProp.Logger.Info("evicted proposal rejected by consensus", "height", height, "round", round, "block_id", blockID)
 	for _, peer := range blockProp.getPeers() {
+		// parts for the evicted identity are dropped on arrival now that its
+		// state is gone, so nothing else will release this budget.
+		if reqs, has := peer.GetRequests(height, round); has {
+			peer.DecreaseConcurrentReqs(int64(len(reqs.GetTrueIndices())))
+		}
 		peer.DeleteRound(height, round)
 	}
 }

--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -378,19 +378,16 @@ func (blockProp *Reactor) SetConsensusState(height int64, round int32, proposer 
 	blockProp.applyCachedProposalIfAvailable()
 }
 
-// EvictProposal drops a proposal that consensus rejected, freeing its height
-// and round so a replacement can be accepted. The per-peer part state bound
-// to the rejected identity is purged, so stale request bits cannot stop
-// retryWants from fetching the replacement's parts, and the request budget
-// spent on it is released.
+// EvictProposal drops a proposal that consensus rejected, along with the peer
+// state and request budget bound to it, so a replacement can be fetched.
 func (blockProp *Reactor) EvictProposal(height int64, round int32, blockID types.BlockID) {
 	if !blockProp.evict(height, round, blockID) {
 		return
 	}
 	blockProp.Logger.Info("evicted proposal rejected by consensus", "height", height, "round", round, "block_id", blockID)
 	for _, peer := range blockProp.getPeers() {
-		// parts for the evicted identity are dropped on arrival now that its
-		// state is gone, so nothing else will release this budget.
+		// the evicted identity's parts are now dropped on arrival, so
+		// nothing else will release this budget.
 		if reqs, has := peer.GetRequests(height, round); has {
 			peer.DecreaseConcurrentReqs(int64(len(reqs.GetTrueIndices())))
 		}

--- a/consensus/propagation/reactor.go
+++ b/consensus/propagation/reactor.go
@@ -378,6 +378,20 @@ func (blockProp *Reactor) SetConsensusState(height int64, round int32, proposer 
 	blockProp.applyCachedProposalIfAvailable()
 }
 
+// EvictProposal drops a proposal that consensus rejected. The rejected
+// identity is quarantined so it is not stored or gossiped again, and the
+// per-peer part state bound to it is purged so stale request bits cannot stop
+// retryWants from fetching a replacement proposal's parts.
+func (blockProp *Reactor) EvictProposal(height int64, round int32, blockID types.BlockID) {
+	if !blockProp.evict(height, round, blockID) {
+		return
+	}
+	blockProp.Logger.Info("evicted proposal rejected by consensus", "height", height, "round", round, "block_id", blockID)
+	for _, peer := range blockProp.getPeers() {
+		peer.DeleteRound(height, round)
+	}
+}
+
 func (blockProp *Reactor) ResetRequestCounts() {
 	peers := blockProp.getPeers()
 	for _, p := range peers {

--- a/consensus/propagation_feedback_test.go
+++ b/consensus/propagation_feedback_test.go
@@ -1,0 +1,61 @@
+package consensus
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/consensus/propagation"
+	cmtrand "github.com/cometbft/cometbft/libs/rand"
+	"github.com/cometbft/cometbft/types"
+)
+
+// recordingPropagator records the proposals evicted by consensus.
+type recordingPropagator struct {
+	*propagation.NoOpPropagator
+	mtx       sync.Mutex
+	evictions []types.BlockID
+}
+
+func newRecordingPropagator() *recordingPropagator {
+	return &recordingPropagator{NoOpPropagator: propagation.NewNoOpPropagator()}
+}
+
+func (r *recordingPropagator) EvictProposal(_ int64, _ int32, blockID types.BlockID) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.evictions = append(r.evictions, blockID)
+}
+
+func (r *recordingPropagator) Evictions() []types.BlockID {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return append([]types.BlockID{}, r.evictions...)
+}
+
+// TestConsensusRejectionEvictsProposal asserts that a proposal consensus
+// deterministically rejects is evicted from propagation, and that a routine
+// height mismatch is not treated as a rejection.
+func TestConsensusRejectionEvictsProposal(t *testing.T) {
+	cs, _ := randState(2)
+	prop := newRecordingPropagator()
+	cs.propagator = prop
+
+	blockID := types.BlockID{
+		Hash:          cmtrand.Bytes(32),
+		PartSetHeader: types.PartSetHeader{Total: 1, Hash: cmtrand.Bytes(32)},
+	}
+	// an invalid signature can never be accepted at this height and round.
+	proposal := types.NewProposal(cs.rs.Height, cs.rs.Round, -1, blockID)
+	proposal.Signature = cmtrand.Bytes(64)
+
+	cs.handleMsg(msgInfo{Msg: &ProposalMessage{Proposal: proposal}, PeerID: "peer1"})
+	require.Equal(t, []types.BlockID{blockID}, prop.Evictions())
+
+	// a proposal for a height we have not reached is routine and must not evict.
+	stale := types.NewProposal(cs.rs.Height+1, cs.rs.Round, -1, blockID)
+	stale.Signature = cmtrand.Bytes(64)
+	cs.handleMsg(msgInfo{Msg: &ProposalMessage{Proposal: stale}, PeerID: "peer1"})
+	require.Len(t, prop.Evictions(), 1)
+}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1038,9 +1038,7 @@ func (cs *State) handleMsg(mi msgInfo) {
 		// will not cause transition.
 		// once proposal is set, we can receive block parts
 		if err := cs.setProposal(msg.Proposal); isProposalRejection(err) {
-			// the proposal can never be accepted at this height and round:
-			// evict it from propagation so it stops being gossiped and a
-			// replacement proposal can be accepted.
+			// evict it from propagation so a replacement can be accepted.
 			cs.propagator.EvictProposal(msg.Proposal.Height, msg.Proposal.Round, msg.Proposal.BlockID)
 		}
 
@@ -2284,9 +2282,8 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	return nil
 }
 
-// isProposalRejection reports whether setProposal failed because the proposal
-// can never be accepted at its height and round. Routine mismatches, such as
-// a proposal for a height or round we already moved past, are not rejections.
+// isProposalRejection reports whether setProposal rejected the proposal
+// outright, rather than hitting a routine height or round mismatch.
 func isProposalRejection(err error) bool {
 	return errors.Is(err, ErrInvalidProposalSignature) ||
 		errors.Is(err, ErrInvalidProposalPOLRound) ||

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1037,7 +1037,12 @@ func (cs *State) handleMsg(mi msgInfo) {
 	case *ProposalMessage:
 		// will not cause transition.
 		// once proposal is set, we can receive block parts
-		_ = cs.setProposal(msg.Proposal)
+		if err := cs.setProposal(msg.Proposal); isProposalRejection(err) {
+			// the proposal can never be accepted at this height and round:
+			// evict it from propagation so it stops being gossiped and a
+			// replacement proposal can be accepted.
+			cs.propagator.EvictProposal(msg.Proposal.Height, msg.Proposal.Round, msg.Proposal.BlockID)
+		}
 
 	case *BlockPartMessage:
 		// if the proposal is complete, we'll enterPrevote or tryFinalizeCommit
@@ -2277,6 +2282,15 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 	cs.Logger.Info("received proposal", "proposal", proposal, "proposer", pubKey.Address())
 	cs.proposalReceivedTime = time.Now()
 	return nil
+}
+
+// isProposalRejection reports whether setProposal failed because the proposal
+// can never be accepted at its height and round. Routine mismatches, such as
+// a proposal for a height or round we already moved past, are not rejections.
+func isProposalRejection(err error) bool {
+	return errors.Is(err, ErrInvalidProposalSignature) ||
+		errors.Is(err, ErrInvalidProposalPOLRound) ||
+		errors.Is(err, ErrProposalTooManyParts)
 }
 
 // NOTE: block is not necessarily valid.


### PR DESCRIPTION
Consensus discarded the error from `setProposal`, so a proposal it rejected stayed pinned in propagation's cache slot for its height and round: it kept being advertised to new peers, requested by `retryWants`, and blocked a valid replacement at the same height and round. `handleMsg` now evicts on a deterministic rejection (invalid signature, POL round, or too many parts), while routine height and round mismatches do not evict. Eviction frees the slot, purges the per-peer part state bound to the rejected identity, and releases the request budget spent on it, so the replacement's parts can be fetched immediately.

The rejected identity is deliberately not blacklisted. `validateCompactBlock` already rejects the same three failures, so a proposal consensus rejects deterministically cannot enter the cache anyway, and refusing the identity afterwards would let a forged proposal message suppress an authentic block. Eviction also matches on the rejected `BlockID` and skips entries confirmed by a +2/3 commitment, because a rejected proposal can be delivered more than once and the slot may have moved on.

Note for reviewers: this adds `EvictProposal` to the `Propagator` interface, hence the breaking marker. Not labeled for backport, since `v0.40.x` needs #3286, #3287, and #3298 first.

Closes #3275
Closes [PROTOCO-2579](https://linear.app/celestia/issue/PROTOCO-2579)