### PR TITLE
chore(db): tune pebble db config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,7 @@ linters:
             - github.com/stretchr/testify/assert
             - github.com/klauspost/reedsolomon
             - github.com/filecoin-project/go-clock
+            - github.com/syndtr/goleveldb/leveldb/opt
         test:
           files:
             - $test
@@ -98,6 +99,7 @@ linters:
             - github.com/gogo/protobuf/proto
             - google.golang.org/protobuf/encoding/protowire
             - github.com/filecoin-project/go-clock
+            - github.com/cockroachdb/pebble
     dogsled:
       max-blank-identifiers: 3
     gosec:

--- a/config/config.go
+++ b/config/config.go
@@ -1325,6 +1325,13 @@ type StorageConfig struct {
 	// large multiple of your retain height as it might occur bigger overheads.
 	// 10000 by default.
 	CompactionInterval int64 `mapstructure:"compaction_interval"`
+	// DBTuning opens the databases with compaction-friendly options (larger
+	// memtables, more concurrent compactions, growing sstable target sizes and
+	// a shared block cache) instead of the library defaults. It trades a higher
+	// memory baseline and a one-time compaction catch-up for a healthier LSM on
+	// large stores — recommended for archival nodes whose blockstore would
+	// otherwise fragment into millions of tiny sstables. false by default.
+	DBTuning bool `mapstructure:"db_tuning"`
 }
 
 // DefaultStorageConfig returns the default configuration options relating to
@@ -1334,6 +1341,7 @@ func DefaultStorageConfig() *StorageConfig {
 		DiscardABCIResponses: false,
 		Compact:              false,
 		CompactionInterval:   10000,
+		DBTuning:             false,
 	}
 }
 

--- a/config/db.go
+++ b/config/db.go
@@ -2,6 +2,10 @@ package config
 
 import (
 	"context"
+	"runtime"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	dbm "github.com/cometbft/cometbft-db"
 
@@ -23,7 +27,9 @@ type DBContext struct {
 type DBProvider func(*DBContext) (dbm.DB, error)
 
 // DefaultDBProvider returns a database using the DBBackend and DBDir
-// specified in the Config.
+// specified in the Config, with library-default options. Used by nodes when
+// compaction is disabled, and by short-lived tools (inspect, light client)
+// regardless of compaction settings.
 func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
 	dbType := dbm.BackendType(ctx.Config.DBBackend)
 	path := ctx.Path
@@ -31,4 +37,77 @@ func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
 		path = ctx.Config.DBDir()
 	}
 	return dbm.NewDB(ctx.ID, dbType, path)
+}
+
+// Hardcoded DB-tuning values applied only when Storage.Compact is enabled.
+// See celestiaorg/celestia-core#3053: with compaction off, the library
+// defaults are fine; with compaction on, the default memtable/L0/cache sizes
+// let writes stall while a compaction is in flight. These knobs absorb write
+// bursts and keep block-save latency bounded under load.
+const (
+	// PebbleSharedCacheBytes is the size of the shared pebble block cache
+	// installed across blockstore, state, evidence, and tx_index when
+	// compaction is enabled and the backend is pebbledb.
+	PebbleSharedCacheBytes int64 = 1 << 30 // 1 GiB
+
+	pebbleMemTableSize                uint64 = 128 << 20 // 128 MiB
+	pebbleMemTableStopWritesThreshold int    = 4
+	pebbleL0StopWritesThreshold       int    = 24
+
+	goLevelDBWriteBuffer            = 128 << 20 // 128 MiB
+	goLevelDBBlockCacheCapacity     = 512 << 20 // 512 MiB per-DB (goleveldb cannot share)
+	goLevelDBWriteL0SlowdownTrigger = 16
+	goLevelDBWriteL0PauseTrigger    = 24
+)
+
+// pebbleMaxConcurrentCompactions depends on GOMAXPROCS, so it is computed at
+// init rather than declared as a const.
+var pebbleMaxConcurrentCompactions = max(2, runtime.GOMAXPROCS(0)/2)
+
+// NewCompactionDBProvider returns a DBProvider that applies the
+// compaction-friendly tuning above. If sharedPebbleCache is non-nil, it is
+// installed into every PebbleDB this provider opens. Pass nil to skip cache
+// sharing (each DB gets its own cache).
+//
+// Callers should only use this provider when Storage.Compact is enabled.
+// When compaction is off, the tuning's larger memory footprint is wasteful.
+func NewCompactionDBProvider(sharedPebbleCache *pebble.Cache) DBProvider {
+	return func(ctx *DBContext) (dbm.DB, error) {
+		dbType := dbm.BackendType(ctx.Config.DBBackend)
+		path := ctx.Path
+		if path == "" {
+			path = ctx.Config.DBDir()
+		}
+		switch dbType {
+		case dbm.PebbleDBBackend:
+			return dbm.NewPebbleDBWithOpts(ctx.ID, path, buildPebbleOptions(sharedPebbleCache))
+		case dbm.GoLevelDBBackend:
+			return dbm.NewGoLevelDBWithOpts(ctx.ID, path, buildGoLevelDBOptions())
+		default:
+			return dbm.NewDB(ctx.ID, dbType, path)
+		}
+	}
+}
+
+func buildPebbleOptions(sharedCache *pebble.Cache) *pebble.Options {
+	o := &pebble.Options{
+		MemTableSize:                pebbleMemTableSize,
+		MemTableStopWritesThreshold: pebbleMemTableStopWritesThreshold,
+		L0StopWritesThreshold:       pebbleL0StopWritesThreshold,
+		MaxConcurrentCompactions:    func() int { return pebbleMaxConcurrentCompactions },
+	}
+	if sharedCache != nil {
+		o.Cache = sharedCache
+	}
+	o.EnsureDefaults()
+	return o
+}
+
+func buildGoLevelDBOptions() *opt.Options {
+	return &opt.Options{
+		WriteBuffer:            goLevelDBWriteBuffer,
+		BlockCacheCapacity:     goLevelDBBlockCacheCapacity,
+		WriteL0SlowdownTrigger: goLevelDBWriteL0SlowdownTrigger,
+		WriteL0PauseTrigger:    goLevelDBWriteL0PauseTrigger,
+	}
 }

--- a/config/db.go
+++ b/config/db.go
@@ -48,20 +48,23 @@ const (
 	// PebbleSharedCacheBytes is the size of the shared pebble block cache
 	// installed across blockstore, state, evidence, and tx_index when
 	// DB tuning is enabled and the backend is pebbledb.
-	PebbleSharedCacheBytes int64 = 1 << 30 // 1 GiB
+	PebbleSharedCacheBytes int64 = 512 << 20 // 512 MiB
 
-	pebbleMemTableSize                uint64 = 128 << 20 // 128 MiB
+	pebbleMemTableSize                uint64 = 64 << 20 // 64 MiB
 	pebbleMemTableStopWritesThreshold int    = 4
 	pebbleL0StopWritesThreshold       int    = 24
 
 	// pebbleL0TargetFileSize is the sstable target size for L0. Pebble's
 	// default is 2 MiB, which on a multi-TB archival blockstore that compaction
 	// can't keep up with degenerates into millions of tiny sstables. A larger
-	// base — doubled per level up to L6 — makes each compaction emit fewer,
-	// larger files and keeps the LSM's file count (and the memory Pebble spends
-	// tracking it) bounded. See celestiaorg/celestia-core#3053.
-	pebbleL0TargetFileSize int64 = 8 << 20 // 8 MiB (L6 ends at 512 MiB)
-	pebbleNumLevels              = 7
+	// base — doubled per level and capped at pebbleMaxTargetFileSize — makes
+	// each compaction emit fewer, larger files and keeps the LSM's file count
+	// (and the memory Pebble spends tracking it) bounded, without the large
+	// per-compaction IO spikes that a very large target would cause. See
+	// celestiaorg/celestia-core#3053.
+	pebbleL0TargetFileSize  int64 = 8 << 20   // 8 MiB
+	pebbleMaxTargetFileSize int64 = 128 << 20 // 128 MiB (matches pebble's default L6)
+	pebbleNumLevels               = 7
 
 	goLevelDBWriteBuffer            = 128 << 20 // 128 MiB
 	goLevelDBBlockCacheCapacity     = 512 << 20 // 512 MiB per-DB (goleveldb cannot share)
@@ -71,7 +74,7 @@ const (
 
 // pebbleMaxConcurrentCompactions depends on GOMAXPROCS, so it is computed at
 // init rather than declared as a const.
-var pebbleMaxConcurrentCompactions = max(2, runtime.GOMAXPROCS(0)/2)
+var pebbleMaxConcurrentCompactions = max(2, runtime.GOMAXPROCS(0)/4)
 
 // NewCompactionDBProvider returns a DBProvider that applies the
 // compaction-friendly tuning above. If sharedPebbleCache is non-nil, it is
@@ -114,15 +117,18 @@ func buildPebbleOptions(sharedCache *pebble.Cache) *pebble.Options {
 }
 
 // buildPebbleLevels returns per-level options whose TargetFileSize starts at
-// pebbleL0TargetFileSize and doubles each level up to L6. Setting the levels
-// explicitly (rather than leaving Levels nil) is what makes EnsureDefaults keep
-// our larger base instead of falling back to the 2 MiB default.
+// pebbleL0TargetFileSize, doubles each level and is capped at
+// pebbleMaxTargetFileSize. Setting the levels explicitly (rather than leaving
+// Levels nil) is what makes EnsureDefaults keep our larger base instead of
+// falling back to the 2 MiB default.
 func buildPebbleLevels() []pebble.LevelOptions {
 	levels := make([]pebble.LevelOptions, pebbleNumLevels)
 	target := pebbleL0TargetFileSize
 	for i := range levels {
 		levels[i].TargetFileSize = target
-		target *= 2
+		if target < pebbleMaxTargetFileSize {
+			target *= 2
+		}
 	}
 	return levels
 }

--- a/config/db.go
+++ b/config/db.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 
 	"github.com/cockroachdb/pebble"
-	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	dbm "github.com/cometbft/cometbft-db"
 
@@ -65,20 +64,16 @@ const (
 	pebbleL0TargetFileSize  int64 = 8 << 20   // 8 MiB
 	pebbleMaxTargetFileSize int64 = 128 << 20 // 128 MiB (matches pebble's default L6)
 	pebbleNumLevels               = 7
-
-	goLevelDBWriteBuffer            = 128 << 20 // 128 MiB
-	goLevelDBBlockCacheCapacity     = 512 << 20 // 512 MiB per-DB (goleveldb cannot share)
-	goLevelDBWriteL0SlowdownTrigger = 16
-	goLevelDBWriteL0PauseTrigger    = 24
 )
 
 // pebbleMaxConcurrentCompactions depends on GOMAXPROCS, so it is computed at
 // init rather than declared as a const.
 var pebbleMaxConcurrentCompactions = max(2, runtime.GOMAXPROCS(0)/4)
 
-// NewCompactionDBProvider returns a DBProvider that opens databases with the
+// NewCompactionDBProvider returns a DBProvider that opens PebbleDB with the
 // compaction-friendly tuning above, optionally sharing sharedPebbleCache
-// (nil = per-DB cache). Use it only when Storage.DBTuning is enabled.
+// (nil = per-DB cache). Non-pebble backends fall back to library defaults.
+// Use it only when Storage.DBTuning is enabled and the backend is pebbledb.
 func NewCompactionDBProvider(sharedPebbleCache *pebble.Cache) DBProvider {
 	return func(ctx *DBContext) (dbm.DB, error) {
 		dbType := dbm.BackendType(ctx.Config.DBBackend)
@@ -89,8 +84,6 @@ func NewCompactionDBProvider(sharedPebbleCache *pebble.Cache) DBProvider {
 		switch dbType {
 		case dbm.PebbleDBBackend:
 			return dbm.NewPebbleDBWithOpts(ctx.ID, path, buildPebbleOptions(sharedPebbleCache))
-		case dbm.GoLevelDBBackend:
-			return dbm.NewGoLevelDBWithOpts(ctx.ID, path, buildGoLevelDBOptions())
 		default:
 			return dbm.NewDB(ctx.ID, dbType, path)
 		}
@@ -127,13 +120,4 @@ func buildPebbleLevels() []pebble.LevelOptions {
 		}
 	}
 	return levels
-}
-
-func buildGoLevelDBOptions() *opt.Options {
-	return &opt.Options{
-		WriteBuffer:            goLevelDBWriteBuffer,
-		BlockCacheCapacity:     goLevelDBBlockCacheCapacity,
-		WriteL0SlowdownTrigger: goLevelDBWriteL0SlowdownTrigger,
-		WriteL0PauseTrigger:    goLevelDBWriteL0PauseTrigger,
-	}
 }

--- a/config/db.go
+++ b/config/db.go
@@ -28,8 +28,8 @@ type DBProvider func(*DBContext) (dbm.DB, error)
 
 // DefaultDBProvider returns a database using the DBBackend and DBDir
 // specified in the Config, with library-default options. Used by nodes when
-// compaction is disabled, and by short-lived tools (inspect, light client)
-// regardless of compaction settings.
+// DB tuning is disabled, and by short-lived tools (inspect, light client)
+// regardless of the tuning setting.
 func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
 	dbType := dbm.BackendType(ctx.Config.DBBackend)
 	path := ctx.Path
@@ -39,15 +39,15 @@ func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
 	return dbm.NewDB(ctx.ID, dbType, path)
 }
 
-// Hardcoded DB-tuning values applied only when Storage.Compact is enabled.
-// See celestiaorg/celestia-core#3053: with compaction off, the library
-// defaults are fine; with compaction on, the default memtable/L0/cache sizes
-// let writes stall while a compaction is in flight. These knobs absorb write
-// bursts and keep block-save latency bounded under load.
+// Hardcoded DB-tuning values applied only when Storage.DBTuning is enabled.
+// See celestiaorg/celestia-core#3053: with tuning off, the library defaults
+// are fine; with tuning on, larger memtables, growing sstable target sizes and
+// a shared cache keep the LSM from fragmenting into millions of tiny sstables
+// on large stores and keep block-save latency bounded under load.
 const (
 	// PebbleSharedCacheBytes is the size of the shared pebble block cache
 	// installed across blockstore, state, evidence, and tx_index when
-	// compaction is enabled and the backend is pebbledb.
+	// DB tuning is enabled and the backend is pebbledb.
 	PebbleSharedCacheBytes int64 = 1 << 30 // 1 GiB
 
 	pebbleMemTableSize                uint64 = 128 << 20 // 128 MiB
@@ -78,8 +78,8 @@ var pebbleMaxConcurrentCompactions = max(2, runtime.GOMAXPROCS(0)/2)
 // installed into every PebbleDB this provider opens. Pass nil to skip cache
 // sharing (each DB gets its own cache).
 //
-// Callers should only use this provider when Storage.Compact is enabled.
-// When compaction is off, the tuning's larger memory footprint is wasteful.
+// Callers should only use this provider when Storage.DBTuning is enabled.
+// When tuning is off, the larger memory footprint is wasteful.
 func NewCompactionDBProvider(sharedPebbleCache *pebble.Cache) DBProvider {
 	return func(ctx *DBContext) (dbm.DB, error) {
 		dbType := dbm.BackendType(ctx.Config.DBBackend)

--- a/config/db.go
+++ b/config/db.go
@@ -76,13 +76,9 @@ const (
 // init rather than declared as a const.
 var pebbleMaxConcurrentCompactions = max(2, runtime.GOMAXPROCS(0)/4)
 
-// NewCompactionDBProvider returns a DBProvider that applies the
-// compaction-friendly tuning above. If sharedPebbleCache is non-nil, it is
-// installed into every PebbleDB this provider opens. Pass nil to skip cache
-// sharing (each DB gets its own cache).
-//
-// Callers should only use this provider when Storage.DBTuning is enabled.
-// When tuning is off, the larger memory footprint is wasteful.
+// NewCompactionDBProvider returns a DBProvider that opens databases with the
+// compaction-friendly tuning above, optionally sharing sharedPebbleCache
+// (nil = per-DB cache). Use it only when Storage.DBTuning is enabled.
 func NewCompactionDBProvider(sharedPebbleCache *pebble.Cache) DBProvider {
 	return func(ctx *DBContext) (dbm.DB, error) {
 		dbType := dbm.BackendType(ctx.Config.DBBackend)

--- a/config/db.go
+++ b/config/db.go
@@ -54,6 +54,15 @@ const (
 	pebbleMemTableStopWritesThreshold int    = 4
 	pebbleL0StopWritesThreshold       int    = 24
 
+	// pebbleL0TargetFileSize is the sstable target size for L0. Pebble's
+	// default is 2 MiB, which on a multi-TB archival blockstore that compaction
+	// can't keep up with degenerates into millions of tiny sstables. A larger
+	// base — doubled per level up to L6 — makes each compaction emit fewer,
+	// larger files and keeps the LSM's file count (and the memory Pebble spends
+	// tracking it) bounded. See celestiaorg/celestia-core#3053.
+	pebbleL0TargetFileSize int64 = 8 << 20 // 8 MiB (L6 ends at 512 MiB)
+	pebbleNumLevels              = 7
+
 	goLevelDBWriteBuffer            = 128 << 20 // 128 MiB
 	goLevelDBBlockCacheCapacity     = 512 << 20 // 512 MiB per-DB (goleveldb cannot share)
 	goLevelDBWriteL0SlowdownTrigger = 16
@@ -95,12 +104,27 @@ func buildPebbleOptions(sharedCache *pebble.Cache) *pebble.Options {
 		MemTableStopWritesThreshold: pebbleMemTableStopWritesThreshold,
 		L0StopWritesThreshold:       pebbleL0StopWritesThreshold,
 		MaxConcurrentCompactions:    func() int { return pebbleMaxConcurrentCompactions },
+		Levels:                      buildPebbleLevels(),
 	}
 	if sharedCache != nil {
 		o.Cache = sharedCache
 	}
 	o.EnsureDefaults()
 	return o
+}
+
+// buildPebbleLevels returns per-level options whose TargetFileSize starts at
+// pebbleL0TargetFileSize and doubles each level up to L6. Setting the levels
+// explicitly (rather than leaving Levels nil) is what makes EnsureDefaults keep
+// our larger base instead of falling back to the 2 MiB default.
+func buildPebbleLevels() []pebble.LevelOptions {
+	levels := make([]pebble.LevelOptions, pebbleNumLevels)
+	target := pebbleL0TargetFileSize
+	for i := range levels {
+		levels[i].TargetFileSize = target
+		target *= 2
+	}
+	return levels
 }
 
 func buildGoLevelDBOptions() *opt.Options {

--- a/config/db_test.go
+++ b/config/db_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
+)
+
+func TestBuildPebbleOptions_NoCache(t *testing.T) {
+	o := buildPebbleOptions(nil)
+	require.NotNil(t, o)
+
+	assert.Equal(t, pebbleMemTableSize, o.MemTableSize)
+	assert.Equal(t, pebbleMemTableStopWritesThreshold, o.MemTableStopWritesThreshold)
+	assert.Equal(t, pebbleL0StopWritesThreshold, o.L0StopWritesThreshold)
+	require.NotNil(t, o.MaxConcurrentCompactions)
+	assert.Equal(t, pebbleMaxConcurrentCompactions, o.MaxConcurrentCompactions())
+	assert.Nil(t, o.Cache, "no cache should be installed when sharedCache is nil")
+}
+
+func TestBuildPebbleOptions_SharedCacheInstalledAndSurvivesEnsureDefaults(t *testing.T) {
+	cache := pebble.NewCache(64 << 20)
+	t.Cleanup(func() { cache.Unref() })
+
+	o := buildPebbleOptions(cache)
+	require.NotNil(t, o)
+
+	assert.Same(t, cache, o.Cache, "shared cache should be installed verbatim")
+	// EnsureDefaults must not clobber our explicit overrides.
+	assert.Equal(t, pebbleMemTableSize, o.MemTableSize)
+	assert.Equal(t, pebbleL0StopWritesThreshold, o.L0StopWritesThreshold)
+}
+
+func TestBuildGoLevelDBOptions(t *testing.T) {
+	o := buildGoLevelDBOptions()
+	require.NotNil(t, o)
+
+	assert.Equal(t, goLevelDBWriteBuffer, o.WriteBuffer)
+	assert.Equal(t, goLevelDBBlockCacheCapacity, o.BlockCacheCapacity)
+	assert.Equal(t, goLevelDBWriteL0SlowdownTrigger, o.WriteL0SlowdownTrigger)
+	assert.Equal(t, goLevelDBWriteL0PauseTrigger, o.WriteL0PauseTrigger)
+}
+
+func TestNewCompactionDBProvider_PebbleRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.SetRoot(dir)
+	cfg.DBBackend = string(dbm.PebbleDBBackend)
+
+	cache := pebble.NewCache(32 << 20)
+	t.Cleanup(func() { cache.Unref() })
+
+	provider := NewCompactionDBProvider(cache)
+	db, err := provider(&DBContext{
+		ID:     "test",
+		Config: cfg,
+		Path:   filepath.Join(dir, "data"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, db.Set([]byte("k"), []byte("v")))
+	got, err := db.Get([]byte("k"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), got)
+}
+
+func TestNewCompactionDBProvider_NilCacheStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.SetRoot(dir)
+	cfg.DBBackend = string(dbm.PebbleDBBackend)
+
+	provider := NewCompactionDBProvider(nil)
+	db, err := provider(&DBContext{
+		ID:     "test",
+		Config: cfg,
+		Path:   filepath.Join(dir, "data"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, db.Set([]byte("k"), []byte("v")))
+}
+
+func TestNewCompactionDBProvider_UnknownBackendFallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.SetRoot(dir)
+	cfg.DBBackend = string(dbm.MemDBBackend)
+
+	provider := NewCompactionDBProvider(nil)
+	db, err := provider(&DBContext{
+		ID:     "test",
+		Config: cfg,
+		Path:   filepath.Join(dir, "data"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, db.Set([]byte("k"), []byte("v")))
+}

--- a/config/db_test.go
+++ b/config/db_test.go
@@ -22,14 +22,19 @@ func TestBuildPebbleOptions_NoCache(t *testing.T) {
 	assert.Equal(t, pebbleMaxConcurrentCompactions, o.MaxConcurrentCompactions())
 	assert.Nil(t, o.Cache, "no cache should be installed when sharedCache is nil")
 
-	// TargetFileSize starts at the larger base and doubles each level; the base
-	// must survive EnsureDefaults rather than reverting to Pebble's 2 MiB.
+	// TargetFileSize starts at the larger base, doubles each level and is capped
+	// at pebbleMaxTargetFileSize; the base must survive EnsureDefaults rather
+	// than reverting to Pebble's 2 MiB.
 	require.Len(t, o.Levels, pebbleNumLevels)
 	want := pebbleL0TargetFileSize
 	for i := range o.Levels {
 		assert.Equal(t, want, o.Levels[i].TargetFileSize, "L%d target file size", i)
-		want *= 2
+		if want < pebbleMaxTargetFileSize {
+			want *= 2
+		}
 	}
+	assert.Equal(t, pebbleMaxTargetFileSize, o.Levels[pebbleNumLevels-1].TargetFileSize,
+		"deepest level should be capped at the max target file size")
 }
 
 func TestBuildPebbleOptions_SharedCacheInstalledAndSurvivesEnsureDefaults(t *testing.T) {

--- a/config/db_test.go
+++ b/config/db_test.go
@@ -21,6 +21,15 @@ func TestBuildPebbleOptions_NoCache(t *testing.T) {
 	require.NotNil(t, o.MaxConcurrentCompactions)
 	assert.Equal(t, pebbleMaxConcurrentCompactions, o.MaxConcurrentCompactions())
 	assert.Nil(t, o.Cache, "no cache should be installed when sharedCache is nil")
+
+	// TargetFileSize starts at the larger base and doubles each level; the base
+	// must survive EnsureDefaults rather than reverting to Pebble's 2 MiB.
+	require.Len(t, o.Levels, pebbleNumLevels)
+	want := pebbleL0TargetFileSize
+	for i := range o.Levels {
+		assert.Equal(t, want, o.Levels[i].TargetFileSize, "L%d target file size", i)
+		want *= 2
+	}
 }
 
 func TestBuildPebbleOptions_SharedCacheInstalledAndSurvivesEnsureDefaults(t *testing.T) {

--- a/config/db_test.go
+++ b/config/db_test.go
@@ -50,16 +50,6 @@ func TestBuildPebbleOptions_SharedCacheInstalledAndSurvivesEnsureDefaults(t *tes
 	assert.Equal(t, pebbleL0StopWritesThreshold, o.L0StopWritesThreshold)
 }
 
-func TestBuildGoLevelDBOptions(t *testing.T) {
-	o := buildGoLevelDBOptions()
-	require.NotNil(t, o)
-
-	assert.Equal(t, goLevelDBWriteBuffer, o.WriteBuffer)
-	assert.Equal(t, goLevelDBBlockCacheCapacity, o.BlockCacheCapacity)
-	assert.Equal(t, goLevelDBWriteL0SlowdownTrigger, o.WriteL0SlowdownTrigger)
-	assert.Equal(t, goLevelDBWriteL0PauseTrigger, o.WriteL0PauseTrigger)
-}
-
 func TestNewCompactionDBProvider_PebbleRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	cfg := DefaultConfig()

--- a/config/toml.go
+++ b/config/toml.go
@@ -580,6 +580,15 @@ compact = {{ .Storage.Compact }}
 # large multiple of your retain height as it might occur bigger overheads.
 compaction_interval = {{ .Storage.CompactionInterval }}
 
+# If set to true, databases are opened with compaction-friendly options (larger
+# memtables, more concurrent compactions, growing sstable target sizes and a
+# shared block cache) instead of the library defaults. This keeps the LSM
+# healthy on large stores that would otherwise fragment into millions of tiny
+# sstables, at the cost of a higher memory baseline and a one-time compaction
+# catch-up on the first restart. Recommended for archival nodes.
+# false by default.
+db_tuning = {{ .Storage.DBTuning }}
+
 #######################################################
 ###   Transaction Indexer Configuration Options     ###
 #######################################################

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/celestiaorg/go-square/v3 v3.0.2
 	github.com/celestiaorg/nmt v0.24.4
+	github.com/cockroachdb/pebble v1.1.4
 	github.com/cometbft/cometbft-db v1.0.4
 	github.com/cosmos/gogoproto v1.7.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
@@ -48,6 +49,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
+	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.46.0
 	go.opentelemetry.io/otel/sdk v1.46.0
@@ -130,7 +132,6 @@ require (
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240816210425-c5d0cb0b6fc0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
-	github.com/cockroachdb/pebble v1.1.4 // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
@@ -282,7 +283,6 @@ require (
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
-	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.46.0
 	go.opentelemetry.io/otel/sdk v1.46.0
@@ -283,6 +282,7 @@ require (
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect

--- a/node/node.go
+++ b/node/node.go
@@ -312,15 +312,16 @@ func NewNodeWithContext(ctx context.Context,
 	logger log.Logger,
 	options ...Option,
 ) (*Node, error) {
-	// When forced compaction is enabled, swap in a DBProvider that opens each
-	// DB with larger memtables and a shared block cache so block-save latency
-	// stays bounded while a compaction is in flight. See celestia-core#3053.
+	// When DB tuning is enabled, swap in a DBProvider that opens each DB with
+	// larger memtables, growing sstable target sizes and a shared block cache
+	// so the LSM stays healthy on large stores instead of fragmenting into
+	// millions of tiny sstables. See celestia-core#3053.
 	//
 	// Each DB pebble opens via Options.Cache takes its own ref on the cache,
 	// so dropping the creator's initial ref here is safe — the cache lives
 	// as long as any DB that uses it.
 	effectiveDBProvider := dbProvider
-	if config.Storage.Compact {
+	if config.Storage.DBTuning {
 		var dbCache *pebble.Cache
 		if dbm.BackendType(config.DBBackend) == dbm.PebbleDBBackend {
 			dbCache = pebble.NewCache(cfg.PebbleSharedCacheBytes)

--- a/node/node.go
+++ b/node/node.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/cometbft/cometbft/consensus/propagation"
 
+	"github.com/cockroachdb/pebble"
 	"github.com/grafana/pyroscope-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/grpc"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	bc "github.com/cometbft/cometbft/blocksync"
 	cfg "github.com/cometbft/cometbft/config"
@@ -309,7 +312,24 @@ func NewNodeWithContext(ctx context.Context,
 	logger log.Logger,
 	options ...Option,
 ) (*Node, error) {
-	blockStore, stateDB, err := initDBs(config, dbProvider, logger)
+	// When forced compaction is enabled, swap in a DBProvider that opens each
+	// DB with larger memtables and a shared block cache so block-save latency
+	// stays bounded while a compaction is in flight. See celestia-core#3053.
+	//
+	// Each DB pebble opens via Options.Cache takes its own ref on the cache,
+	// so dropping the creator's initial ref here is safe — the cache lives
+	// as long as any DB that uses it.
+	effectiveDBProvider := dbProvider
+	if config.Storage.Compact {
+		var dbCache *pebble.Cache
+		if dbm.BackendType(config.DBBackend) == dbm.PebbleDBBackend {
+			dbCache = pebble.NewCache(cfg.PebbleSharedCacheBytes)
+			defer dbCache.Unref()
+		}
+		effectiveDBProvider = cfg.NewCompactionDBProvider(dbCache)
+	}
+
+	blockStore, stateDB, err := initDBs(config, effectiveDBProvider, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +364,7 @@ func NewNodeWithContext(ctx context.Context,
 	}
 
 	indexerService, txIndexer, blockIndexer, err := createAndStartIndexerService(config,
-		genDoc.ChainID, dbProvider, eventBus, logger)
+		genDoc.ChainID, effectiveDBProvider, eventBus, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +450,7 @@ func NewNodeWithContext(ctx context.Context,
 		}
 	}
 
-	evidenceReactor, evidencePool, err := createEvidenceReactor(config, dbProvider, stateStore, blockStore, logger)
+	evidenceReactor, evidencePool, err := createEvidenceReactor(config, effectiveDBProvider, stateStore, blockStore, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -312,22 +312,26 @@ func NewNodeWithContext(ctx context.Context,
 	logger log.Logger,
 	options ...Option,
 ) (*Node, error) {
-	// When DB tuning is enabled, swap in a DBProvider that opens each DB with
-	// larger memtables, growing sstable target sizes and a shared block cache
-	// so the LSM stays healthy on large stores instead of fragmenting into
-	// millions of tiny sstables. See celestia-core#3053.
-	//
-	// Each DB pebble opens via Options.Cache takes its own ref on the cache,
-	// so dropping the creator's initial ref here is safe — the cache lives
-	// as long as any DB that uses it.
+	// When DB tuning is enabled and the backend is pebbledb, swap in a
+	// DBProvider that opens each DB with larger memtables, growing sstable
+	// target sizes and a shared block cache so the LSM stays healthy on large
+	// stores instead of fragmenting into millions of tiny sstables.
+	// See celestia-core#3053. The tuning only applies to pebbledb, so for any
+	// other backend the caller-supplied provider is kept as-is.
 	effectiveDBProvider := dbProvider
 	if config.Storage.DBTuning {
-		var dbCache *pebble.Cache
 		if dbm.BackendType(config.DBBackend) == dbm.PebbleDBBackend {
-			dbCache = pebble.NewCache(cfg.PebbleSharedCacheBytes)
+			// Each DB pebble opens via Options.Cache takes its own ref on the
+			// cache, so dropping the creator's initial ref here is safe — the
+			// cache lives as long as any DB that uses it.
+			dbCache := pebble.NewCache(cfg.PebbleSharedCacheBytes)
 			defer dbCache.Unref()
+			logger.Info("db_tuning enabled: overriding DB provider with compaction-friendly pebbledb options")
+			effectiveDBProvider = cfg.NewCompactionDBProvider(dbCache)
+		} else {
+			logger.Info("db_tuning enabled but db_backend is not pebbledb; keeping default provider (tuning skipped)",
+				"db_backend", config.DBBackend)
 		}
-		effectiveDBProvider = cfg.NewCompactionDBProvider(dbCache)
 	}
 
 	blockStore, stateDB, err := initDBs(config, effectiveDBProvider, logger)


### PR DESCRIPTION
fixes [PROTOCO-2595](https://linear.app/celestia/issue/PROTOCO-2595/pebbledb-auto-compaction-kills-nodes-with-large-tx-indexdb-and-indexkv)

Adds an opt-in, compaction-friendly Pebble configuration behind a new `[storage] db_tuning` flag (default `false`). When enabled, all node DBs (blockstore, state, tx_index, evidence) open with:
- `MemTableSize` = 64 MiB (default 4 MiB)
- shared block `Cache` = 512 MiB (default 8 MiB)
- `MaxConcurrentCompactions` = max(2, GOMAXPROCS/4) (default 1)
- growing per-level `TargetFileSize`: 8 MiB base, doubling, capped at 128 MiB (default flat 2 MiB)
- `MemTableStopWritesThreshold` = 4, `L0StopWritesThreshold` = 24

Default path (flag off) is byte-identical to today — zero behavior change.

## Why

Archival consensus nodes (`pruning=nothing`) OOM under default Pebble config.

Root cause: single-threaded compaction + 2 MiB target file size cannot keep a multi-TB blockstore compacted, so it degenerates into millions of tiny sstables (observed on a real node: 4.4 TB blockstore = ~2.27M sstables, 99.86% < 4 MiB).
Pebble background work whose cost scales with file count (`collectTableStats`, `VersionEdit` FileMetadata) then allocates proportionally and ramps heap to OOM. The tuning keeps compaction ahead so the file count stays low.

## How tested

A/B on a Talis devnet: 4 validators on identical `s-2vcpu-4gb` boxes, same chain — 2 with `db_tuning=true`, 2 with `db_tuning=false` — under sustained ~32 MB blob load, `pruning=nothing`, `db_backend=pebbledb`. Since all nodes
process the identical chain, any difference in sstable count is purely the config. Metric = blockstore sstable count (proxy for the `collectTableStats`/`VersionEdit` memory that drives the OOM) sampled over the run.

## Results

Blockstore sstable count over sustained load (identical chain on all nodes):

| Block data | `db_tuning=true` | `db_tuning=false` | ratio |
|-----------:|-----------------:|------------------:|:-----:|
| ~1.0 GB    | 39               | 122               | 3.1×  |
| ~1.7 GB    | 47               | 188               | 4.0×  |
| ~2.3 GB    | 53               | 265–284           | ~5×   |
| ~2.5 GB    | 80               | 246               | 3.1×  |

At ~2.5 GB: tuned ≈ 80 sstables (~34 MB avg file) vs default ≈ 246 (~10 MB avg).
The gap widens with data volume — default fragments faster while tuned holds
steady, confirming compaction keeps up only when tuned.


NOTE:
- Talis shows **direction**, not the literal OOM. It can't reach the real  4.4 TB / months-of-growth scale. The memory win from fewer sstables only  materializes at that scale; a real-node canary is the follow-up.
- On small (4 GB) boxes tuned RSS is not lower (fixed 512 MiB cache + 64 MiB memtables), so the tuning is opt-in — enabling it on already-fragmented nodes also triggers a one-time compaction catch-up. Intended for archival nodes.