### PR TITLE
fix(propagation): use SetConsensusState in identity test

### DIFF
--- a/consensus/propagation/identity_test.go
+++ b/consensus/propagation/identity_test.go
@@ -112,7 +112,7 @@ func TestAddCommitmentReplacementPurgesPeerState(t *testing.T) {
 	cbB, _, _, _ := testCompactBlock(t, sm, pv, 3, 0)
 	require.False(t, cbA.Proposal.BlockID.Equals(cbB.Proposal.BlockID))
 
-	n1.SetHeightAndRound(3, 0)
+	n1.SetConsensusState(3, 0, mockPubKey)
 	n1.handleCompactBlock(cbB, n2.self, false)
 	_, parts, _, has := n1.getAllState(3, 0, true)
 	require.True(t, has)


### PR DESCRIPTION
Fixes the lint and test failures on main ([lint run](https://github.com/celestiaorg/celestia-core/actions/runs/34386166102), [test run](https://github.com/celestiaorg/celestia-core/actions/runs/34386166098)).

#3298 added a test calling `SetHeightAndRound`, but #3287 had already replaced that method with `SetConsensusState` before #3298 merged, so `consensus/propagation` no longer compiled. This switches the call to `SetConsensusState(3, 0, mockPubKey)`, matching how the other tests in the package migrated. Main-only: `v0.40.x` still has the old API and lacks the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)