### PR TITLE
ci: sync GitHub releases to the Linear release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  linear-release:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Only scan commits since the previous stable tag reachable from this
+      # tag. Without this the action falls back to the last release synced
+      # to Linear, which is wrong when releases are cut from several release
+      # branches (e.g. v0.40.x and main) in interleaved order.
+      - name: Find previous release tag
+        id: prev
+        run: |
+          PREV=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-*' "${GITHUB_REF_NAME}^")
+          echo "Scanning commits in ${PREV}..${GITHUB_REF_NAME}"
+          echo "tag=${PREV}" >> "$GITHUB_OUTPUT"
+
+      # Attach the Linear issues fixed by this release (found via PR numbers
+      # and issue IDs in commit messages) to a release in the celestia-core
+      # Linear pipeline, then mark that release as completed.
+      - name: Sync release with Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+          version: ${{ github.ref_name }}
+          base_ref: ${{ steps.prev.outputs.tag }}
+          links: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+
+      - name: Complete release in Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ github.ref_name }}
+
   release-success:
     needs: release
     if: ${{ success() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Pinned to a commit SHA: this job holds LINEAR_ACCESS_KEY, so a repointed
+      # mutable tag would run third-party code alongside the credential.
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       # and issue IDs in commit messages) to a release in the celestia-core
       # Linear pipeline, then mark that release as completed.
       - name: Sync release with Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@53ad0f863963e7f8e270fba18426bbb55ef55384 # v0.17.2
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: sync
@@ -84,7 +84,7 @@ jobs:
           links: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
 
       - name: Complete release in Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@53ad0f863963e7f8e270fba18426bbb55ef55384 # v0.17.2
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: complete


### PR DESCRIPTION
Linear's Done status was split into Merged and Released. Merged is already handled by Linear's GitHub integration; this wires up the Released half via the [Linear Release action](https://github.com/marketplace/actions/linear-release) and the [celestia-core release pipeline](https://linear.app/celestia/pipeline/celestia-core/releases).

A new `linear-release` job in the Release workflow runs after the GitHub release is published. It scans the commits since the previous stable tag reachable from the released tag, attaches the Linear issues they fix (resolved from PR numbers and issue IDs in commit messages) to a Linear release versioned by the tag name, and marks it completed. The base ref is computed explicitly because the action's default (the last release synced to Linear) is wrong when releases are cut from `v0.40.x` and `main` in interleaved order. The job uses the `LINEAR_ACCESS_KEY` repository secret, so every action it runs is pinned to a commit SHA.

Note for reviewers: not exercised end to end yet. The first release after merge will be the real test; the job runs after the release job so a failure cannot block the release itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
